### PR TITLE
Add aws_acm_certificate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ List of support AWS services:
 *   `route53`
     * `aws_route53_zone`
     * `aws_route53_record`
+*   `acm`
+    * `aws_acm_certificate`
 *   `elasticache`
     * `aws_elasticache_cluster`
     * `aws_elasticache_parameter_group`

--- a/providers/aws/acm.go
+++ b/providers/aws/acm.go
@@ -76,10 +76,6 @@ func (g *ACMGenerator) InitResources() error {
 	return nil
 }
 
-func (g *ACMGenerator) PostConvertHook() error {
-	return nil
-}
-
 // extractCertificateUUID extracts UUID from ARN
 func extractCertificateUUID(arn string) string {
 	if i := strings.Index(arn, "/"); i != -1 {

--- a/providers/aws/acm.go
+++ b/providers/aws/acm.go
@@ -1,0 +1,89 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"log"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/acm"
+)
+
+var acmAllowEmptyValues = []string{}
+
+var acmAdditionalFields = map[string]string{}
+
+type ACMGenerator struct {
+	AWSService
+}
+
+func (g ACMGenerator) createCertificatesResources(svc *acm.ACM) []terraform_utils.Resource {
+	resources := []terraform_utils.Resource{}
+	err := svc.ListCertificatesPages(
+		&acm.ListCertificatesInput{},
+		func(certs *acm.ListCertificatesOutput, lastPage bool) bool {
+			for _, cert := range certs.CertificateSummaryList {
+				certArn := aws.StringValue(cert.CertificateArn)
+				certID := extractCertificateUUID(certArn)
+				resources = append(resources, terraform_utils.NewResource(
+					certArn,
+					certID+"_"+strings.TrimSuffix(aws.StringValue(cert.DomainName), "."),
+					"aws_acm_certificate",
+					"aws",
+					map[string]string{
+						"domain_name": aws.StringValue(cert.DomainName),
+					},
+					acmAllowEmptyValues,
+					acmAdditionalFields,
+				))
+			}
+			return true
+		},
+	)
+
+	if err != nil {
+		log.Println(err)
+		return resources
+	}
+
+	return resources
+}
+
+// Generate TerraformResources from AWS API,
+// create terraform resource for each certificates
+func (g *ACMGenerator) InitResources() error {
+	sess, _ := session.NewSession(&aws.Config{Region: aws.String(g.GetArgs()["region"])})
+	svc := acm.New(sess)
+
+	g.Resources = g.createCertificatesResources(svc)
+	g.PopulateIgnoreKeys()
+	return nil
+}
+
+func (g *ACMGenerator) PostConvertHook() error {
+	return nil
+}
+
+// extractCertificateUUID extracts UUID from ARN
+func extractCertificateUUID(arn string) string {
+	if i := strings.Index(arn, "/"); i != -1 {
+		return arn[i+1:]
+	}
+	return arn
+}

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -121,5 +121,6 @@ func (p *AWSProvider) GetSupportedService() map[string]terraform_utils.ServiceGe
 		"rds":            &RDSGenerator{},
 		"elasticache":    &ElastiCacheGenerator{},
 		"alb":            &AlbGenerator{},
+		"acm":            &ACMGenerator{},
 	}
 }


### PR DESCRIPTION
This PR adds ability to import AWS Certificate Manager certificate resource (`aws_acm_certificate`).

## Exported sample

The exported HCL and state file will look like following:

### `acm_certificate.tf`

```hcl
resource "aws_acm_certificate" "01234567-89ab-cdef-0123-456789abcdef_example--com" {
  domain_name               = "*.example.com"
  subject_alternative_names = ["*.foo.example.com"]
  tags                      {}
  validation_method         = "EMAIL"
}
```

### `terraform.tfstate`

```json
{
    "version": 3,
    "terraform_version": "0.11.12",
    "serial": 1,
    "lineage": "01234567-89ab-cdef-0123-456789abcdef",
    "modules": [
        {
            "path": [
                "root"
            ],
            "outputs": {
                "aws_acm_certificate_01234567-89ab-cdef-0123-456789abcdef_example--com_id": {
                    "sensitive": false,
                    "type": "string",
                    "value": "arn:aws:acm:us-east-1:012345678910:certificate/01234567-89ab-cdef-0123-456789abcdef"
                }
            },
            "resources": {
                "aws_acm_certificate.01234567-89ab-cdef-0123-456789abcdef_example--com": {
                    "type": "aws_acm_certificate",
                    "depends_on": [],
                    "primary": {
                        "id": "arn:aws:acm:us-east-1:012345678910:certificate/01234567-89ab-cdef-0123-456789abcdef",
                        "attributes": {
                            "arn": "arn:aws:acm:us-east-1:012345678910:certificate/01234567-89ab-cdef-0123-456789abcdef",
                            "domain_name": "*.example.com",
                            "domain_validation_options.#": "0",
                            "id": "arn:aws:acm:us-east-1:012345678910:certificate/01234567-89ab-cdef-0123-456789abcdef",
                            "subject_alternative_names.#": "1",
                            "subject_alternative_names.0": "*.foo.example.com",
                            "tags.%": "0",
                            "validation_emails.#": "4",
                            "validation_emails.0": "admin@example.com",
                            "validation_emails.1": "postmaster@example.com",
                            "validation_emails.2": "hostmaster@example.com",
                            "validation_emails.3": "...",
                            "validation_method": "EMAIL"
                        },
                        "meta": {},
                        "tainted": false
                    },
                    "deposed": [],
                    "provider": "provider.aws"
                },
            },
            "depends_on": []
        }
    ]
}
```