### PR TITLE
Support Cloudflare provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ A CLI tool that generates `tf` and `tfstate` files based on existing infrastruct
     * [Kubernetes](#use-with-kubernetes)
     * [Github](#use-with-github)
     * [Datadog](#use-with-datadog)
+    * [Cloudflare](#use-with-cloudflare)
+
 - [Contributing](#contributing)
 - [Developing](#developing)
 - [Infrastructure](#infrastructure)
@@ -481,6 +483,26 @@ List of supported Datadog services:
     * `datadog_user`
 
 
+### Use with Cloudflare
+
+Example:
+```
+CLOUDFLARE_TOKEN=[CLOUDFLARE_API_TOKEN]
+CLOUDFLARE_EMAIL=[CLOUDFLARE_EMAIL]
+ ./terraformer import cloudflare --resources=firewall,dns
+```
+
+List of supported Cloudflare services:
+
+* `firewall`
+  * `cloudflare_access_rule`
+  * `cloudflare_filter`
+  * `cloudflare_firewall_rule`
+  * `cloudflare_zone_lockdown`
+* `dns`
+  * `cloudflare_zone`
+  * `cloudflare_record`
+
 ## Contributing
 
 If you have improvements or fixes, we would love to have your contributions.
@@ -532,7 +554,7 @@ go run providers/gcp/gcp_compute_code_generator/*.go
 
 ##### Comparison
 
-Terraforming gets all attributes from cloud APIs and creates HCL and tfstate files with templating. Each attribute in the API needs to map to attribute in terraform. Generated files from templating can be broken with illegal syntax. When a provider adds new attributes the terraforming code needs to be updated. 
+Terraforming gets all attributes from cloud APIs and creates HCL and tfstate files with templating. Each attribute in the API needs to map to attribute in terraform. Generated files from templating can be broken with illegal syntax. When a provider adds new attributes the terraforming code needs to be updated.
 
 Terraformer instead uses terraform provider files for mapping attributes, HCL library from hashicorp, and terraform code.
 

--- a/cmd/cloudflare.go
+++ b/cmd/cloudflare.go
@@ -42,46 +42,9 @@ func newCmdCloudflareImporter(options ImportOptions) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
 	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
 	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
-	//cmd.PersistentFlags().StringVar(&options.Profile, "profile", "default", "prod")
-	//cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "aws_elb=id1:id2:id4")
 	return cmd
 }
 
 func newClouflareProvider() terraform_utils.ProviderGenerator {
 	return &cloudflare_terraforming.CloudflareProvider{}
 }
-
-// func newCmdAwsImporter(options ImportOptions) *cobra.Command {
-// 	cmd := &cobra.Command{
-// 		Use:   "aws",
-// 		Short: "Import current State to terraform configuration from aws",
-// 		Long:  "Import current State to terraform configuration from aws",
-// 		RunE: func(cmd *cobra.Command, args []string) error {
-// 			originalPathPattern := options.PathPattern
-// 			for _, region := range options.Regions {
-// 				provider := newAWSProvider()
-// 				options.PathPattern = originalPathPattern
-// 				options.PathPattern += region + "/"
-// 				log.Println(provider.GetName() + " importing region " + region)
-// 				profile := options.Profile
-// 				err := Import(provider, options, []string{region, profile})
-// 				if err != nil {
-// 					return err
-// 				}
-// 			}
-// 			return nil
-// 		},
-// 	}
-
-//
-// 	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
-// 	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "vpc,subnet,nacl")
-// 	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
-// 	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
-// 	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
-// 	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
-// 	cmd.PersistentFlags().StringVar(&options.Profile, "profile", "default", "prod")
-// 	cmd.PersistentFlags().StringSliceVarP(&options.Regions, "regions", "", []string{}, "eu-west-1,eu-west-2,us-east-1")
-// 	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "aws_elb=id1:id2:id4")
-// 	return cmd
-// }

--- a/cmd/cloudflare.go
+++ b/cmd/cloudflare.go
@@ -1,0 +1,87 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cmd
+
+import (
+	cloudflare_terraforming "github.com/GoogleCloudPlatform/terraformer/providers/cloudflare"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/spf13/cobra"
+)
+
+func newCmdCloudflareImporter(options ImportOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cloudflare",
+		Short: "Import current State to terraform configuration from cloudflare",
+		Long:  "Import current State to terraform configuration from cloudflare",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			provider := newClouflareProvider()
+			err := Import(provider, options, []string{})
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.AddCommand(listCmd(newClouflareProvider()))
+	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
+	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "zone")
+	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
+	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
+	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
+	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
+	//cmd.PersistentFlags().StringVar(&options.Profile, "profile", "default", "prod")
+	//cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "aws_elb=id1:id2:id4")
+	return cmd
+}
+
+func newClouflareProvider() terraform_utils.ProviderGenerator {
+	return &cloudflare_terraforming.CloudflareProvider{}
+}
+
+// func newCmdAwsImporter(options ImportOptions) *cobra.Command {
+// 	cmd := &cobra.Command{
+// 		Use:   "aws",
+// 		Short: "Import current State to terraform configuration from aws",
+// 		Long:  "Import current State to terraform configuration from aws",
+// 		RunE: func(cmd *cobra.Command, args []string) error {
+// 			originalPathPattern := options.PathPattern
+// 			for _, region := range options.Regions {
+// 				provider := newAWSProvider()
+// 				options.PathPattern = originalPathPattern
+// 				options.PathPattern += region + "/"
+// 				log.Println(provider.GetName() + " importing region " + region)
+// 				profile := options.Profile
+// 				err := Import(provider, options, []string{region, profile})
+// 				if err != nil {
+// 					return err
+// 				}
+// 			}
+// 			return nil
+// 		},
+// 	}
+
+//
+// 	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
+// 	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "vpc,subnet,nacl")
+// 	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
+// 	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
+// 	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
+// 	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
+// 	cmd.PersistentFlags().StringVar(&options.Profile, "profile", "default", "prod")
+// 	cmd.PersistentFlags().StringSliceVarP(&options.Regions, "regions", "", []string{}, "eu-west-1,eu-west-2,us-east-1")
+// 	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "aws_elb=id1:id2:id4")
+// 	return cmd
+// }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,6 +44,7 @@ func providerImporterSubcommands() []func(options ImportOptions) *cobra.Command 
 		newCmdKubernetesImporter,
 		newCmdGithubImporter,
 		newCmdDatadogImporter,
+		newCmdCloudflareImporter,
 	}
 }
 

--- a/providers/cloudflare/cloudflare_provider.go
+++ b/providers/cloudflare/cloudflare_provider.go
@@ -1,0 +1,69 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudflare
+
+import (
+	"errors"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+)
+
+const cloudflareProviderVersion = "~> 1.16"
+
+type CloudflareProvider struct {
+	terraform_utils.Provider
+}
+
+func (p *CloudflareProvider) Init(args []string) error {
+	return nil
+}
+
+func (p *CloudflareProvider) GetName() string {
+	return "cloudflare"
+}
+
+func (p *CloudflareProvider) GetProviderData(arg ...string) map[string]interface{} {
+	return map[string]interface{}{
+		"provider": map[string]interface{}{
+			"cloudflare": map[string]interface{}{
+				"version": cloudflareProviderVersion,
+			},
+		},
+	}
+}
+
+func (CloudflareProvider) GetResourceConnections() map[string]map[string][]string {
+	return map[string]map[string][]string{}
+}
+
+func (p *CloudflareProvider) GetSupportedService() map[string]terraform_utils.ServiceGenerator {
+	return map[string]terraform_utils.ServiceGenerator{
+		"dns":      &DNSGenerator{},
+		"firewall": &FirewallGenerator{},
+		//"access":   &AccessGenerator{},
+	}
+}
+
+func (p *CloudflareProvider) InitService(serviceName string) error {
+	var isSupported bool
+	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+		return errors.New("cloudflare: " + serviceName + " not supported service")
+	}
+	p.Service = p.GetSupportedService()[serviceName]
+	p.Service.SetName(serviceName)
+	p.Service.SetProviderName(p.GetName())
+
+	return nil
+}

--- a/providers/cloudflare/cloudflare_service.go
+++ b/providers/cloudflare/cloudflare_service.go
@@ -1,0 +1,41 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+type CloudflareService struct {
+	terraform_utils.Service
+}
+
+func (s *CloudflareService) initializeAPI() (*cf.API, error) {
+	apiKey := os.Getenv("CLOUDFLARE_TOKEN")
+	apiEmail := os.Getenv("CLOUDFLARE_EMAIL")
+
+	if apiEmail == "" || apiKey == "" {
+		err := errors.New("No CLOUDFLARE_TOKEN/CLOUDFLARE_EMAIL environment set")
+		fmt.Fprintln(os.Stderr, err)
+		return nil, err
+	}
+
+	return cf.New(apiKey, apiEmail)
+}

--- a/providers/cloudflare/dns.go
+++ b/providers/cloudflare/dns.go
@@ -1,0 +1,131 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudflare
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+type DNSGenerator struct {
+	CloudflareService
+}
+
+func (*DNSGenerator) createZonesResource(api *cf.API, zoneID string) ([]terraform_utils.Resource, error) {
+	zoneDetails, err := api.ZoneDetails(zoneID)
+	if err != nil {
+		log.Println(err)
+		return []terraform_utils.Resource{}, err
+	}
+
+	resource := terraform_utils.NewResource(
+		zoneDetails.ID,
+		zoneDetails.Name,
+		"cloudflare_zone",
+		"cloudflare",
+		map[string]string{
+			"id": zoneDetails.ID,
+		},
+		[]string{},
+		map[string]string{},
+	)
+
+	return []terraform_utils.Resource{resource}, nil
+}
+
+func (*DNSGenerator) createRecordsResources(api *cf.API, zoneID string) ([]terraform_utils.Resource, error) {
+	resources := []terraform_utils.Resource{}
+	records, err := api.DNSRecords(zoneID, cf.DNSRecord{})
+	if err != nil {
+		log.Println(err)
+		return resources, err
+	}
+
+	for _, record := range records {
+		resources = append(resources, terraform_utils.NewResource(
+			record.ID,
+			fmt.Sprintf("%s_%s_%s", record.Type, record.ZoneName, record.ID),
+			"cloudflare_record",
+			"cloudflare",
+			map[string]string{
+				"zone_id": zoneID,
+				"domain":  record.ZoneName,
+			},
+			[]string{},
+			map[string]string{},
+		))
+	}
+
+	return resources, nil
+}
+
+func (g *DNSGenerator) InitResources() error {
+	api, err := g.initializeAPI()
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	zones, err := api.ListZones()
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	funcs := []func(*cf.API, string) ([]terraform_utils.Resource, error){
+		g.createZonesResource,
+		g.createRecordsResources,
+	}
+
+	for _, zone := range zones {
+		for _, f := range funcs {
+			tmpRes, err := f(api, zone.ID)
+			if err != nil {
+				log.Println(err)
+				return err
+			}
+			g.Resources = append(g.Resources, tmpRes...)
+		}
+	}
+
+	g.PopulateIgnoreKeys()
+	return nil
+
+}
+
+func (g *DNSGenerator) PostConvertHook() error {
+	for i, resourceRecord := range g.Resources {
+		if resourceRecord.InstanceInfo.Type == "cloudflare_zone" {
+			continue
+		}
+
+		item := resourceRecord.Item
+		zoneID := item["zone_id"].(string)
+		for _, resourceZone := range g.Resources {
+			if resourceZone.InstanceInfo.Type != "cloudflare_zone" {
+				continue
+			}
+			if zoneID == resourceZone.InstanceState.ID {
+				if resourceRecord.InstanceInfo.Type == "cloudflare_record" {
+					g.Resources[i].Item["domain"] = "${cloudflare_zone." + resourceZone.ResourceName + ".zone}"
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/providers/cloudflare/firewall.go
+++ b/providers/cloudflare/firewall.go
@@ -1,0 +1,209 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//cloudflare_access_rule
+//cloudflare_rate_limit
+
+package cloudflare
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+type FirewallGenerator struct {
+	CloudflareService
+}
+
+func (*FirewallGenerator) createZoneLockdownsResources(api *cf.API, zoneID, zoneName string) ([]terraform_utils.Resource, error) {
+	resources := []terraform_utils.Resource{}
+	page := 1
+
+	for {
+		zonelockdowns, err := api.ListZoneLockdowns(zoneID, page)
+		if err != nil {
+			log.Println(err)
+			return resources, err
+		}
+		for _, zonelockdown := range zonelockdowns.Result {
+			resources = append(resources, terraform_utils.NewResource(
+				zonelockdown.ID,
+				fmt.Sprintf("%s_%s", zoneName, zonelockdown.ID),
+				"cloudflare_zone_lockdown",
+				"cloudflare",
+				map[string]string{
+					"zone_id": zoneID,
+					"zone":    zoneName,
+				},
+				[]string{},
+				map[string]string{},
+			))
+		}
+
+		if zonelockdowns.TotalPages > page {
+			page++
+		} else {
+			break
+		}
+	}
+
+	return resources, nil
+}
+
+func (*FirewallGenerator) createAccessRuleResources(api *cf.API, zoneID, zoneName string) ([]terraform_utils.Resource, error) {
+	resources := []terraform_utils.Resource{}
+	accessRules, err := api.ListZoneAccessRules(zoneID, cf.AccessRule{}, 1)
+	if err != nil {
+		log.Println(err)
+		return resources, err
+	}
+
+	for _, r := range accessRules.Result {
+		resources = append(resources, terraform_utils.NewResource(
+			r.ID,
+			fmt.Sprintf("%s_%s", zoneName, r.ID),
+			"cloudflare_access_rule",
+			"cloudflare",
+			map[string]string{
+				"zone_id": zoneID,
+				"zone":    zoneName,
+			},
+			[]string{},
+			map[string]string{},
+		))
+	}
+
+	return resources, nil
+}
+
+func (*FirewallGenerator) createFilterResources(api *cf.API, zoneID, zoneName string) ([]terraform_utils.Resource, error) {
+	resources := []terraform_utils.Resource{}
+	filters, err := api.Filters(zoneID, cf.PaginationOptions{})
+	if err != nil {
+		log.Println(err)
+		return resources, err
+	}
+
+	for _, filter := range filters {
+		resources = append(resources, terraform_utils.NewResource(
+			filter.ID,
+			fmt.Sprintf("%s_%s", zoneName, filter.ID),
+			"cloudflare_filter",
+			"cloudflare",
+			map[string]string{
+				"zone_id": zoneID,
+			},
+			[]string{},
+			map[string]string{},
+		))
+	}
+
+	return resources, nil
+}
+
+func (*FirewallGenerator) createFirewallRuleResources(api *cf.API, zoneID, zoneName string) ([]terraform_utils.Resource, error) {
+	resources := []terraform_utils.Resource{}
+
+	fwrules, err := api.FirewallRules(zoneID, cf.PaginationOptions{})
+	if err != nil {
+		log.Println(err)
+		return resources, err
+	}
+	for _, rule := range fwrules {
+		resources = append(resources, terraform_utils.NewResource(
+			rule.ID,
+			fmt.Sprintf("%s_%s", zoneName, rule.ID),
+			"cloudflare_firewall_rule",
+			"cloudflare",
+			map[string]string{
+				"zone_id": zoneID,
+			},
+			[]string{},
+			map[string]string{},
+		))
+	}
+
+	return resources, nil
+
+}
+
+func (g *FirewallGenerator) InitResources() error {
+	api, err := g.initializeAPI()
+	if err != nil {
+		panic(err)
+		return err
+	}
+
+	zones, err := api.ListZones()
+	if err != nil {
+		panic(err)
+		return err
+	}
+
+	funcs := []func(*cf.API, string, string) ([]terraform_utils.Resource, error){
+		g.createFirewallRuleResources,
+		g.createFilterResources,
+		g.createAccessRuleResources,
+		g.createZoneLockdownsResources,
+	}
+
+	for _, zone := range zones {
+		for _, f := range funcs {
+			// Getting all firewall filters
+			tmpRes, err := f(api, zone.ID, zone.Name)
+			if err != nil {
+				panic(err)
+				return err
+			}
+			g.Resources = append(g.Resources, tmpRes...)
+		}
+	}
+
+	g.PopulateIgnoreKeys()
+	return nil
+}
+
+func (g *FirewallGenerator) PostConvertHook() error {
+	for i, resourceRecord := range g.Resources {
+		// If Zone Name exists, delete ZoneID
+		if _, zoneIDExist := resourceRecord.Item["zone_id"]; zoneIDExist {
+			delete(g.Resources[i].Item, "zone")
+		}
+
+		if resourceRecord.InstanceInfo.Type == "cloudflare_firewall_rule" {
+			if resourceRecord.Item["priority"].(string) == "0" {
+				delete(g.Resources[i].Item, "priority")
+			}
+		}
+
+		// Reference to 'cloudflare_filter' resource in 'cloudflare_firewall_rule'
+		if resourceRecord.InstanceInfo.Type == "cloudflare_filter" {
+			continue
+		}
+		filterID := resourceRecord.Item["filter_id"]
+		for _, filterResource := range g.Resources {
+			if filterResource.InstanceInfo.Type != "cloudflare_filter" {
+				continue
+			}
+			if filterID == filterResource.InstanceState.ID {
+				g.Resources[i].Item["filter_id"] = "${cloudflare_filter." + filterResource.ResourceName + ".id}"
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds support [Cloudflare provider](https://www.terraform.io/docs/providers/cloudflare/index.html). Currently this provider supports the following resources:

* `firewall`
  * `cloudflare_access_rule`
  * `cloudflare_filter`
  * `cloudflare_firewall_rule`
  * `cloudflare_zone_lockdown`
* `dns`
  * `cloudflare_zone`
  * `cloudflare_record`