### PR TITLE
Remove other empty values 

### DIFF
--- a/terraform_utils/resource.go
+++ b/terraform_utils/resource.go
@@ -80,6 +80,13 @@ func (r *Resource) ConvertTFstate() {
 		attributes[k] = v
 	}
 
+	// delete empty map
+	for key := range r.InstanceState.Attributes {
+		if strings.HasSuffix(key, ".%") && r.InstanceState.Attributes[key] == "0" {
+			delete(attributes, key)
+		}
+	}
+
 	// delete empty array
 	for key := range r.InstanceState.Attributes {
 		if strings.HasSuffix(key, ".#") && r.InstanceState.Attributes[key] == "0" {
@@ -97,7 +104,7 @@ func (r *Resource) ConvertTFstate() {
 	}
 	// delete empty keys with empty value, but not from AllowEmptyValue list
 	for keyAttribute, value := range r.InstanceState.Attributes {
-		if value != "" {
+		if value != "" && value != "0" {
 			continue
 		}
 		allowEmptyValue := false


### PR DESCRIPTION
The empty maps can be detected and eliminated like the empty arrays.

Having the "0" for missing optional integer values is leading to some errors in some providers. As an example k8s is rejecting the **most-be-positive** keys that are "0"! 

However there might be some string fields or reuired integer fields that will be broken by making this commit!

Do we need to check the field type and optionality before removing it?