### PR TITLE
Add filter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Example:
 
 ```
 terraformer import google --resources=gcs,forwardingRules,httpHealthChecks --connect=true --zone=europe-west1-a --projects=aaa,fff
+terraformer import google --resources=gcs,forwardingRules,httpHealthChecksm--filter=google_compute_firewall=rule1:rule2:rule3 --zone=europe-west1-a --projects=aaa,fff
 ```
 
 List of supported GCP services:
@@ -146,6 +147,7 @@ Example:
 
 ```
  terraformer import aws --resources=vpc,subnet --connect=true --regions=eu-west-1
+ terraformer import aws --resources=vpc,subnet --filter=aws_vpc=vpc_id1:vpc_id2:vpc_id3 --regions=eu-west-1
 ```
 
 ```
@@ -202,6 +204,7 @@ Example:
 
 ```
  terraformer import kubernetes --resources=deployments,services,storageclasses
+ terraformer import kubernetes --resources=deployments,services,storageclasses --filter=kubernetes_deployment=name1:name2:name3
 ```
 
 All of the kubernetes resources that are currently being supported by kubernetes provider are supported by this module as well. Here is the list of resources which are currently supported by kubernetes provider v.1.4:
@@ -235,6 +238,7 @@ Example:
 
 ```
  ./terraformer import github --organizations=YOUR_ORGANIZATION --resources=repositories --token=YOUR_TOKEN // or GITHUB_TOKEN in env
+ ./terraformer import github --organizations=YOUR_ORGANIZATION --resources=repositories --filter=github_repository=id1:id2:id4 --token=YOUR_TOKEN // or GITHUB_TOKEN in env
 ```
 
 Support only organizations resources. List of supported resources:

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -49,5 +49,6 @@ func newCmdAwsImporter(options ImportOptions) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
 	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
 	cmd.PersistentFlags().StringSliceVarP(&options.Regions, "regions", "", []string{}, "eu-west-1,eu-west-2,us-east-1")
+	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "aws_elb=id1:id2:id4")
 	return cmd
 }

--- a/cmd/github.go
+++ b/cmd/github.go
@@ -52,6 +52,7 @@ func newCmdGithubImporter(options ImportOptions) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
 	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
 	cmd.PersistentFlags().StringVarP(&token, "token", "t", "", "YOUR_GITHUB_TOKEN or env param GITHUB_TOKEN")
+	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "github_repository=id1:id2:id4")
 	cmd.PersistentFlags().StringSliceVarP(&organizations, "organizations", "", []string{}, "")
 	return cmd
 }

--- a/cmd/google.go
+++ b/cmd/google.go
@@ -50,6 +50,7 @@ func newCmdGoogleImporter(options ImportOptions) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
 	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
 	cmd.PersistentFlags().StringVarP(&options.Zone, "zone", "z", "", "")
+	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "google_compute_firewall=id1:id2:id4")
 	cmd.PersistentFlags().StringSliceVarP(&options.Projects, "projects", "", []string{}, "")
 	return cmd
 }

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -37,6 +37,7 @@ type ImportOptions struct {
 	Regions    []string
 	Projects   []string
 	Connect    bool
+	Filter     []string
 }
 
 const DefaultPathPatter = "{output}/{provider}/{service}/"
@@ -77,6 +78,12 @@ func Import(provider terraform_utils.ProviderGenerator, options ImportOptions, a
 		if err != nil {
 			return err
 		}
+
+		if len(options.Filter) != 0 {
+			provider.GetService().ParseFilter(options.Filter)
+			provider.GetService().CleanupWithFilter()
+		}
+
 		refreshedResources, err := terraform_utils.RefreshResources(provider.GetService().GetResources(), provider.GetName(), provider.GetConfig())
 		if err != nil {
 			return err

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -41,5 +41,6 @@ func newCmdKubernetesImporter(options ImportOptions) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
 	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
 	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
+	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "kubernetes_deployment=name1:name2:name3")
 	return cmd
 }

--- a/cmd/openstack.go
+++ b/cmd/openstack.go
@@ -49,5 +49,6 @@ func newCmdOpenStackImporter(options ImportOptions) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
 	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
 	cmd.PersistentFlags().StringSliceVarP(&options.Regions, "regions", "", []string{}, "RegionOne")
+	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "openstack_compute_instance_v2=id1:id2:id4")
 	return cmd
 }

--- a/terraform_utils/service.go
+++ b/terraform_utils/service.go
@@ -14,16 +14,23 @@
 
 package terraform_utils
 
+import (
+	"log"
+	"strings"
+)
+
 type ServiceGenerator interface {
 	InitResources() error
 	GetResources() []Resource
 	SetResources(resources []Resource)
+	ParseFilter(rawFilter []string)
 	PostConvertHook() error
 	GetArgs() map[string]string
 	SetArgs(args map[string]string)
 	SetName(name string)
 	SetProviderName(name string)
 	GetName() string
+	CleanupWithFilter()
 }
 
 type Service struct {
@@ -31,10 +38,24 @@ type Service struct {
 	Resources    []Resource
 	ProviderName string
 	Args         map[string]string
+	Filter       map[string][]string
 }
 
 func (s *Service) SetProviderName(providerName string) {
 	s.ProviderName = providerName
+}
+
+func (s *Service) ParseFilter(rawFilter []string) {
+	s.Filter = map[string][]string{}
+	for _, resource := range rawFilter {
+		t := strings.Split(resource, "=")
+		if len(t) != 2 {
+			log.Println("Pattern for filter must be resource_type=id1:id2:id4")
+			continue
+		}
+		resourceName, resourcesID := t[0], t[1]
+		s.Filter[resourceName] = strings.Split(resourcesID, ":")
+	}
 }
 
 func (s *Service) SetName(name string) {
@@ -42,6 +63,25 @@ func (s *Service) SetName(name string) {
 }
 func (s *Service) GetName() string {
 	return s.Name
+}
+
+func (s *Service) CleanupWithFilter() {
+	if len(s.Filter) == 0 {
+		return
+	}
+	newListOfResources := []Resource{}
+	for _, v := range s.Resources {
+		if _, exist := s.Filter[v.InstanceInfo.Type]; exist {
+			for _, r := range s.Filter[v.InstanceInfo.Type] {
+				if v.InstanceState.ID == r {
+					newListOfResources = append(newListOfResources, v)
+				}
+			}
+		} else {
+			newListOfResources = append(newListOfResources, v)
+		}
+	}
+	s.Resources = newListOfResources
 }
 
 func (s *Service) GetArgs() map[string]string {


### PR DESCRIPTION
Add filter options. We can import resource by IDs and not all.
syntax for flag small complicate 
```
--filter=TERRAFORM_TYPE1=ID_OF_RESOURCE1:ID_OF_RESOURCE2
--filter=TERRAFORM_TYPE2=ID_OF_RESOURCE4:ID_OF_RESOURCE3
```
example
```
--filter=google_compute_firewall=jenkins1:ssh
--filter=google_compute_network=stage:productions
```


TODO use regex