### PR TITLE
Add support datadog_synthetics_test resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,8 @@ List of support Datadog services:
     * `datadog_downtime`
 * `monitor`
     * `datadog_monitor`
+* `synthetics`
+    * `datadog_synthetics_test`
 * `user`
     * `datadog_user`
 

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -86,9 +86,10 @@ func (p *DatadogProvider) InitService(serviceName string) error {
 // GetSupportedService return map of support service for Datadog
 func (p *DatadogProvider) GetSupportedService() map[string]terraform_utils.ServiceGenerator {
 	return map[string]terraform_utils.ServiceGenerator{
-		"downtime": &DowntimeGenerator{},
-		"monitor":  &MonitorGenerator{},
-		"user":     &UserGenerator{},
+		"downtime":   &DowntimeGenerator{},
+		"monitor":    &MonitorGenerator{},
+		"synthetics": &SyntheticsGenerator{},
+		"user":       &UserGenerator{},
 	}
 }
 

--- a/providers/datadog/synthetics.go
+++ b/providers/datadog/synthetics.go
@@ -1,0 +1,73 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datadog
+
+import (
+	"fmt"
+
+	datadog "github.com/zorkian/go-datadog-api"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+)
+
+var (
+	// SyntheticsAllowEmptyValues ...
+	SyntheticsAllowEmptyValues = []string{"tags."}
+	// SyntheticsAttributes ...
+	SyntheticsAttributes = map[string]string{}
+	// SyntheticsAdditionalFields ...
+	SyntheticsAdditionalFields = map[string]string{}
+)
+
+// SyntheticsGenerator ...
+type SyntheticsGenerator struct {
+	DatadogService
+}
+
+func (SyntheticsGenerator) createResources(syntheticsList []datadog.SyntheticsTest) []terraform_utils.Resource {
+	resources := []terraform_utils.Resource{}
+	for _, synthetics := range syntheticsList {
+		resourceName := synthetics.GetPublicId()
+		resources = append(resources, terraform_utils.NewResource(
+			resourceName,
+			fmt.Sprintf("synthetics_%s", resourceName),
+			"datadog_synthetics_test",
+			"datadog",
+			SyntheticsAttributes,
+			SyntheticsAllowEmptyValues,
+			SyntheticsAdditionalFields,
+		))
+	}
+
+	return resources
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each synthetics create 1 TerraformResource.
+// Need Synthetics ID as ID for terraform resource
+func (g *SyntheticsGenerator) InitResources() error {
+	client := datadog.NewClient(g.Args["api-key"], g.Args["app-key"])
+	_, err := client.Validate()
+	if err != nil {
+		return err
+	}
+	syntheticsList, err := client.GetSyntheticsTests()
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(syntheticsList)
+	g.PopulateIgnoreKeys()
+	return nil
+}


### PR DESCRIPTION
This PR add support for Datadog provider.

- supported resources
  - [datadog_synthetics_test](https://www.terraform.io/docs/providers/datadog/r/synthetics.html)