### PR TITLE
fix filtering of "import aws"

### DIFF
--- a/providers/aws/s3.go
+++ b/providers/aws/s3.go
@@ -17,6 +17,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 
@@ -117,4 +118,20 @@ func (g *S3Generator) PostConvertHook() error {
 POLICY`, policy)
 	}
 	return nil
+}
+
+func (g *S3Generator) ParseFilter(rawFilter []string) {
+	g.Filter = map[string][]string{}
+	for _, resource := range rawFilter {
+		t := strings.Split(resource, "=")
+		if len(t) != 2 {
+			log.Println("Pattern for filter must be resource_type=id1:id2:id4")
+			continue
+		}
+		resourceName, resourcesID := t[0], t[1]
+		g.Filter[resourceName] = strings.Split(resourcesID, ":")
+		if resourceName == "aws_s3_bucket" {
+			g.Filter["aws_s3_bucket_policy"] = strings.Split(resourcesID, ":")
+		}
+	}
 }


### PR DESCRIPTION
This change improved `terraformer import(plan) aws -r s3 -f aws_s3_bucket=bucketX` result.
* Import S3 bucket policy just related to only `aws_s3_bucket` (or `aws_s3_bucket_policy`) filter

Example
`terraformer import s3 -f "aws_s3_bucket=terraformer-test" `
We expect to import only `terraformer-test` bucket policy but current implementation import following bucket policies
* `bucket A`
* `bucket B`
* ...`bucket C..Z`
* `terraformer-test`

This change improved this behavior to import only `terraformer-test` bucket policy.

