### PR TITLE
Fix nilness: impossible condition: nil != nil

### DIFF
--- a/providers/aws/route53.go
+++ b/providers/aws/route53.go
@@ -58,10 +58,6 @@ func (g Route53Generator) createZonesResources(svc *route53.Route53) []terraform
 		records := g.createRecordsResources(svc, zoneID)
 		resources = append(resources, records...)
 	}
-	if err != nil {
-		log.Println(err)
-		return []terraform_utils.Resource{}
-	}
 	return resources
 }
 

--- a/providers/gcp/monitoring.go
+++ b/providers/gcp/monitoring.go
@@ -46,9 +46,6 @@ func (g *MonitoringGenerator) loadAlerts(ctx context.Context, project string) er
 	}
 
 	alertIterator := client.ListAlertPolicies(ctx, req)
-	if err != nil {
-		return err
-	}
 
 	for {
 		alert, err := alertIterator.Next()


### PR DESCRIPTION
linter(golangci-lint) said
```
providers/aws/route53.go:61:9: nilness: impossible condition: nil != nil (govet)
	if err != nil {
	       ^
providers/gcp/monitoring.go:49:9: nilness: impossible condition: nil != nil (govet)
	if err != nil {
	       ^
```

https://github.com/GoogleCloudPlatform/terraformer/blob/9bc5fe1add8a73bc4ba12d08d69bebc2bc0e5162/providers/aws/route53.go#L37-L66

e.g.  createZonesResources is unreachable condition in L61 because It has return on L41 when err is not nil, and L45-L60 hasn't change the value of err.