### PR TITLE
Replace if statement with an unconditional strings.TrimPrefix

### DIFF
--- a/aws_terraforming/route53.go
+++ b/aws_terraforming/route53.go
@@ -132,8 +132,5 @@ func cleanZoneID(ID string) string {
 
 // cleanPrefix removes a string prefix from an ID
 func cleanPrefix(ID, prefix string) string {
-	if strings.HasPrefix(ID, prefix) {
-		ID = strings.TrimPrefix(ID, prefix)
-	}
-	return ID
+	return strings.TrimPrefix(ID, prefix)
 }


### PR DESCRIPTION
aws_terraforming/route53.go

https://golang.org/pkg/strings/#TrimPrefix

TrimPrefix returns s without the provided leading prefix string. If s doesn't start with prefix, s is returned **unchanged**. Therefore It is unnecessary to check with `strings.HasPrefix`