### PR TITLE
Proposal: Adding a "plan" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,25 @@ Check the import part of [Terraform documentation][terraform-providers] for your
 
 [terraform-providers]: https://www.terraform.io/docs/providers/
 
+#### Planning
+
+`plan` command let you review the resources to import, rename them, or even filter only what you need.
+
+The rest of subcommands and parameters are same to `import` command.
+
+```
+$ terraformer plan aws --resources=vpc,subnet --filter=aws_vpc=myvpcid --regions=eu-west-1
+(snip)
+
+Saving planfile to generated/aws/terraformer/eu-west-1/plan.json
+```
+
+After reviewing/customizing the planfile, perform import by `import plan` command.
+
+```
+$ terraformer import plan generated/aws/terraformer/eu-west-1/plan.json
+```
+
 ### Installation
 From source:
 1.  Run `git clone <terraformer repo>`

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -17,7 +17,7 @@ import (
 	"log"
 
 	aws_terraforming "github.com/GoogleCloudPlatform/terraformer/providers/aws"
-
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +29,7 @@ func newCmdAwsImporter(options ImportOptions) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			originalPathPattern := options.PathPattern
 			for _, region := range options.Regions {
-				provider := &aws_terraforming.AWSProvider{}
+				provider := newAWSProvider()
 				options.PathPattern = originalPathPattern
 				options.PathPattern += region + "/"
 				log.Println(provider.GetName() + " importing region " + region)
@@ -41,7 +41,7 @@ func newCmdAwsImporter(options ImportOptions) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.AddCommand(listCmd(&aws_terraforming.AWSProvider{}))
+	cmd.AddCommand(listCmd(newAWSProvider()))
 	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
 	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "vpc,subnet,nacl")
 	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
@@ -51,4 +51,8 @@ func newCmdAwsImporter(options ImportOptions) *cobra.Command {
 	cmd.PersistentFlags().StringSliceVarP(&options.Regions, "regions", "", []string{}, "eu-west-1,eu-west-2,us-east-1")
 	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "aws_elb=id1:id2:id4")
 	return cmd
+}
+
+func newAWSProvider() terraform_utils.ProviderGenerator {
+	return &aws_terraforming.AWSProvider{}
 }

--- a/cmd/datadog.go
+++ b/cmd/datadog.go
@@ -15,7 +15,7 @@ package cmd
 
 import (
 	datadog_terraforming "github.com/GoogleCloudPlatform/terraformer/providers/datadog"
-
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 	"github.com/spf13/cobra"
 )
 
@@ -26,7 +26,7 @@ func newCmdDatadogImporter(options ImportOptions) *cobra.Command {
 		Short: "Import current State to terraform configuration from datadog",
 		Long:  "Import current State to terraform configuration from datadog",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			provider := &datadog_terraforming.DatadogProvider{}
+			provider := newDataDogProvider()
 			err := Import(provider, options, []string{apiKey, appKey})
 			if err != nil {
 				return err
@@ -34,7 +34,7 @@ func newCmdDatadogImporter(options ImportOptions) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.AddCommand(listCmd(&datadog_terraforming.DatadogProvider{}))
+	cmd.AddCommand(listCmd(newDataDogProvider()))
 	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
 	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "monitors,users")
 	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
@@ -45,4 +45,8 @@ func newCmdDatadogImporter(options ImportOptions) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&appKey, "app-key", "", "", "YOUR_DATADOG_APP_KEY or env param DATADOG_APP_KEY")
 	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "datadog_monitor=id1:id2:id4")
 	return cmd
+}
+
+func newDataDogProvider() terraform_utils.ProviderGenerator {
+	return &datadog_terraforming.DatadogProvider{}
 }

--- a/cmd/github.go
+++ b/cmd/github.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 
 	github_terraforming "github.com/GoogleCloudPlatform/terraformer/providers/github"
-
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 	"github.com/spf13/cobra"
 )
 
@@ -32,7 +32,7 @@ func newCmdGithubImporter(options ImportOptions) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			originalPathPattern := options.PathPattern
 			for _, organization := range organizations {
-				provider := &github_terraforming.GithubProvider{}
+				provider := newGitHubProvider()
 				options.PathPattern = originalPathPattern
 				options.PathPattern = strings.Replace(options.PathPattern, "{provider}", "{provider}/"+organization, -1)
 				log.Println(provider.GetName() + " importing organization " + organization)
@@ -44,7 +44,7 @@ func newCmdGithubImporter(options ImportOptions) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.AddCommand(listCmd(&github_terraforming.GithubProvider{}))
+	cmd.AddCommand(listCmd(newGitHubProvider()))
 	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
 	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "repository")
 	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
