### PR TITLE
Re-add `import plan` command

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -56,6 +56,7 @@ func newImportCmd() *cobra.Command {
 		//Version:       version.String(),
 	}
 
+	cmd.AddCommand(newCmdPlanImporter(options))
 	for _, subcommand := range providerImporterSubcommands() {
 		cmd.AddCommand(subcommand(options))
 	}


### PR DESCRIPTION
I accidentally removed `import plan` subcommand at e4d975b 😭

This commit re-adds it. My apologies.