### PR TITLE
Add support datadog user and downtime resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,8 +436,12 @@ Example:
 
 List of support Datadog services:
 
-*   `monitor`
+* `downtime`
+    * `datadog_downtime`
+* `monitor`
     * `datadog_monitor`
+* `user`
+    * `datadog_user`
 
 
 ## Contributing

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -87,6 +87,7 @@ func (p *DatadogProvider) InitService(serviceName string) error {
 func (p *DatadogProvider) GetSupportedService() map[string]terraform_utils.ServiceGenerator {
 	return map[string]terraform_utils.ServiceGenerator{
 		"monitor": &MonitorGenerator{},
+		"user":    &UserGenerator{},
 	}
 }
 

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -86,8 +86,9 @@ func (p *DatadogProvider) InitService(serviceName string) error {
 // GetSupportedService return map of support service for Datadog
 func (p *DatadogProvider) GetSupportedService() map[string]terraform_utils.ServiceGenerator {
 	return map[string]terraform_utils.ServiceGenerator{
-		"monitor": &MonitorGenerator{},
-		"user":    &UserGenerator{},
+		"downtime": &DowntimeGenerator{},
+		"monitor":  &MonitorGenerator{},
+		"user":     &UserGenerator{},
 	}
 }
 

--- a/providers/datadog/downtime.go
+++ b/providers/datadog/downtime.go
@@ -1,0 +1,74 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datadog
+
+import (
+	"fmt"
+	"strconv"
+
+	datadog "github.com/zorkian/go-datadog-api"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+)
+
+var (
+	// DowntimeAllowEmptyValues ...
+	DowntimeAllowEmptyValues = []string{}
+	// DowntimeAttributes ...
+	DowntimeAttributes = map[string]string{}
+	// DowntimeAdditionalFields ...
+	DowntimeAdditionalFields = map[string]string{}
+)
+
+// DowntimeGenerator ...
+type DowntimeGenerator struct {
+	DatadogService
+}
+
+func (DowntimeGenerator) createResources(downtimes []datadog.Downtime) []terraform_utils.Resource {
+	resources := []terraform_utils.Resource{}
+	for _, downtime := range downtimes {
+		resourceName := strconv.Itoa(downtime.GetId())
+		resources = append(resources, terraform_utils.NewResource(
+			resourceName,
+			fmt.Sprintf("downtime_%s", resourceName),
+			"datadog_downtime",
+			"datadog",
+			DowntimeAttributes,
+			DowntimeAllowEmptyValues,
+			DowntimeAdditionalFields,
+		))
+	}
+
+	return resources
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each downtime create 1 TerraformResource.
+// Need Downtime ID as ID for terraform resource
+func (g *DowntimeGenerator) InitResources() error {
+	client := datadog.NewClient(g.Args["api-key"], g.Args["app-key"])
+	_, err := client.Validate()
+	if err != nil {
+		return err
+	}
+	downtimes, err := client.GetDowntimes()
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(downtimes)
+	g.PopulateIgnoreKeys()
+	return nil
+}

--- a/providers/datadog/user.go
+++ b/providers/datadog/user.go
@@ -1,0 +1,73 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datadog
+
+import (
+	"fmt"
+
+	datadog "github.com/zorkian/go-datadog-api"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+)
+
+var (
+	// UserAllowEmptyValues ...
+	UserAllowEmptyValues = []string{}
+	// UserAttributes ...
+	UserAttributes = map[string]string{}
+	// UserAdditionalFields ...
+	UserAdditionalFields = map[string]string{}
+)
+
+// UserGenerator ...
+type UserGenerator struct {
+	DatadogService
+}
+
+func (UserGenerator) createResources(users []datadog.User) []terraform_utils.Resource {
+	resources := []terraform_utils.Resource{}
+	for _, user := range users {
+		resourceName := user.GetHandle()
+		resources = append(resources, terraform_utils.NewResource(
+			resourceName,
+			fmt.Sprintf("user_%s", resourceName),
+			"datadog_user",
+			"datadog",
+			UserAttributes,
+			UserAllowEmptyValues,
+			UserAdditionalFields,
+		))
+	}
+
+	return resources
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each user create 1 TerraformResource.
+// Need User ID as ID for terraform resource
+func (g *UserGenerator) InitResources() error {
+	client := datadog.NewClient(g.Args["api-key"], g.Args["app-key"])
+	_, err := client.Validate()
+	if err != nil {
+		return err
+	}
+	users, err := client.GetUsers()
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(users)
+	g.PopulateIgnoreKeys()
+	return nil
+}


### PR DESCRIPTION
This PR add support for Datadog provider.

- supported resources
  - [datadog_downtime](https://www.terraform.io/docs/providers/datadog/r/downtime.html)
  - [datadog_user](https://www.terraform.io/docs/providers/datadog/r/user.html)