@@ -55,4 +55,8 @@ func newCmdGithubImporter(options ImportOptions) *cobra.Command {
 	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "github_repository=id1:id2:id4")
 	cmd.PersistentFlags().StringSliceVarP(&organizations, "organizations", "", []string{}, "")
 	return cmd
+}
+
+func newGitHubProvider() terraform_utils.ProviderGenerator {
+	return &github_terraforming.GithubProvider{}
 }

--- a/cmd/google.go
+++ b/cmd/google.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 
 	gcp_terraforming "github.com/GoogleCloudPlatform/terraformer/providers/gcp"
-
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 	"github.com/spf13/cobra"
 )
 
@@ -30,7 +30,7 @@ func newCmdGoogleImporter(options ImportOptions) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			originalPathPattern := options.PathPattern
 			for _, project := range options.Projects {
-				provider := &gcp_terraforming.GCPProvider{}
+				provider := newGCPProvider()
 				options.PathPattern = originalPathPattern
 				options.PathPattern = strings.Replace(options.PathPattern, "{provider}", "{provider}/"+project, -1)
 				log.Println(provider.GetName() + " importing project " + project)
@@ -42,7 +42,7 @@ func newCmdGoogleImporter(options ImportOptions) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.AddCommand(listCmd(&gcp_terraforming.GCPProvider{}))
+	cmd.AddCommand(listCmd(newGCPProvider()))
 	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
 	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "firewalls,networks")
 	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
@@ -53,4 +53,8 @@ func newCmdGoogleImporter(options ImportOptions) *cobra.Command {
 	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "google_compute_firewall=id1:id2:id4")
 	cmd.PersistentFlags().StringSliceVarP(&options.Projects, "projects", "", []string{}, "")
 	return cmd
+}
+
+func newGCPProvider() terraform_utils.ProviderGenerator {
+	return &gcp_terraforming.GCPProvider{}
 }

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -55,13 +55,10 @@ func newImportCmd() *cobra.Command {
 		SilenceErrors: false,
 		//Version:       version.String(),
 	}
-	cmd.AddCommand(newCmdPlanImporter(options))
-	cmd.AddCommand(newCmdGoogleImporter(options))
-	cmd.AddCommand(newCmdAwsImporter(options))
-	cmd.AddCommand(newCmdOpenStackImporter(options))
-	cmd.AddCommand(newCmdKubernetesImporter(options))
-	cmd.AddCommand(newCmdGithubImporter(options))
-	cmd.AddCommand(newCmdDatadogImporter(options))
+
+	for _, subcommand := range providerImporterSubcommands() {
+		cmd.AddCommand(subcommand(options))
+	}
 	return cmd
 }
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -38,7 +38,7 @@ type ImportOptions struct {
 	Projects    []string
 	Connect     bool
 	Filter      []string
-	Plan        bool     `json:"-"`
+	Plan        bool `json:"-"`
 }
 
 const DefaultPathPattern = "{output}/{provider}/{service}/"
