### PR TITLE
Log refreshing status

### DIFF
--- a/terraform_utils/utils.go
+++ b/terraform_utils/utils.go
@@ -93,6 +93,7 @@ func RefreshResources(resources []Resource, providerName string, providerConfig 
 
 func RefreshResourceWorker(input chan *Resource, wg *sync.WaitGroup, provider *provider_wrapper.ProviderWrapper) {
 	for r := range input {
+		log.Println("Refreshing state...", r.InstanceInfo.Id)
 		r.Refresh(provider)
 		wg.Done()
 	}


### PR DESCRIPTION
Refresh may take long time depending on the number of resources and stability of network connection. For instance in my case it hangs up for tens of minutes at refreshing step.

This commit let refresh show which resource are being imported so users can see it's still in progress.

Thread safety: [logger is simultaneously writable](https://golang.org/pkg/log/#Logger) so it would cause no problem in goroutine loop :)