### PR TITLE
google: Add role_entity to google_storage_bucket_acl

### DIFF
--- a/gcp_terraforming/gcs.go
+++ b/gcp_terraforming/gcs.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 
@@ -62,7 +63,8 @@ func (g *GcsGenerator) createResources(bucketIterator *storage.BucketIterator) [
 			"google_storage_bucket_acl",
 			"google",
 			map[string]string{
-				"bucket": battrs.Name,
+				"bucket":        battrs.Name,
+				"role_entity.#": strconv.Itoa(len(battrs.ACL)),
 			},
 			GcsAllowEmptyValues,
 			GcsAdditionalFields,


### PR DESCRIPTION
GCP provider checks "role_entity" attribute for retrieving GCS ACL.
https://github.com/terraform-providers/terraform-provider-google/blob/d43a1795b4c1ee45d15d83ba33b588448f3ff392/google/resource_storage_bucket_acl.go#L202
This PR adds "role_entity" to attributes of google_storage_bucket_acl.