@@ -104,7 +104,7 @@ func Import(provider terraform_utils.ProviderGenerator, options ImportOptions, a
 	plan := &ImportPlan{
 		Provider:  provider.GetName(),
 		Options:   options,
-		Args: args,
+		Args:      args,
 		Resources: provider.GetService().GetResources(),
 	}
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -38,7 +38,7 @@ type ImportOptions struct {
 	Projects    []string
 	Connect     bool
 	Filter      []string
-	Plan        bool
+	Plan        bool     `json:"-"`
 }
 
 const DefaultPathPattern = "{output}/{provider}/{service}/"

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -38,6 +38,7 @@ type ImportOptions struct {
 	Projects    []string
 	Connect     bool
 	Filter      []string
+	Plan        bool
 }
 
 const DefaultPathPattern = "{output}/{provider}/{service}/"
@@ -54,6 +55,7 @@ func newImportCmd() *cobra.Command {
 		SilenceErrors: false,
 		//Version:       version.String(),
 	}
+	cmd.AddCommand(newCmdPlanImporter(options))
 	cmd.AddCommand(newCmdGoogleImporter(options))
 	cmd.AddCommand(newCmdAwsImporter(options))
 	cmd.AddCommand(newCmdOpenStackImporter(options))
@@ -68,7 +70,7 @@ func Import(provider terraform_utils.ProviderGenerator, options ImportOptions, a
 	if err != nil {
 		return err
 	}
-	importedResource := map[string][]terraform_utils.Resource{}
+
 	for _, service := range options.Resources {
 		log.Println(provider.GetName() + " importing... " + service)
 		err = provider.InitService(service)
@@ -100,7 +102,30 @@ func Import(provider terraform_utils.ProviderGenerator, options ImportOptions, a
 		if err != nil {
 			return err
 		}
-		importedResource[service] = append(importedResource[service], provider.GetService().GetResources()...)
+	}
+
+	plan := &ImportPlan{
+		Provider:  provider.GetName(),
+		Options:   options,
+		Args: args,
+		Resources: provider.GetService().GetResources(),
+	}
+
+	if options.Plan {
+		path := Path(options.PathPattern, provider.GetName(), "terraformer", options.PathOutput)
+		return ExportPlanfile(plan, path, "plan.json")
+	} else {
+		return ImportFromPlan(provider, plan)
+	}
+}
+
+func ImportFromPlan(provider terraform_utils.ProviderGenerator, plan *ImportPlan) error {
+	options := plan.Options
+	provider.GetService().SetResources(plan.Resources)
+
+	importedResource := map[string][]terraform_utils.Resource{}
+	for _, service := range options.Resources {
+		importedResource[service] = append(importedResource[service], plan.Resources...)
 	}
 
 	if options.Connect {

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -15,7 +15,7 @@ package cmd
 
 import (
 	kubernetes_terraforming "github.com/GoogleCloudPlatform/terraformer/providers/kubernetes"
-
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 	"github.com/spf13/cobra"
 )
 
@@ -25,7 +25,7 @@ func newCmdKubernetesImporter(options ImportOptions) *cobra.Command {
 		Short: "Import current State to terraform configuration from kubernetes",
 		Long:  "Import current State to terraform configuration from kubernetes",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			provider := &kubernetes_terraforming.KubernetesProvider{}
+			provider := newKubernetesProvider()
 			err := Import(provider, options, []string{})
 			if err != nil {
 				return err
@@ -34,7 +34,7 @@ func newCmdKubernetesImporter(options ImportOptions) *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(listCmd(&kubernetes_terraforming.KubernetesProvider{}))
+	cmd.AddCommand(listCmd(newKubernetesProvider()))
 	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
 	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "configmaps,deployments,services")
 	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
@@ -43,4 +43,8 @@ func newCmdKubernetesImporter(options ImportOptions) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
 	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "kubernetes_deployment=name1:name2:name3")
 	return cmd
+}
+
+func newKubernetesProvider() terraform_utils.ProviderGenerator {
+	return &kubernetes_terraforming.KubernetesProvider{}
 }

--- a/cmd/openstack.go
+++ b/cmd/openstack.go
@@ -17,7 +17,7 @@ import (
 	"log"
 
 	openstack_terraforming "github.com/GoogleCloudPlatform/terraformer/providers/openstack"
-
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +29,7 @@ func newCmdOpenStackImporter(options ImportOptions) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			originalPathPattern := options.PathPattern
 			for _, region := range options.Regions {
-				provider := &openstack_terraforming.OpenStackProvider{}
+				provider := newOpenStackProvider()
 				options.PathPattern = originalPathPattern
 				options.PathPattern += region + "/"
 				log.Println(provider.GetName() + " importing region " + region)
@@ -41,7 +41,7 @@ func newCmdOpenStackImporter(options ImportOptions) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.AddCommand(listCmd(&openstack_terraforming.OpenStackProvider{}))
+	cmd.AddCommand(listCmd(newOpenStackProvider()))
 	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
 	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "compute,networking")
 	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
@@ -51,4 +51,8 @@ func newCmdOpenStackImporter(options ImportOptions) *cobra.Command {
 	cmd.PersistentFlags().StringSliceVarP(&options.Regions, "regions", "", []string{}, "RegionOne")
 	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "openstack_compute_instance_v2=id1:id2:id4")
 	return cmd
+}
+
+func newOpenStackProvider() terraform_utils.ProviderGenerator {
+	return &openstack_terraforming.OpenStackProvider{}
 }

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -1,0 +1,135 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/spf13/cobra"
+)
+
+type ImportPlan struct {
+	Provider  string
+	Options   ImportOptions
+	Args      []string
+	Resources []terraform_utils.Resource
+}
+
+func newPlanCmd() *cobra.Command {
+	options := ImportOptions{
+		Plan: true,
+	}
+	cmd := &cobra.Command{
+		Use:           "plan",
+		Short:         "Plan to import current State to terraform configuration",
+		Long:          "Plan to import current State to terraform configuration",
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		//Version:       version.String(),
+	}
+	cmd.AddCommand(newCmdGoogleImporter(options))
+	cmd.AddCommand(newCmdAwsImporter(options))
+	cmd.AddCommand(newCmdOpenStackImporter(options))
+	cmd.AddCommand(newCmdKubernetesImporter(options))
+	cmd.AddCommand(newCmdGithubImporter(options))
+	cmd.AddCommand(newCmdDatadogImporter(options))
+	return cmd
+}
+
+func newCmdPlanImporter(options ImportOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "plan",
+		Short: "Import planned state to terraform configuration",
+		Long:  "Import planned state to terraform configuration",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plan, err := LoadPlanfile(args[0])
+			if err != nil {
+				return err
+			}
+
+			var provider terraform_utils.ProviderGenerator
+			switch plan.Provider {
+			// TODO: Make this something beautiful
+			case newGCPProvider().GetName():
+				provider = newGCPProvider()
+			case newAWSProvider().GetName():
+				provider = newAWSProvider()
+			case newOpenStackProvider().GetName():
+				provider = newOpenStackProvider()
+			case newKubernetesProvider().GetName():
+				provider = newKubernetesProvider()
+			case newGitHubProvider().GetName():
+				provider = newGitHubProvider()
+			case newDataDogProvider().GetName():
+				provider = newDataDogProvider()
+			default:
+				return errors.New("unsupported provider: " + plan.Provider)
+			}
+
+			if err = provider.Init(plan.Args); err != nil {
+				return err
+			}
+
+			for _, service := range plan.Options.Resources {
+				if err = provider.InitService(service); err != nil {
+					return err
+				}
+			}
+
+			return ImportFromPlan(provider, plan)
+		},
+	}
+	return cmd
+}
+
+func LoadPlanfile(path string) (*ImportPlan, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	plan := &ImportPlan{}
+	dec := json.NewDecoder(f)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(plan); err != nil {
+		return nil, err
+	}
+	return plan, nil
+}
+
+func ExportPlanfile(plan *ImportPlan, path, filename string) error {
+	planfilePath := filepath.Join(path, filename)
+	log.Println("Saving planfile to", planfilePath)
+
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(planfilePath, os.O_RDWR|os.O_CREATE, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "\t")
+	return enc.Encode(plan)
+}

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -66,21 +66,9 @@ func newCmdPlanImporter(options ImportOptions) *cobra.Command {
 			}
 
 			var provider terraform_utils.ProviderGenerator
