### PR TITLE
Add support datadog dashboards resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,8 @@ List of support Datadog services:
     * `datadog_screenboard`
 * `synthetics`
     * `datadog_synthetics_test`
+* `timeboard`
+    * `datadog_timeboard`
 * `user`
     * `datadog_user`
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,8 @@ List of support Datadog services:
     * `datadog_downtime`
 * `monitor`
     * `datadog_monitor`
+* `screenboard`
+    * `datadog_screenboard`
 * `synthetics`
     * `datadog_synthetics_test`
 * `user`

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -90,6 +90,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraform_utils.Servi
 		"monitor":     &MonitorGenerator{},
 		"screenboard": &ScreenboardGenerator{},
 		"synthetics":  &SyntheticsGenerator{},
+		"timeboard":   &TimeboardGenerator{},
 		"user":        &UserGenerator{},
 	}
 }

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -86,10 +86,11 @@ func (p *DatadogProvider) InitService(serviceName string) error {
 // GetSupportedService return map of support service for Datadog
 func (p *DatadogProvider) GetSupportedService() map[string]terraform_utils.ServiceGenerator {
 	return map[string]terraform_utils.ServiceGenerator{
-		"downtime":   &DowntimeGenerator{},
-		"monitor":    &MonitorGenerator{},
-		"synthetics": &SyntheticsGenerator{},
-		"user":       &UserGenerator{},
+		"downtime":    &DowntimeGenerator{},
+		"monitor":     &MonitorGenerator{},
+		"screenboard": &ScreenboardGenerator{},
+		"synthetics":  &SyntheticsGenerator{},
+		"user":        &UserGenerator{},
 	}
 }
 

--- a/providers/datadog/screenboard.go
+++ b/providers/datadog/screenboard.go
@@ -1,0 +1,74 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datadog
+
+import (
+	"fmt"
+	"strconv"
+
+	datadog "github.com/zorkian/go-datadog-api"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+)
+
+var (
+	// ScreenboardAllowEmptyValues ...
+	ScreenboardAllowEmptyValues = []string{"tags."}
+	// ScreenboardAttributes ...
+	ScreenboardAttributes = map[string]string{}
+	// ScreenboardAdditionalFields ...
+	ScreenboardAdditionalFields = map[string]string{}
+)
+
+// ScreenboardGenerator ...
+type ScreenboardGenerator struct {
+	DatadogService
+}
+
+func (ScreenboardGenerator) createResources(screenboards []*datadog.ScreenboardLite) []terraform_utils.Resource {
+	resources := []terraform_utils.Resource{}
+	for _, screenboard := range screenboards {
+		resourceName := strconv.Itoa(screenboard.GetId())
+		resources = append(resources, terraform_utils.NewResource(
+			resourceName,
+			fmt.Sprintf("screenboard_%s", resourceName),
+			"datadog_screenboard",
+			"datadog",
+			ScreenboardAttributes,
+			ScreenboardAllowEmptyValues,
+			ScreenboardAdditionalFields,
+		))
+	}
+
+	return resources
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each screenboard create 1 TerraformResource.
+// Need Screenboard ID as ID for terraform resource
+func (g *ScreenboardGenerator) InitResources() error {
+	client := datadog.NewClient(g.Args["api-key"], g.Args["app-key"])
+	_, err := client.Validate()
+	if err != nil {
+		return err
+	}
+	screenboards, err := client.GetScreenboards()
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(screenboards)
+	g.PopulateIgnoreKeys()
+	return nil
+}

--- a/providers/datadog/timeboard.go
+++ b/providers/datadog/timeboard.go
@@ -1,0 +1,74 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datadog
+
+import (
+	"fmt"
+	"strconv"
+
+	datadog "github.com/zorkian/go-datadog-api"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+)
+
+var (
+	// TimeboardAllowEmptyValues ...
+	TimeboardAllowEmptyValues = []string{"tags."}
+	// TimeboardAttributes ...
+	TimeboardAttributes = map[string]string{}
+	// TimeboardAdditionalFields ...
+	TimeboardAdditionalFields = map[string]string{}
+)
+
+// TimeboardGenerator ...
+type TimeboardGenerator struct {
+	DatadogService
+}
+
+func (TimeboardGenerator) createResources(timeboards []datadog.DashboardLite) []terraform_utils.Resource {
+	resources := []terraform_utils.Resource{}
+	for _, timeboard := range timeboards {
+		resourceName := strconv.Itoa(timeboard.GetId())
+		resources = append(resources, terraform_utils.NewResource(
+			resourceName,
+			fmt.Sprintf("timeboard_%s", resourceName),
+			"datadog_timeboard",
+			"datadog",
+			TimeboardAttributes,
+			TimeboardAllowEmptyValues,
+			TimeboardAdditionalFields,
+		))
+	}
+
+	return resources
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each timeboard create 1 TerraformResource.
+// Need Timeboard ID as ID for terraform resource
+func (g *TimeboardGenerator) InitResources() error {
+	client := datadog.NewClient(g.Args["api-key"], g.Args["app-key"])
+	_, err := client.Validate()
+	if err != nil {
+		return err
+	}
+	timeboards, err := client.GetDashboards()
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(timeboards)
+	g.PopulateIgnoreKeys()
+	return nil
+}


### PR DESCRIPTION
This PR add support for Datadog provider.

- supported resources
  - [datadog_screenboard](https://www.terraform.io/docs/providers/datadog/r/screenboard.html)
  - [datadog_timeboard](https://www.terraform.io/docs/providers/datadog/r/timeboard.html)