### PR TITLE
Support OpenStack provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Flags:
 
 1.  Google cloud
 2.  AWS
+3.  OpenStack
 
 #### Permissions
 
@@ -57,10 +58,11 @@ Readonly permissions
 3.  Run `go build -v`
 4.  Copy your Terraform provider's plugin(s) to
     `~/.terraform.d/plugins/{darwin,linux}_amd64`, as appropriate.
-    
+
 Links for download terraform providers:
 * google cloud provider - [here](https://releases.hashicorp.com/terraform-provider-google/)
 * aws provider - [here](https://releases.hashicorp.com/terraform-provider-aws/)
+* openstack provider - [here](https://releases.hashicorp.com/terraform-provider-openstack/)
 
 Information on provider plugins:
 https://www.terraform.io/docs/configuration/providers.html
@@ -158,6 +160,19 @@ List of support AWS services:
 *   `vpn_gateway`
 *   `route53`
 *   `elasticache`
+
+### Use with OpenStack
+
+Example:
+
+```
+ terraformer import openstack --resources=compute,networking --regions=RegionOne
+```
+
+List of support OpenStack services:
+
+*   `compute`
+*   `networking`
 
 ## Contributing
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -55,6 +55,7 @@ func newImportCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newCmdGoogleImporter(options))
 	cmd.AddCommand(newCmdAwsImporter(options))
+	cmd.AddCommand(newCmdOpenStackImporter(options))
 	return cmd
 }
 

--- a/cmd/openstack.go
+++ b/cmd/openstack.go
@@ -1,0 +1,53 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cmd
+
+import (
+	"log"
+
+	"github.com/GoogleCloudPlatform/terraformer/openstack_terraforming"
+
+	"github.com/spf13/cobra"
+)
+
+func newCmdOpenStackImporter(options ImportOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "openstack",
+		Short: "Import current State to terraform configuration from OpenStack",
+		Long:  "Import current State to terraform configuration from OpenStack",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			originalPathPatter := options.PathPatter
+			for _, region := range options.Regions {
+				provider := &openstack_terraforming.OpenStackProvider{}
+				options.PathPatter = originalPathPatter
+				options.PathPatter += region + "/"
+				log.Println(provider.GetName() + " importing region " + region)
+				err := Import(provider, options, []string{region})
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+	cmd.AddCommand(listCmd(&openstack_terraforming.OpenStackProvider{}))
+	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
+	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "compute,networking")
+	cmd.PersistentFlags().StringVarP(&options.PathPatter, "path-patter", "p", DefaultPathPatter, "{output}/{provider}/custom/{service}/")
+	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
+	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
+	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
+	cmd.PersistentFlags().StringSliceVarP(&options.Regions, "regions", "", []string{}, "RegionOne")
+	return cmd
+}

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/martian v2.1.0+incompatible // indirect
 	github.com/googleapis/gax-go v2.0.2+incompatible // indirect
-	github.com/gophercloud/gophercloud v0.0.0-20170823032606-7f0936597349 // indirect
+	github.com/gophercloud/gophercloud v0.0.0-20190504011306-6f9faf57fddc // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
@@ -112,7 +112,6 @@ require (
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
 	github.com/zclconf/go-cty v0.0.0-20181017232614-01c5aba823a6 // indirect
 	go.opencensus.io v0.18.0 // indirect
-	golang.org/x/crypto v0.0.0-20181126163421-e657309f52e7 // indirect
 	golang.org/x/oauth2 v0.0.0-20181120190819-8f65e3013eba
 	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c // indirect
 	google.golang.org/api v0.0.0-20181212003324-40e757e92c52

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,8 @@ github.com/googleapis/gax-go v2.0.2+incompatible h1:silFMLAnr330+NRuag/VjIGF7TLp
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/gophercloud/gophercloud v0.0.0-20170823032606-7f0936597349 h1:rzcyr6kxDiS0fQRZDChgvsYg2mr/3bF8dtCaVOi1Sc0=
 github.com/gophercloud/gophercloud v0.0.0-20170823032606-7f0936597349/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
+github.com/gophercloud/gophercloud v0.0.0-20190504011306-6f9faf57fddc h1:uSlJNJjuqu+HrNGtCqIVjtMjrC0lzUjXZqfiUHxSzZc=
+github.com/gophercloud/gophercloud v0.0.0-20190504011306-6f9faf57fddc/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e h1:JKmoR8x90Iww1ks85zJ1lfDGgIiMDuIptTOhJq+zKyg=
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
@@ -340,6 +342,7 @@ golang.org/x/crypto v0.0.0-20180816225734-aabede6cba87/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181126163421-e657309f52e7 h1:70UTJTdHsz+jRjphEW+is2SdxjhZL1AdKsewqjYzcQU=
 golang.org/x/crypto v0.0.0-20181126163421-e657309f52e7/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/net v0.0.0-20180811021610-c39426892332/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -358,6 +361,7 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e h1:o3PsSEY8E4eXWkXrIP9YJALUkVZqzHJT5DOasTyn8Vs=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c h1:fqgJT0MGcGpPgpWU7VRdRjuArfcOvC4AoJmILihzhDg=
@@ -383,5 +387,6 @@ gopkg.in/vmihailenco/msgpack.v2 v2.9.1 h1:kb0VV7NuIojvRfzwslQeP3yArBqJHW9tOl4t38
 gopkg.in/vmihailenco/msgpack.v2 v2.9.1/go.mod h1:/3Dn1Npt9+MYyLpYYXjInO/5jvMLamn+AEGwNEOatn8=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 howett.net/plist v0.0.0-20180609054337-500bd5b9081b/go.mod h1:jInWmjR7JRkkon4jlLXDZGVEeY/wo3kOOJEWYhNE+9Y=

--- a/openstack_terraforming/compute.go
+++ b/openstack_terraforming/compute.go
@@ -44,9 +44,7 @@ func (g *ComputeGenerator) createResources(list *pagination.Pager) []terraform_u
 				s.Name,
 				"openstack_compute_instance_v2",
 				"openstack",
-				map[string]string{
-					"name": s.Name,
-				},
+				map[string]string{},
 				[]string{},
 				map[string]string{},
 			)

--- a/openstack_terraforming/compute.go
+++ b/openstack_terraforming/compute.go
@@ -1,0 +1,115 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openstack_terraforming
+
+import (
+	"strings"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type ComputeGenerator struct {
+	OpenStackService
+}
+
+// createResources iterate on all openstack_compute_instance_v2
+func (g *ComputeGenerator) createResources(list *pagination.Pager) []terraform_utils.Resource {
+	resources := []terraform_utils.Resource{}
+
+	list.EachPage(func(page pagination.Page) (bool, error) {
+		servers, err := servers.ExtractServers(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, s := range servers {
+			resource := terraform_utils.NewResource(
+				s.ID,
+				s.Name,
+				"openstack_compute_instance_v2",
+				"openstack",
+				map[string]string{
+					"name": s.Name,
+				},
+				[]string{},
+				map[string]string{},
+			)
+
+			resources = append(resources, resource)
+		}
+
+		return true, nil
+	})
+
+	return resources
+}
+
+// Generate TerraformResources from OpenStack API,
+func (g *ComputeGenerator) InitResources() error {
+	opts, err := openstack.AuthOptionsFromEnv()
+	if err != nil {
+		return err
+	}
+
+	provider, err := openstack.AuthenticatedClient(opts)
+	if err != nil {
+		return err
+	}
+
+	client, err := openstack.NewComputeV2(provider, gophercloud.EndpointOpts{
+		Region: g.GetArgs()["region"],
+	})
+	if err != nil {
+		return err
+	}
+
+	list := servers.List(client, nil)
+
+	g.Resources = g.createResources(&list)
+	g.PopulateIgnoreKeys()
+
+	return nil
+}
+
+func (g *ComputeGenerator) PostConvertHook() error {
+	for i, r := range g.Resources {
+		if r.InstanceInfo.Type != "openstack_compute_instance_v2" {
+			continue
+		}
+
+		// Rename "all_metadata" to "metadata"
+		// because "all_metadata" field cannot be set as resource argument
+		for k, v := range g.Resources[i].InstanceState.Attributes {
+			if strings.HasPrefix(k, "all_metadata") {
+				newKey := strings.Replace(k, "all_metadata", "metadata", 1)
+				g.Resources[i].InstanceState.Attributes[newKey] = v
+				delete(g.Resources[i].InstanceState.Attributes, k)
+			}
+		}
+		for k, v := range g.Resources[i].Item {
+			if strings.HasPrefix(k, "all_metadata") {
+				newKey := strings.Replace(k, "all_metadata", "metadata", 1)
+				g.Resources[i].Item[newKey] = v
+				delete(g.Resources[i].Item, k)
+			}
+		}
+	}
+
+	return nil
+}

--- a/openstack_terraforming/compute.go
+++ b/openstack_terraforming/compute.go
@@ -91,15 +91,15 @@ func (g *ComputeGenerator) PostConvertHook() error {
 			continue
 		}
 
-		// Rename "all_metadata" to "metadata"
-		// because "all_metadata" field cannot be set as resource argument
+		// Copy "all_metadata.%" to "metadata.%"
 		for k, v := range g.Resources[i].InstanceState.Attributes {
 			if strings.HasPrefix(k, "all_metadata") {
 				newKey := strings.Replace(k, "all_metadata", "metadata", 1)
 				g.Resources[i].InstanceState.Attributes[newKey] = v
-				delete(g.Resources[i].InstanceState.Attributes, k)
 			}
 		}
+		// Replace "all_metadata" to "metadata"
+		// because "all_metadata" field cannot be set as resource argument
 		for k, v := range g.Resources[i].Item {
 			if strings.HasPrefix(k, "all_metadata") {
 				newKey := strings.Replace(k, "all_metadata", "metadata", 1)

--- a/openstack_terraforming/networking.go
+++ b/openstack_terraforming/networking.go
@@ -1,0 +1,125 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openstack_terraforming
+
+import (
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type NetworkingGenerator struct {
+	OpenStackService
+}
+
+// createResources iterate on all openstack_networking_secgroup_v2
+func (g *NetworkingGenerator) createSecgroupResources(list *pagination.Pager) []terraform_utils.Resource {
+	resources := []terraform_utils.Resource{}
+
+	list.EachPage(func(page pagination.Page) (bool, error) {
+		groups, err := groups.ExtractGroups(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, grp := range groups {
+			resource := terraform_utils.NewResource(
+				grp.ID,
+				grp.Name,
+				"openstack_networking_secgroup_v2",
+				"openstack",
+				map[string]string{
+					"name": grp.Name,
+				},
+				[]string{},
+				map[string]string{},
+			)
+			resources = append(resources, resource)
+			resources = append(resources, g.createSecgroupRuleResources(grp.Rules)...)
+		}
+
+		return true, nil
+	})
+
+	return resources
+}
+
+// createResources iterate on all openstack_networking_secgroup_v2
+func (g *NetworkingGenerator) createSecgroupRuleResources(rules []rules.SecGroupRule) []terraform_utils.Resource {
+	resources := []terraform_utils.Resource{}
+	for _, r := range rules {
+		resource := terraform_utils.NewResource(
+			r.ID,
+			r.ID,
+			"openstack_networking_secgroup_rule_v2",
+			"openstack",
+			map[string]string{
+				"id": r.ID,
+			},
+			[]string{},
+			map[string]string{},
+		)
+		resources = append(resources, resource)
+	}
+	return resources
+}
+
+// Generate TerraformResources from OpenStack API,
+func (g *NetworkingGenerator) InitResources() error {
+	opts, err := openstack.AuthOptionsFromEnv()
+	if err != nil {
+		return err
+	}
+
+	provider, err := openstack.AuthenticatedClient(opts)
+	if err != nil {
+		return err
+	}
+
+	client, err := openstack.NewNetworkV2(provider, gophercloud.EndpointOpts{
+		Region: g.GetArgs()["region"],
+	})
+	if err != nil {
+		return err
+	}
+
+	list := groups.List(client, groups.ListOpts{})
+
+	g.Resources = g.createSecgroupResources(&list)
+	g.PopulateIgnoreKeys()
+
+	return nil
+}
+
+func (g *NetworkingGenerator) PostConvertHook() error {
+	for i, r := range g.Resources {
+		if r.InstanceInfo.Type != "openstack_networking_secgroup_rule_v2" {
+			continue
+		}
+		for _, sg := range g.Resources {
+			if sg.InstanceInfo.Type != "openstack_networking_secgroup_v2" {
+				continue
+			}
+			if r.InstanceState.Attributes["security_group_id"] == sg.InstanceState.Attributes["id"] {
+				g.Resources[i].Item["security_group_id"] = "${openstack_networking_secgroup_v2." + sg.ResourceName + ".id}"
+			}
+		}
+	}
+
+	return nil
+}

--- a/openstack_terraforming/networking.go
+++ b/openstack_terraforming/networking.go
@@ -43,9 +43,7 @@ func (g *NetworkingGenerator) createSecgroupResources(list *pagination.Pager) []
 				grp.Name,
 				"openstack_networking_secgroup_v2",
 				"openstack",
-				map[string]string{
-					"name": grp.Name,
-				},
+				map[string]string{},
 				[]string{},
 				map[string]string{},
 			)
@@ -68,9 +66,7 @@ func (g *NetworkingGenerator) createSecgroupRuleResources(rules []rules.SecGroup
 			r.ID,
 			"openstack_networking_secgroup_rule_v2",
 			"openstack",
-			map[string]string{
-				"id": r.ID,
-			},
+			map[string]string{},
 			[]string{},
 			map[string]string{},
 		)

--- a/openstack_terraforming/openstack_provider.go
+++ b/openstack_terraforming/openstack_provider.go
@@ -1,0 +1,81 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openstack_terraforming
+
+import (
+	"os"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+
+	"github.com/pkg/errors"
+)
+
+type OpenStackProvider struct {
+	terraform_utils.Provider
+	region string
+}
+
+const openStackProviderVersion = "~>1.17.0"
+
+func (p OpenStackProvider) GetResourceConnections() map[string]map[string][]string {
+	return map[string]map[string][]string{}
+}
+
+func (p OpenStackProvider) GetProviderData(arg ...string) map[string]interface{} {
+	return map[string]interface{}{
+		"provider": map[string]interface{}{
+			"openstack": map[string]interface{}{
+				"version": openStackProviderVersion,
+				"region":  p.region,
+			},
+		},
+	}
+}
+
+// check projectName in env params
+func (p *OpenStackProvider) Init(args []string) error {
+	p.region = args[0]
+	// terraform work with env param OS_REGION_NAME
+	err := os.Setenv("OS_REGION_NAME", p.region)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *OpenStackProvider) GetName() string {
+	return "openstack"
+}
+
+func (p *OpenStackProvider) InitService(serviceName string) error {
+	var isSupported bool
+	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+		return errors.New("openstack: " + serviceName + " not supported service")
+	}
+	p.Service = p.GetSupportedService()[serviceName]
+	p.Service.SetName(serviceName)
+	p.Service.SetProviderName(p.GetName())
+	p.Service.SetArgs(map[string]string{
+		"region": p.region,
+	})
+	return nil
+}
+
+// GetOpenStackSupportService return map of support service for OpenStack
+func (p *OpenStackProvider) GetSupportedService() map[string]terraform_utils.ServiceGenerator {
+	return map[string]terraform_utils.ServiceGenerator{
+		"compute": &ComputeGenerator{},
+	}
+}

--- a/openstack_terraforming/openstack_provider.go
+++ b/openstack_terraforming/openstack_provider.go
@@ -76,6 +76,7 @@ func (p *OpenStackProvider) InitService(serviceName string) error {
 // GetOpenStackSupportService return map of support service for OpenStack
 func (p *OpenStackProvider) GetSupportedService() map[string]terraform_utils.ServiceGenerator {
 	return map[string]terraform_utils.ServiceGenerator{
-		"compute": &ComputeGenerator{},
+		"compute":    &ComputeGenerator{},
+		"networking": &NetworkingGenerator{},
 	}
 }

--- a/openstack_terraforming/openstack_service.go
+++ b/openstack_terraforming/openstack_service.go
@@ -1,0 +1,21 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openstack_terraforming
+
+import "github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+
+type OpenStackService struct {
+	terraform_utils.Service
+}

--- a/tests/openstack/main.go
+++ b/tests/openstack/main.go
@@ -1,0 +1,69 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"sort"
+
+	"github.com/GoogleCloudPlatform/terraformer/cmd"
+	"github.com/GoogleCloudPlatform/terraformer/openstack_terraforming"
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+)
+
+const command = "terraform init && terraform plan"
+
+func main() {
+	region := "RegionOne"
+	services := []string{}
+	provider := &openstack_terraforming.OpenStackProvider{}
+	for service := range provider.GetSupportedService() {
+		services = append(services, service)
+	}
+	sort.Strings(services)
+	provider = &openstack_terraforming.OpenStackProvider{
+		Provider: terraform_utils.Provider{},
+	}
+	err := cmd.Import(provider, cmd.ImportOptions{
+		Resources:  services,
+		PathPatter: cmd.DefaultPathPatter,
+		PathOutput: cmd.DefaultPathOutput,
+		State:      "local",
+		Connect:    true,
+	}, []string{region})
+	if err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
+	rootPath, _ := os.Getwd()
+	for _, serviceName := range services {
+		currentPath := cmd.Path(cmd.DefaultPathPatter, provider.GetName(), serviceName, cmd.DefaultPathOutput)
+		if err := os.Chdir(currentPath); err != nil {
+			log.Println(err)
+			os.Exit(1)
+		}
+		cmd := exec.Command("sh", "-c", command)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err = cmd.Run()
+		if err != nil {
+			log.Println(err)
+			os.Exit(1)
+		}
+		os.Chdir(rootPath)
+	}
+}


### PR DESCRIPTION
This PR adds support [OpenStack provider](https://www.terraform.io/docs/providers/openstack/). Currently this provider supports the following resources:

* Compute
    * [compute_instance_v2](https://www.terraform.io/docs/providers/openstack/r/compute_instance_v2.html)
* Networking
    * [networking_secgroup_v2](https://www.terraform.io/docs/providers/openstack/r/networking_secgroup_v2.html)
    * [networking_secgroup_rule_v2](https://www.terraform.io/docs/providers/openstack/r/networking_secgroup_rule_v2.html)