-			switch plan.Provider {
-			// TODO: Make this something beautiful
-			case newGCPProvider().GetName():
-				provider = newGCPProvider()
-			case newAWSProvider().GetName():
-				provider = newAWSProvider()
-			case newOpenStackProvider().GetName():
-				provider = newOpenStackProvider()
-			case newKubernetesProvider().GetName():
-				provider = newKubernetesProvider()
-			case newGitHubProvider().GetName():
-				provider = newGitHubProvider()
-			case newDataDogProvider().GetName():
-				provider = newDataDogProvider()
-			default:
+			if providerGen, ok := providerGenerators()[plan.Provider]; ok {
+				provider = providerGen()
+			} else {
 				return fmt.Errorf("unsupported provider: %s", plan.Provider)
 			}
 

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -44,12 +44,10 @@ func newPlanCmd() *cobra.Command {
 		SilenceErrors: false,
 		//Version:       version.String(),
 	}
-	cmd.AddCommand(newCmdGoogleImporter(options))
-	cmd.AddCommand(newCmdAwsImporter(options))
-	cmd.AddCommand(newCmdOpenStackImporter(options))
-	cmd.AddCommand(newCmdKubernetesImporter(options))
-	cmd.AddCommand(newCmdGithubImporter(options))
-	cmd.AddCommand(newCmdDatadogImporter(options))
+
+	for _, subcommand := range providerImporterSubcommands() {
+		cmd.AddCommand(subcommand(options))
+	}
 	return cmd
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,17 @@ func Execute() error {
 	return cmd.Execute()
 }
 
+func providerImporterSubcommands() []func(options ImportOptions) *cobra.Command {
+	return []func(options ImportOptions) *cobra.Command {
+		newCmdGoogleImporter,
+		newCmdAwsImporter,
+		newCmdOpenStackImporter,
+		newCmdKubernetesImporter,
+		newCmdGithubImporter,
+		newCmdDatadogImporter,
+	}
+}
+
 func providerGenerators() map[string]func() terraform_utils.ProviderGenerator {
 	list := make(map[string]func() terraform_utils.ProviderGenerator)
 	for _, providerGen := range []func() terraform_utils.ProviderGenerator{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 	"github.com/spf13/cobra"
 )
 
@@ -33,4 +34,19 @@ func NewCmdRoot() *cobra.Command {
 func Execute() error {
 	cmd := NewCmdRoot()
 	return cmd.Execute()
+}
+
+func providerGenerators() map[string]func() terraform_utils.ProviderGenerator {
+	list := make(map[string]func() terraform_utils.ProviderGenerator)
+	for _, providerGen := range []func() terraform_utils.ProviderGenerator{
+		newGCPProvider,
+		newAWSProvider,
+		newOpenStackProvider,
+		newKubernetesProvider,
+		newGitHubProvider,
+		newDataDogProvider,
+	} {
+		list[providerGen().GetName()] = providerGen
+	}
+	return list
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ func NewCmdRoot() *cobra.Command {
 		Version:       version,
 	}
 	cmd.AddCommand(newImportCmd())
+	cmd.AddCommand(newPlanCmd())
 	cmd.AddCommand(versionCmd)
 	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,7 +37,7 @@ func Execute() error {
 }
 
 func providerImporterSubcommands() []func(options ImportOptions) *cobra.Command {
-	return []func(options ImportOptions) *cobra.Command {
+	return []func(options ImportOptions) *cobra.Command{
 		newCmdGoogleImporter,
 		newCmdAwsImporter,
 		newCmdOpenStackImporter,

--- a/terraform_utils/resource.go
+++ b/terraform_utils/resource.go
@@ -16,10 +16,11 @@ package terraform_utils
 
 import (
 	"fmt"
-	"github.com/GoogleCloudPlatform/terraformer/terraform_utils/provider_wrapper"
 	"log"
 	"regexp"
 	"strings"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils/provider_wrapper"
 
 	"github.com/hashicorp/terraform/flatmap"
 	"github.com/hashicorp/terraform/terraform"
@@ -28,13 +29,13 @@ import (
 type Resource struct {
 	InstanceInfo     *terraform.InstanceInfo
 	InstanceState    *terraform.InstanceState
-	Outputs          map[string]*terraform.OutputState
+	Outputs          map[string]*terraform.OutputState `json:",omitempty"`
 	ResourceName     string
 	Provider         string
-	Item             map[string]interface{}
-	IgnoreKeys       []string
-	AllowEmptyValues []string
-	AdditionalFields map[string]string
+	Item             map[string]interface{} `json:",omitempty"`
+	IgnoreKeys       []string               `json:",omitempty"`
+	AllowEmptyValues []string               `json:",omitempty"`
+	AdditionalFields map[string]string      `json:",omitempty"`
 }
 
 func NewResource(ID, resourceName, resourceType, provider string,


### PR DESCRIPTION
⚠️ **This PR is a feature proposal.** Codes/implementation may not be clean/intelligent enough.

---

This PR adds two new commands:

```
terraformer plan <provider> ...
```

and:

```
terraformer import plan <planfile>
```

The first command generates a JSON file (_planfile_) that contains a list of resources that Terraformer retrieved.

Then the second command loads the generated planfile, and generates `.tf` and `.tfstate` files.

This makes users able to review the retrieved resources, and edit them to rename the resources before generating `.tf` files, or filter the resources to only what they needed.

This is especially useful if the user had a huge number of resources on the cloud provider and they wouldn't want to import all of them at one time, but some.

I believe this feature is really useful (it at least really really helps my workflow) so please consider implementing planning features like this PR.

Thanks!


