### PR TITLE
aws: support firehose

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,8 @@ List of supported AWS services:
     * `aws_cloudfront_distribution`
 *   `ec2_instance`
     * `aws_instance`
+*   `firehose`
+    * `aws_kinesis_firehose_delivery_stream`
 
 ### Use with OpenStack
 

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -131,5 +131,6 @@ func (p *AWSProvider) GetSupportedService() map[string]terraform_utils.ServiceGe
 		"acm":            &ACMGenerator{},
 		"cloudfront":     &CloudFrontGenerator{},
 		"ec2_instance":   &Ec2Generator{},
+		"firehose":       &FirehoseGenerator{},
 	}
 }

--- a/providers/aws/firehose.go
+++ b/providers/aws/firehose.go
@@ -1,13 +1,3 @@
-package aws
-
-
-import (
-	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/firehose"
-)
-
 // Copyright 2018 The Terraformer Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,13 +12,20 @@ import (
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+package aws
+
+import (
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/firehose"
+)
 
 type FirehoseGenerator struct {
 	AWSService
 }
 
-func (g FirehoseGenerator) createResources(sess *session.Session, streamNames []*string, region string) []terraform_utils.Resource {
-
+func (g FirehoseGenerator) createResources(sess *session.Session, streamNames []*string) []terraform_utils.Resource {
 	var resources []terraform_utils.Resource
 	for _, streamName := range streamNames {
 		resourceName := aws.StringValue(streamName)
@@ -62,7 +59,7 @@ func (g *FirehoseGenerator) InitResources() error {
 		}
 	}
 
-	g.Resources = g.createResources(sess, streamNames, g.GetArgs()["region"].(string))
+	g.Resources = g.createResources(sess, streamNames)
 
 	g.PopulateIgnoreKeys()
 	return nil

--- a/providers/aws/firehose.go
+++ b/providers/aws/firehose.go
@@ -1,0 +1,69 @@
+package aws
+
+
+import (
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/firehose"
+)
+
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+type FirehoseGenerator struct {
+	AWSService
+}
+
+func (g FirehoseGenerator) createResources(sess *session.Session, streamNames []*string, region string) []terraform_utils.Resource {
+
+	var resources []terraform_utils.Resource
+	for _, streamName := range streamNames {
+		resourceName := aws.StringValue(streamName)
+
+		resources = append(resources, terraform_utils.NewResource(
+			resourceName,
+			resourceName,
+			"aws_kinesis_firehose_delivery_stream",
+			"aws",
+			map[string]string{"name": resourceName},
+			[]string{".tags"},
+			map[string]string{}))
+	}
+	return resources
+}
+
+// Generate TerraformResources from AWS API,
+// Need deliver stream name for terraform resource
+func (g *FirehoseGenerator) InitResources() error {
+	sess := g.generateSession()
+	svc := firehose.New(sess)
+	var streamNames []*string
+	for {
+		output, err := svc.ListDeliveryStreams(&firehose.ListDeliveryStreamsInput{})
+		if err != nil {
+			return err
+		}
+		streamNames = append(streamNames, output.DeliveryStreamNames...)
+		if *output.HasMoreDeliveryStreams == false {
+			break
+		}
+	}
+
+	g.Resources = g.createResources(sess, streamNames, g.GetArgs()["region"].(string))
+
+	g.PopulateIgnoreKeys()
+	return nil
+}


### PR DESCRIPTION
Hello.
This change support "aws_kinesis_firehose_delivery_stream" like following command.

```
terraformer import aws  -r firehose --regions "ap-northeast-1"
```

FYI
https://www.terraform.io/docs/providers/aws/r/kinesis_firehose_delivery_stream.html
https://aws.amazon.com/kinesis/data-firehose/

Thank you.