### PR TITLE
Add Logz.io provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A CLI tool that generates `tf` and `tfstate` files based on existing infrastruct
     * [Github](#use-with-github)
     * [Datadog](#use-with-datadog)
     * [Cloudflare](#use-with-cloudflare)
-
+    * [Logzio](#use-with-logzio)
 - [Contributing](#contributing)
 - [Developing](#developing)
 - [Infrastructure](#infrastructure)
@@ -145,6 +145,7 @@ Links to download terraform providers:
 * kubernetes provider >=1.4.0 - [here](https://releases.hashicorp.com/terraform-provider-kubernetes/)
 * github provider >=2.0.0 - [here](https://releases.hashicorp.com/terraform-provider-github/)
 * datadog provider >1.19.0 - [here](https://releases.hashicorp.com/terraform-provider-datadog/)
+* logzio provider >=1.1.1 - [here](https://github.com/jonboydell/logzio_terraform_provider/)
 
 Information on provider plugins:
 https://www.terraform.io/docs/configuration/providers.html
@@ -504,6 +505,24 @@ List of supported Cloudflare services:
   * `cloudflare_record`
 * `access`
   * `cloudflare_access_application`
+
+
+### Use with Logz.io
+
+Example:
+
+```
+ LOGZIO_API_TOKEN=foobar LOGZIO_BASE_URL=https://api-eu.logz.io ./terraformer import logzio -r=alerts,alert_notification_endpoints // Import Logz.io alerts and alert notification endpoints
+```
+
+List of supported Logz.io resources:
+
+* `alerts`
+    * `logzio_alert`
+* `alert notification endpoints`
+    * `logzio_endpoint`
+
+
 ## Contributing
 
 If you have improvements or fixes, we would love to have your contributions.

--- a/cmd/logzio.go
+++ b/cmd/logzio.go
@@ -1,0 +1,65 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cmd
+
+import (
+	"errors"
+	"os"
+
+	logzio_terraforming "github.com/GoogleCloudPlatform/terraformer/providers/logzio"
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultBaseURL = "https://api.logz.io"
+)
+
+func newCmdLogzioImporter(options ImportOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "logzio",
+		Short: "Import current State to terraform configuration from Logz.io",
+		Long:  "Import current State to terraform configuration from Logz.io",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			token := os.Getenv("LOGZIO_API_TOKEN")
+			if len(token) == 0 {
+				return errors.New("API Token for Logz.io must be set through `LOGZIO_API_TOKEN` env var")
+			}
+			baseURL := os.Getenv("LOGZIO_BASE_URL")
+			if len(baseURL) == 0 {
+				baseURL = defaultBaseURL
+			}
+
+			provider := newLogzioProvider()
+			err := Import(provider, options, []string{token, baseURL})
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	cmd.AddCommand(listCmd(newLogzioProvider()))
+	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
+	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "repository")
+	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
+	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
+	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
+	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
+	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "logzio_alert=id1:id2:id4")
+	return cmd
+}
+
+func newLogzioProvider() terraform_utils.ProviderGenerator {
+	return &logzio_terraforming.LogzioProvider{}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,7 @@ func providerImporterSubcommands() []func(options ImportOptions) *cobra.Command 
 		newCmdGithubImporter,
 		newCmdDatadogImporter,
 		newCmdCloudflareImporter,
+		newCmdLogzioImporter,
 	}
 }
 
@@ -57,6 +58,7 @@ func providerGenerators() map[string]func() terraform_utils.ProviderGenerator {
 		newKubernetesProvider,
 		newGitHubProvider,
 		newDataDogProvider,
+		newLogzioProvider,
 	} {
 		list[providerGen().GetName()] = providerGen
 	}

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jen20/awspolicyequivalence v1.0.0 // indirect
+	github.com/jonboydell/logzio_client v0.0.0-20190726085421-c93d6b149c1e
 	github.com/joyent/triton-go v0.0.0-20180628001255-830d2b111e62 // indirect
 	github.com/json-iterator/go v1.1.6 // indirect
 	github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1 // indirect
@@ -77,6 +78,7 @@ require (
 	github.com/sirupsen/logrus v1.2.0 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/stoewer/go-strcase v1.0.2 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/terraform-providers/terraform-provider-aws v1.48.0 // indirect
 	github.com/terraform-providers/terraform-provider-google v1.20.0 // indirect
 	github.com/terraform-providers/terraform-provider-kubernetes v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -266,6 +266,10 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jonboydell/logzio_client v0.0.0-20190719124443-5e42bfdf749f h1:kASfbngq48p4bXixKJGRrP4EhGKTUJ/ETLBVOYn6Jbw=
+github.com/jonboydell/logzio_client v0.0.0-20190719124443-5e42bfdf749f/go.mod h1:ZXJYF4M9/chuG+4fQDS9BN6CqXqokUjtQOjdMqzGC/Y=
+github.com/jonboydell/logzio_client v0.0.0-20190726085421-c93d6b149c1e h1:+fjlEMEatpz35dZ4rMa18HEXdsZ9ZOCkmcIAZJgilDM=
+github.com/jonboydell/logzio_client v0.0.0-20190726085421-c93d6b149c1e/go.mod h1:ZXJYF4M9/chuG+4fQDS9BN6CqXqokUjtQOjdMqzGC/Y=
 github.com/joyent/triton-go v0.0.0-20180313100802-d8f9c0314926/go.mod h1:U+RSyWxWd04xTqnuOQxnai7XGS2PrPY2cfGoDKtMHjA=
 github.com/joyent/triton-go v0.0.0-20180628001255-830d2b111e62 h1:JHCT6xuyPUrbbgAPE/3dqlvUKzRHMNuTBKKUb6OeR/k=
 github.com/joyent/triton-go v0.0.0-20180628001255-830d2b111e62/go.mod h1:U+RSyWxWd04xTqnuOQxnai7XGS2PrPY2cfGoDKtMHjA=
@@ -424,6 +428,7 @@ github.com/stoewer/go-strcase v1.0.2 h1:l3iQ2FPu8+36ars/7syO1dQAkjwMCb1IE3J+Th0o
 github.com/stoewer/go-strcase v1.0.2/go.mod h1:eLfe5bL3qbL7ep/KafHzthxejrOF5J3xmt03uL5tzek=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=

--- a/providers/logzio/alert_notification_endpoints.go
+++ b/providers/logzio/alert_notification_endpoints.go
@@ -1,0 +1,51 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logzio
+
+import (
+	"strconv"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+
+	"github.com/jonboydell/logzio_client/endpoints"
+)
+
+type AlertNotificationEndpointsGenerator struct {
+	LogzioService
+}
+
+// Generate Terraform Resources from Logzio API,
+func (g *AlertNotificationEndpointsGenerator) InitResources() error {
+	var client *endpoints.EndpointsClient
+	client, _ = endpoints.New(g.Args["token"].(string), g.Args["baseURL"].(string))
+
+	endpoints, err := client.ListEndpoints()
+	if err != nil {
+		return err
+	}
+	for _, endpoint := range endpoints {
+		g.Resources = append(g.Resources, terraform_utils.NewResource(
+			strconv.FormatInt(endpoint.Id, 10),
+			createSlug(endpoint.Title+"-"+string(endpoint.EndpointType)+"-"+strconv.FormatInt(endpoint.Id, 10)),
+			"logzio_endpoint",
+			"logzio",
+			map[string]string{},
+			[]string{},
+			map[string]string{},
+		))
+	}
+	g.PopulateIgnoreKeys()
+	return nil
+}

--- a/providers/logzio/alerts.go
+++ b/providers/logzio/alerts.go
@@ -1,0 +1,52 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logzio
+
+import (
+	"strconv"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+
+	"github.com/jonboydell/logzio_client/alerts"
+)
+
+type AlertsGenerator struct {
+	LogzioService
+}
+
+// Generate Terraform Resources from Logzio API,
+func (g *AlertsGenerator) InitResources() error {
+	var client *alerts.AlertsClient
+	client, _ = alerts.New(g.Args["token"].(string), g.Args["baseURL"].(string))
+
+	alerts, err := client.ListAlerts()
+	if err != nil {
+		return err
+	}
+	allowedEmptyValues := []string{"alert_notification_endpoints.#", "notification_emails.#"}
+	for _, alert := range alerts {
+		g.Resources = append(g.Resources, terraform_utils.NewResource(
+			strconv.FormatInt(alert.AlertId, 10),
+			createSlug(alert.Title+"-"+strconv.FormatInt(alert.AlertId, 10)),
+			"logzio_alert",
+			"logzio",
+			map[string]string{},
+			allowedEmptyValues,
+			map[string]string{},
+		))
+	}
+	g.PopulateIgnoreKeys()
+	return nil
+}

--- a/providers/logzio/logzio_provider.go
+++ b/providers/logzio/logzio_provider.go
@@ -1,0 +1,99 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logzio
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+
+	"github.com/pkg/errors"
+)
+
+type LogzioProvider struct {
+	terraform_utils.Provider
+	token   string
+	baseURL string
+}
+
+var (
+	disallowedChars = regexp.MustCompile(`[^A-Za-z0-9-]`)
+)
+
+const logzioProviderVersion = "~>v1.1.1"
+
+func (p LogzioProvider) GetResourceConnections() map[string]map[string][]string {
+	return map[string]map[string][]string{
+		"alerts": {"alert_notification_endpoints": []string{"alert_notification_endpoints", "id"}},
+	}
+}
+
+func (p LogzioProvider) GetProviderData(arg ...string) map[string]interface{} {
+	return map[string]interface{}{
+		"provider": map[string]interface{}{
+			"logzio": map[string]interface{}{
+				"version": logzioProviderVersion,
+			},
+		},
+	}
+}
+
+func (p *LogzioProvider) GetConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"token":   p.token,
+		"baseURL": p.baseURL,
+	}
+}
+
+// Init LogzioProvider with API token
+func (p *LogzioProvider) Init(args []string) error {
+	p.token = args[0]
+	p.baseURL = args[1]
+	return nil
+}
+
+func (p *LogzioProvider) GetName() string {
+	return "logzio"
+}
+
+func (p *LogzioProvider) InitService(serviceName string) error {
+	var isSupported bool
+	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
+	}
+	p.Service = p.GetSupportedService()[serviceName]
+	p.Service.SetName(serviceName)
+	p.Service.SetProviderName(p.GetName())
+	p.Service.SetArgs(map[string]interface{}{
+		"token":   p.token,
+		"baseURL": p.baseURL,
+	})
+	return nil
+}
+
+// GetSupportedService return map of support service for Logzio
+func (p *LogzioProvider) GetSupportedService() map[string]terraform_utils.ServiceGenerator {
+	return map[string]terraform_utils.ServiceGenerator{
+		"alerts":                       &AlertsGenerator{},
+		"alert_notification_endpoints": &AlertNotificationEndpointsGenerator{},
+	}
+}
+
+func createSlug(s string) string {
+	s = strings.ToLower(s)
+
+	return disallowedChars.ReplaceAllString(s, "-")
+}

--- a/providers/logzio/logzio_service.go
+++ b/providers/logzio/logzio_service.go
@@ -1,0 +1,21 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logzio
+
+import "github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+
+type LogzioService struct {
+	terraform_utils.Service
+}

--- a/terraform_utils/resource.go
+++ b/terraform_utils/resource.go
@@ -106,7 +106,7 @@ func (r *Resource) ConvertTFstate() {
 			continue
 		}
 
-		if !r.isAllowedEmptyValue(keyAttribute)  {
+		if !r.isAllowedEmptyValue(keyAttribute) {
 			delete(attributes, keyAttribute)
 		}
 	}

--- a/terraform_utils/utils.go
+++ b/terraform_utils/utils.go
@@ -102,13 +102,13 @@ func RefreshResourceWorker(input chan *Resource, wg *sync.WaitGroup, provider *p
 func IgnoreKeys(resourcesTypes []string, providerName string) map[string][]string {
 	p, err := provider_wrapper.NewProviderWrapper(providerName, map[string]interface{}{})
 	if err != nil {
-		log.Println("plugin error:", err)
+		log.Println("plugin error 1:", err)
 		return map[string][]string{}
 	}
 	defer p.Kill()
 	readOnlyAttributes, err := p.GetReadOnlyAttributes(resourcesTypes)
 	if err != nil {
-		log.Println("plugin error:", err)
+		log.Println("plugin error 2:", err)
 		return map[string][]string{}
 	}
 	return readOnlyAttributes

--- a/vendor/github.com/jonboydell/logzio_client/.gitignore
+++ b/vendor/github.com/jonboydell/logzio_client/.gitignore
@@ -1,0 +1,9 @@
+# idea
+.idea
+
+# golang
+coverage.out
+vendor
+
+# swagger server
+swagger

--- a/vendor/github.com/jonboydell/logzio_client/.travis.yml
+++ b/vendor/github.com/jonboydell/logzio_client/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+go:
+  - "1.12.7"
+env:
+  global:
+  - GO111MODULE=on
+before_install:
+  - go get golang.org/x/tools/cmd/cover
+  - go get github.com/mattn/goveralls
+script:
+  - go test -v -race ./... -covermode=atomic -coverprofile=coverage.out
+  - goveralls -coverprofile=coverage.out -service=travis-ci -repotoken=$COVERALLS_TOKEN

--- a/vendor/github.com/jonboydell/logzio_client/LICENSE
+++ b/vendor/github.com/jonboydell/logzio_client/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 jonboydell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/jonboydell/logzio_client/README.md
+++ b/vendor/github.com/jonboydell/logzio_client/README.md
@@ -1,0 +1,96 @@
+# Logz.io client library
+
+DEVELOP - [![Build Status](https://travis-ci.org/jonboydell/logzio_client.svg?branch=develop)](https://travis-ci.org/jonboydell/logzio_client) [![Coverage Status](https://coveralls.io/repos/github/jonboydell/logzio_client/badge.svg?branch=develop)](https://coveralls.io/github/jonboydell/logzio_client?branch=develop)
+
+MASTER - [![Build Status](https://travis-ci.org/jonboydell/logzio_client.svg?branch=master)](https://travis-ci.org/jonboydell/logzio_client)
+
+Client library for logz.io API, see below for supported endpoints.
+
+The primary purpose of this library is to act as the API interface for the logz.io Terraform provider.
+
+Logz.io have not written an especially consistent API. Sometimes, JSON will be presented back from an API call, sometimes not. Sometimes just a status code, sometimes a 200 status code, but with an error message in the body. I have attempted to shield the user of this library from those inconsistencies, but as they are laregely not documented, it's pretty diffcult to know if I've got them all.
+
+[Roadmap](#roadmap)
+
+##### Usage
+
+Note: the lastest version of the API (1.1) is not backwards compatible with previous versions, specifically the client entrypoint names have changed to prevent naming conflicts. Use `UsersClient` ([Users API](#users)) , `AlertsClient` ([Alerts API](#alerts)) and `EndpointsClient` ([Endpoints API](#endpoints)) rather than `Users`, `Alerts` and `Endpoints`.
+
+
+##### Alerts
+
+To create an alert where the type field = 'mytype' and the loglevel field = ERROR, see the logz.io docs for more info
+
+https://support.logz.io/hc/en-us/articles/209487329-How-do-I-create-an-Alert-
+
+```go
+client, _ := alerts.New(apiToken)
+client.CreateAlert(alerts.CreateAlertType{
+    Title:       "this is my alert",
+    Description: "this is my description",
+    QueryString: "loglevel:ERROR",
+    Filter:      "{\"bool\":{\"must\":[{\"match\":{\"type\":\"mytype\"}}],\"must_not\":[]}}",
+    Operation:   alerts.OperatorGreaterThan,
+    SeverityThresholdTiers: []alerts.SeverityThresholdType{
+        alerts.SeverityThresholdType{
+            alerts.SeverityHigh,
+            10,
+        },
+    },
+    SearchTimeFrameMinutes:       0,
+    NotificationEmails:           []interface{}{},
+    IsEnabled:                    true,
+    SuppressNotificationsMinutes: 0,
+    ValueAggregationType:         alerts.AggregationTypeCount,
+    ValueAggregationField:        nil,
+    GroupByAggregationFields:     []interface{}{"my_field"},
+    AlertNotificationEndpoints:   []interface{}{},
+})
+```
+
+|function|func name|
+|---|---|
+|create alert|`func (c *AlertsClient) CreateAlert(alert CreateAlertType) (*AlertType, error)`|
+|update alert|`func (c *AlertsClient) UpdateAlert(alertId int64, alert CreateAlertType) (*AlertType, error)`
+|delete alert|`func (c *AlertsClient) DeleteAlert(alertId int64) error`|
+|get alert (by id)|`func (c *AlertsClient) GetAlert(alertId int64) (*AlertType, error)`|
+|list alerts|`func (c *AlertsClient) ListAlerts() ([]AlertType, error)`|
+
+
+##### Users
+
+To create a new user, on a specific account or sub-account (you can get your account id from the logz.io console)
+
+```go
+client, _ := users.New(apiToken)
+user := client.User{
+    Username:  "createa@test.user",
+    Fullname:  "my username",
+    AccountId: 123456,
+    Roles:     []int32{users.UserTypeUser},
+}
+```
+
+|function|func name|
+|---|---|
+|create user|`func (c *UsersClient) CreateUser(user User) (*User, error)`|
+|update user|`func (c *UsersClient) UpdateUser(user User) (*User, error)`|
+|delete user|`func (c *UsersClient) DeleteUser(id int32) error`|
+|get user|`func (c *UsersClient) GetUser(id int32) (*User, error)`|
+|list users|`func (c *UsersClient) ListUsers() ([]User, error)`|
+|suspend user|`func (c *UsersClient) SuspendUser(userId int32) (bool, error)`|
+|unsuspend user|`func (c *UsersClient) UnSuspendUser(userId int32) (bool, error)`|
+
+##### Endpoints
+
+There's no 1-1 mapping between this library and the logz.io API functions, logz.io provide one API endpoint per *type* of notification endpoint being created.  I have abstracted this so that depending on how you create your `Endpoints` variable that you pass to `CreateEndpoint` the `CreateEndpoint` function will work out which API call to make.
+
+For more info, see: https://docs.logz.io/api/#tag/Manage-notification-endpoints
+
+#### Contributing
+
+1. Clone this repo locally
+2. As this package uses Go modules, make sure you are outside of `$GOPATH` or you have the `GO111MODULE=on` environment variable set. Then run `go get` to pull down the dependencies.
+
+##### Run tests
+`go test -v -race ./...`

--- a/vendor/github.com/jonboydell/logzio_client/alerts/client_alerts.go
+++ b/vendor/github.com/jonboydell/logzio_client/alerts/client_alerts.go
@@ -1,0 +1,175 @@
+package alerts
+
+import (
+	"fmt"
+
+	"github.com/jonboydell/logzio_client/client"
+)
+
+const (
+	alertsServiceEndpoint = "%s/v1/alerts"
+)
+
+const (
+	AggregationTypeUniqueCount string = "UNIQUE_COUNT"
+	AggregationTypeAvg         string = "AVG"
+	AggregationTypeMax         string = "MAX"
+	AggregationTypeNone        string = "NONE"
+	AggregationTypeSum         string = "SUM"
+	AggregationTypeCount       string = "COUNT"
+	AggregationTypeMin         string = "MIN"
+
+	OperatorGreaterThanOrEquals string = "GREATER_THAN_OR_EQUALS"
+	OperatorLessThanOrEquals    string = "LESS_THAN_OR_EQUALS"
+	OperatorGreaterThan         string = "GREATER_THAN"
+	OperatorLessThan            string = "LESS_THAN"
+	OperatorNotEquals           string = "NOT_EQUALS"
+	OperatorEquals              string = "EQUALS"
+
+	SeveritySevere string = "SEVERE"
+	SeverityHigh   string = "HIGH"
+	SeverityMedium string = "MEDIUM"
+	SeverityLow    string = "LOW"
+	SeverityInfo   string = "INFO"
+
+	fldAlertId                      string = "alertId"
+	fldAlertNotificationEndpoints   string = "alertNotificationEndpoints"
+	fldCreatedAt                    string = "createdAt"
+	fldCreatedBy                    string = "createdBy"
+	fldDescription                  string = "description"
+	fldFilter                       string = "filter"
+	fldGroupByAggregationFields     string = "groupByAggregationFields"
+	fldIsEnabled                    string = "isEnabled"
+	fldQueryString                  string = "query_string"
+	fldLastTriggeredAt              string = "lastTriggeredAt"
+	fldLastUpdated                  string = "lastUpdated"
+	fldNotificationEmails           string = "notificationEmails"
+	fldOperation                    string = "operation"
+	fldSearchTimeFrameMinutes       string = "searchTimeFrameMinutes"
+	fldSeverity                     string = "severity"
+	fldSeverityThresholdTiers       string = "severityThresholdTiers"
+	fldSuppressNotificationsMinutes string = "suppressNotificationsMinutes"
+	fldThreshold                    string = "threshold"
+	fldTitle                        string = "title"
+	fldValueAggregationField        string = "valueAggregationField"
+	fldValueAggregationType         string = "valueAggregationType"
+)
+
+type CreateAlertType struct {
+	AlertNotificationEndpoints   []interface{}
+	Description                  string
+	Filter                       string
+	GroupByAggregationFields     []interface{}
+	IsEnabled                    bool
+	NotificationEmails           []interface{}
+	Operation                    string
+	QueryString                  string
+	SearchTimeFrameMinutes       int
+	SeverityThresholdTiers       []SeverityThresholdType `json:"severityThresholdTiers"`
+	SuppressNotificationsMinutes int
+	Title                        string
+	ValueAggregationField        interface{}
+	ValueAggregationType         string
+}
+
+type AlertType struct {
+	AlertId                      int64
+	AlertNotificationEndpoints   []interface{}
+	CreatedAt                    string
+	CreatedBy                    string
+	Description                  string
+	Filter                       string
+	GroupByAggregationFields     []interface{}
+	IsEnabled                    bool
+	LastTriggeredAt              interface{}
+	LastUpdated                  string
+	NotificationEmails           []interface{}
+	Operation                    string
+	QueryString                  string `json:"query_string"`
+	SearchTimeFrameMinutes       int
+	Severity                     string
+	SeverityThresholdTiers       []SeverityThresholdType `json:"severityThresholdTiers"`
+	SuppressNotificationsMinutes int
+	Threshold                    int `json:"threshold"`
+	Title                        string
+	ValueAggregationField        interface{}
+	ValueAggregationType         string
+}
+
+type SeverityThresholdType struct {
+	Severity  string `json:"severity"`
+	Threshold int    `json:"threshold"`
+}
+
+func jsonAlertToAlert(jsonAlert map[string]interface{}) AlertType {
+	alert := AlertType{
+		AlertId:                    int64(jsonAlert[fldAlertId].(float64)),
+		AlertNotificationEndpoints: jsonAlert[fldAlertNotificationEndpoints].([]interface{}),
+		Description:                jsonAlert[fldDescription].(string),
+		Filter:                     jsonAlert[fldFilter].(string),
+		IsEnabled:                  jsonAlert[fldIsEnabled].(bool),
+		LastUpdated:                jsonAlert[fldLastUpdated].(string),
+		NotificationEmails:         jsonAlert[fldNotificationEmails].([]interface{}),
+		Operation:                  jsonAlert[fldOperation].(string),
+		QueryString:                jsonAlert[fldQueryString].(string),
+		Severity:                   jsonAlert[fldSeverity].(string),
+		SearchTimeFrameMinutes:     int(jsonAlert[fldSearchTimeFrameMinutes].(float64)),
+		SeverityThresholdTiers:     []SeverityThresholdType{},
+		Threshold:                  int(jsonAlert[fldThreshold].(float64)),
+		Title:                      jsonAlert[fldTitle].(string),
+		ValueAggregationType:       jsonAlert[fldValueAggregationType].(string),
+	}
+
+	if jsonAlert[fldGroupByAggregationFields] != nil {
+		alert.GroupByAggregationFields = jsonAlert[fldGroupByAggregationFields].([]interface{})
+	}
+
+	if jsonAlert[fldCreatedAt] != nil {
+		alert.CreatedAt = jsonAlert[fldCreatedAt].(string)
+	}
+
+	if jsonAlert[fldCreatedBy] != nil {
+		alert.CreatedBy = jsonAlert[fldCreatedBy].(string)
+	}
+
+	if jsonAlert[fldLastTriggeredAt] != nil {
+		alert.LastTriggeredAt = jsonAlert[fldLastTriggeredAt].(interface{})
+	}
+
+	tiers := jsonAlert[fldSeverityThresholdTiers].([]interface{})
+	for x := 0; x < len(tiers); x++ {
+		tier := tiers[x].(map[string]interface{})
+		threshold := SeverityThresholdType{
+			Threshold: int(tier[fldThreshold].(float64)),
+			Severity:  tier[fldSeverity].(string),
+		}
+		alert.SeverityThresholdTiers = append(alert.SeverityThresholdTiers, threshold)
+	}
+
+	if jsonAlert[fldSuppressNotificationsMinutes] != nil {
+		alert.SuppressNotificationsMinutes = int(jsonAlert[fldSuppressNotificationsMinutes].(float64))
+	}
+
+	if jsonAlert[fldValueAggregationField] != nil {
+		alert.ValueAggregationField = jsonAlert[fldValueAggregationField].(interface{})
+	}
+
+	return alert
+}
+
+type AlertsClient struct {
+	*client.Client
+}
+
+func New(apiToken, baseUrl string) (*AlertsClient, error) {
+	if len(apiToken) == 0 {
+		return nil, fmt.Errorf("API token not defined")
+	}
+	if len(baseUrl) == 0 {
+		return nil, fmt.Errorf("Base URL not defined")
+	}
+	c := &AlertsClient{
+		Client: client.New(apiToken, baseUrl),
+	}
+	return c, nil
+}

--- a/vendor/github.com/jonboydell/logzio_client/alerts/client_alerts_create.go
+++ b/vendor/github.com/jonboydell/logzio_client/alerts/client_alerts_create.go
@@ -1,0 +1,138 @@
+package alerts
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/jonboydell/logzio_client"
+	"github.com/jonboydell/logzio_client/client"
+)
+
+const createAlertServiceUrl string = alertsServiceEndpoint
+const createAlertServiceMethod string = http.MethodPost
+const createAlertMethodSuccess int = 200
+
+type FieldError struct {
+	Field   string
+	Message string
+}
+
+func (e FieldError) Error() string {
+	return fmt.Sprintf("%v: %v", e.Field, e.Message)
+}
+
+func validateCreateAlertRequest(alert CreateAlertType) error {
+
+	if len(alert.Title) == 0 {
+		return fmt.Errorf("title must be set")
+	}
+
+	if len(alert.QueryString) == 0 {
+		return fmt.Errorf("query string must be set")
+	}
+
+	if alert.NotificationEmails == nil {
+		return fmt.Errorf("notificationEmails must not be nil")
+	}
+
+	validAggregationTypes := []string{AggregationTypeUniqueCount, AggregationTypeAvg, AggregationTypeMax, AggregationTypeNone, AggregationTypeSum, AggregationTypeCount, AggregationTypeMin}
+	if !logzio_client.Contains(validAggregationTypes, alert.ValueAggregationType) {
+		return fmt.Errorf("valueAggregationType must be one of %s", validAggregationTypes)
+	}
+
+	validOperations := []string{OperatorGreaterThanOrEquals, OperatorLessThanOrEquals, OperatorGreaterThan, OperatorLessThan, OperatorNotEquals, OperatorEquals}
+	if !logzio_client.Contains(validOperations, alert.Operation) {
+		return fmt.Errorf("operation must be one of %s", validOperations)
+	}
+
+	validSeverities := []string{
+		SeveritySevere,
+		SeverityHigh,
+		SeverityMedium,
+		SeverityLow,
+		SeverityInfo,
+	}
+	for _, tier := range alert.SeverityThresholdTiers {
+		if !logzio_client.Contains(validSeverities, tier.Severity) {
+			return fmt.Errorf("severity must be one of %s", validSeverities)
+		}
+	}
+
+	if AggregationTypeNone == alert.ValueAggregationType && (alert.ValueAggregationField != nil || alert.GroupByAggregationFields != nil) {
+		message := fmt.Sprintf("if ValueAggregaionType is %s then ValueAggregationField and GroupByAggregationFields must be nil", AggregationTypeNone)
+		return FieldError{"valueAggregationTypeComposite", message}
+	}
+
+	return nil
+}
+
+func buildCreateAlertRequest(alert CreateAlertType) map[string]interface{} {
+	var createAlert = map[string]interface{}{}
+	createAlert[fldAlertNotificationEndpoints] = alert.AlertNotificationEndpoints
+	createAlert[fldDescription] = alert.Description
+	if len(alert.Filter) > 0 {
+		createAlert[fldFilter] = alert.Filter
+	}
+	createAlert[fldGroupByAggregationFields] = alert.GroupByAggregationFields
+	createAlert[fldIsEnabled] = alert.IsEnabled
+	createAlert[fldQueryString] = alert.QueryString
+	createAlert[fldNotificationEmails] = alert.NotificationEmails
+	createAlert[fldOperation] = alert.Operation
+	createAlert[fldSearchTimeFrameMinutes] = alert.SearchTimeFrameMinutes
+	createAlert[fldSeverityThresholdTiers] = alert.SeverityThresholdTiers
+	createAlert[fldSuppressNotificationsMinutes] = alert.SuppressNotificationsMinutes
+	createAlert[fldTitle] = alert.Title
+	createAlert[fldValueAggregationField] = alert.ValueAggregationField
+	createAlert[fldValueAggregationType] = alert.ValueAggregationType
+	return createAlert
+}
+
+func (c *AlertsClient) buildCreateApiRequest(apiToken string, jsonObject map[string]interface{}) (*http.Request, error) {
+	jsonBytes, err := json.Marshal(jsonObject)
+	if err != nil {
+		return nil, err
+	}
+
+	baseUrl := c.BaseUrl
+	req, err := http.NewRequest(createAlertServiceMethod, fmt.Sprintf(createAlertServiceUrl, baseUrl), bytes.NewBuffer(jsonBytes))
+	logzio_client.AddHttpHeaders(apiToken, req)
+
+	return req, err
+}
+
+// Create an alert, return the created alert if successful, an error otherwise
+func (c *AlertsClient) CreateAlert(alert CreateAlertType) (*AlertType, error) {
+	err := validateCreateAlertRequest(alert)
+	if err != nil {
+		return nil, err
+	}
+
+	createAlert := buildCreateAlertRequest(alert)
+	req, _ := c.buildCreateApiRequest(c.ApiToken, createAlert)
+
+	httpClient := client.GetHttpClient(req)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	jsonBytes, _ := ioutil.ReadAll(resp.Body)
+	if !logzio_client.CheckValidStatus(resp, []int{createAlertMethodSuccess}) {
+		return nil, fmt.Errorf("API call %s failed with status code %d, data: %s", "CreateAlert", resp.StatusCode, jsonBytes)
+	}
+
+	var jsonResponse map[string]interface{}
+	err = json.Unmarshal(jsonBytes, &jsonResponse)
+
+	retVal := jsonAlertToAlert(jsonResponse)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &retVal, nil
+}

--- a/vendor/github.com/jonboydell/logzio_client/alerts/client_alerts_delete.go
+++ b/vendor/github.com/jonboydell/logzio_client/alerts/client_alerts_delete.go
@@ -1,0 +1,46 @@
+package alerts
+
+import (
+	"fmt"
+	"github.com/jonboydell/logzio_client"
+	"github.com/jonboydell/logzio_client/client"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+const deleteAlertServiceUrl string = alertsServiceEndpoint + "/%d"
+const deleteAlertServiceMethod string = http.MethodDelete
+const deleteAlertMethodSuccess int = 200
+
+func (c *AlertsClient) buildDeleteApiRequest(apiToken string, alertId int64) (*http.Request, error) {
+	baseUrl := c.BaseUrl
+	req, err := http.NewRequest(deleteAlertServiceMethod, fmt.Sprintf(deleteAlertServiceUrl, baseUrl, alertId), nil)
+	logzio_client.AddHttpHeaders(apiToken, req)
+
+	return req, err
+}
+
+// Delete an alert, specified by it's unique id, returns an error if a problem is encountered
+func (c *AlertsClient) DeleteAlert(alertId int64) error {
+	req, _ := c.buildDeleteApiRequest(c.ApiToken, alertId)
+
+	httpClient := client.GetHttpClient(req)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	jsonBytes, _ := ioutil.ReadAll(resp.Body)
+
+	if !logzio_client.CheckValidStatus(resp, []int{deleteAlertMethodSuccess}) {
+		return fmt.Errorf("API call %s failed with status code %d, data: %s", "DeleteAlert", resp.StatusCode, jsonBytes)
+	}
+
+	str := fmt.Sprintf("%s", jsonBytes)
+	if strings.Contains(str, "no alert id") {
+		return fmt.Errorf("API call %s failed with missing alert %d, data: %s", "DeleteAlert", alertId, jsonBytes)
+	}
+
+	return nil
+}

--- a/vendor/github.com/jonboydell/logzio_client/alerts/client_alerts_get.go
+++ b/vendor/github.com/jonboydell/logzio_client/alerts/client_alerts_get.go
@@ -1,0 +1,56 @@
+package alerts
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/jonboydell/logzio_client"
+	"github.com/jonboydell/logzio_client/client"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+const getAlertServiceUrl string = alertsServiceEndpoint + "/%d"
+const getAlertServiceMethod string = http.MethodGet
+const getAlertMethodSuccess int = 200
+
+func (c *AlertsClient) buildGetApiRequest(apiToken string, alertId int64) (*http.Request, error) {
+	baseUrl := c.BaseUrl
+	req, err := http.NewRequest(getAlertServiceMethod, fmt.Sprintf(getAlertServiceUrl, baseUrl, alertId), nil)
+	logzio_client.AddHttpHeaders(apiToken, req)
+
+	return req, err
+}
+
+// Returns an alert given it's unique identifier, an error otherwise
+func (c *AlertsClient) GetAlert(alertId int64) (*AlertType, error) {
+	req, _ := c.buildGetApiRequest(c.ApiToken, alertId)
+
+	httpClient := client.GetHttpClient(req)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	jsonBytes, _ := ioutil.ReadAll(resp.Body)
+
+	if !logzio_client.CheckValidStatus(resp, []int{getAlertMethodSuccess}) {
+		return nil, fmt.Errorf("API call %s failed with status code %d, data: %s", "GetAlert", resp.StatusCode, jsonBytes)
+	}
+
+	str := fmt.Sprintf("%s", jsonBytes)
+	if strings.Contains(str, "no alert id") {
+		return nil, fmt.Errorf("API call %s failed with missing alert %d, data: %s", "GetAlert", alertId, str)
+	}
+
+	var jsonAlert map[string]interface{}
+	err = json.Unmarshal([]byte(jsonBytes), &jsonAlert)
+	if err != nil {
+		return nil, err
+	}
+
+	alert := jsonAlertToAlert(jsonAlert)
+
+	return &alert, nil
+}

--- a/vendor/github.com/jonboydell/logzio_client/alerts/client_alerts_list.go
+++ b/vendor/github.com/jonboydell/logzio_client/alerts/client_alerts_list.go
@@ -1,0 +1,54 @@
+package alerts
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/jonboydell/logzio_client"
+	"github.com/jonboydell/logzio_client/client"
+	"io/ioutil"
+	"net/http"
+)
+
+const listAlertServiceUrl string = alertsServiceEndpoint
+const listAlertServiceMethod string = http.MethodGet
+const listAlertMethodSuccess int = 200
+
+func (c *AlertsClient) buildListApiRequest(apiToken string) (*http.Request, error) {
+	baseUrl := c.BaseUrl
+	req, err := http.NewRequest(listAlertServiceMethod, fmt.Sprintf(listAlertServiceUrl, baseUrl), nil)
+	logzio_client.AddHttpHeaders(apiToken, req)
+
+	return req, err
+}
+
+// Returns all the alerts in an array associated with the account identified by the supplied API token, returns an error if
+// any problem occurs during the API call
+func (c *AlertsClient) ListAlerts() ([]AlertType, error) {
+	req, _ := c.buildListApiRequest(c.ApiToken)
+
+	httpClient := client.GetHttpClient(req)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	jsonBytes, _ := ioutil.ReadAll(resp.Body)
+
+	if !logzio_client.CheckValidStatus(resp, []int{listAlertMethodSuccess}) {
+		return nil, fmt.Errorf("API call %s failed with status code %d, data: %s", "ListAlerts", resp.StatusCode, jsonBytes)
+	}
+
+	var arr []AlertType
+	var jsonResponse []interface{}
+	err = json.Unmarshal([]byte(jsonBytes), &jsonResponse)
+
+	for x := 0; x < len(jsonResponse); x++ {
+		var jsonAlert map[string]interface{}
+		jsonAlert = jsonResponse[x].(map[string]interface{})
+		alert := jsonAlertToAlert(jsonAlert)
+		arr = append(arr, alert)
+	}
+
+	return arr, nil
+}

--- a/vendor/github.com/jonboydell/logzio_client/alerts/client_alerts_update.go
+++ b/vendor/github.com/jonboydell/logzio_client/alerts/client_alerts_update.go
@@ -1,0 +1,89 @@
+package alerts
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/jonboydell/logzio_client"
+	"github.com/jonboydell/logzio_client/client"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+const updateAlertServiceUrl string = alertsServiceEndpoint + "/%d"
+const updateAlertServiceMethod string = http.MethodPut
+const updateAlertMethodSuccess int = 200
+
+func buildUpdateAlertRequest(alert CreateAlertType) map[string]interface{} {
+	var createAlert = map[string]interface{}{}
+	createAlert[fldAlertNotificationEndpoints] = alert.AlertNotificationEndpoints
+	createAlert[fldDescription] = alert.Description
+	if len(alert.Filter) > 0 {
+		createAlert[fldFilter] = alert.Filter
+	}
+	createAlert[fldGroupByAggregationFields] = alert.GroupByAggregationFields
+	createAlert[fldIsEnabled] = alert.IsEnabled
+	createAlert[fldQueryString] = alert.QueryString
+	createAlert[fldNotificationEmails] = alert.NotificationEmails
+	createAlert[fldOperation] = alert.Operation
+	createAlert[fldSearchTimeFrameMinutes] = alert.SearchTimeFrameMinutes
+	createAlert[fldSeverityThresholdTiers] = alert.SeverityThresholdTiers
+	createAlert[fldSuppressNotificationsMinutes] = alert.SuppressNotificationsMinutes
+	createAlert[fldTitle] = alert.Title
+	createAlert[fldValueAggregationField] = alert.ValueAggregationField
+	createAlert[fldValueAggregationType] = alert.ValueAggregationType
+
+	return createAlert
+}
+
+func (c *AlertsClient) buildUpdateApiRequest(apiToken string, alertId int64, jsonObject map[string]interface{}) (*http.Request, error) {
+	jsonBytes, err := json.Marshal(jsonObject)
+	if err != nil {
+		return nil, err
+	}
+
+	baseUrl := c.BaseUrl
+	req, err := http.NewRequest(updateAlertServiceMethod, fmt.Sprintf(updateAlertServiceUrl, baseUrl, alertId), bytes.NewBuffer(jsonBytes))
+	logzio_client.AddHttpHeaders(apiToken, req)
+
+	return req, err
+}
+
+// Updates an existing alert, based on the supplied alert identifier, using the parameters of the specified alert
+// Returns the updated alert if successful, an error otherwise
+func (c *AlertsClient) UpdateAlert(alertId int64, alert CreateAlertType) (*AlertType, error) {
+	err := validateCreateAlertRequest(alert)
+	if err != nil {
+		return nil, err
+	}
+
+	createAlert := buildUpdateAlertRequest(alert)
+	req, err := c.buildUpdateApiRequest(c.ApiToken, alertId, createAlert)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := client.GetHttpClient(req)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	jsonBytes, _ := ioutil.ReadAll(resp.Body)
+
+	if !logzio_client.CheckValidStatus(resp, []int{updateAlertMethodSuccess}) {
+		return nil, fmt.Errorf("API call %s failed with status code %d, data: %s", "UpdateAlert", resp.StatusCode, jsonBytes)
+	}
+
+	str := fmt.Sprintf("%s", jsonBytes)
+	if strings.Contains(str, "no alert id") {
+		return nil, fmt.Errorf("API call %s failed with missing alert %d, data: %s", "UpdateAlert", alertId, jsonBytes)
+	}
+
+	var target AlertType
+	json.Unmarshal(jsonBytes, &target)
+
+	return &target, nil
+}

--- a/vendor/github.com/jonboydell/logzio_client/client/client.go
+++ b/vendor/github.com/jonboydell/logzio_client/client/client.go
@@ -1,0 +1,50 @@
+package client
+
+import (
+	"crypto/tls"
+	"log"
+	"net/http"
+)
+
+
+const (
+	ERROR_CODE    = "errorCode"
+	ERROR_MESSAGE = "errorMessage"
+)
+
+type Client struct {
+	ApiToken string
+	BaseUrl  string
+	log      log.Logger
+}
+
+// Entry point into the logz.io client
+func New(apiToken, baseUrl string) *Client {
+	var c Client
+	c.ApiToken = apiToken
+	c.BaseUrl = baseUrl
+	return &c
+}
+
+func GetHttpClient(req *http.Request) *http.Client {
+	url, err := http.ProxyFromEnvironment(req)
+	if url != nil && err == nil {
+		tr := &http.Transport{
+			Proxy:           http.ProxyURL(url),
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		return &http.Client{Transport: tr}
+	} else {
+		return &http.Client{}
+	}
+}
+
+func IsErrorResponse(response map[string]interface{}) (bool, string) {
+	if _, ok := response[ERROR_CODE]; ok {
+		return true, response[ERROR_CODE].(string)
+	}
+	if _, ok := response[ERROR_MESSAGE]; ok {
+		return true, response[ERROR_MESSAGE].(string)
+	}
+	return false, ""
+}

--- a/vendor/github.com/jonboydell/logzio_client/endpoints/client_endpoints.go
+++ b/vendor/github.com/jonboydell/logzio_client/endpoints/client_endpoints.go
@@ -1,0 +1,175 @@
+package endpoints
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/jonboydell/logzio_client"
+	"github.com/jonboydell/logzio_client/client"
+)
+
+const (
+	endpointServiceEndpoint = "%s/v1/endpoints"
+)
+
+const (
+	fldEndpointId            string = "id"
+	fldEndpointType          string = "endpointType"
+	fldEndpointTitle         string = "title"
+	fldEndpointDescription   string = "description"
+	fldEndpointUrl           string = "url"
+	fldEndpointMethod        string = "method"
+	fldEndpointHeaders       string = "headers"
+	fldEndpointBodyTemplate  string = "bodyTemplate"
+	fldEndpointServiceKey    string = "serviceKey"
+	fldEndpointApiToken      string = "apiToken"
+	fldEndpointAppKey        string = "appKey"
+	fldEndpointApiKey        string = "apiKey"
+	fldEndpointRoutingKey    string = "routingKey"
+	fldEndpointMessageType   string = "messageType"
+	fldEndpointServiceApiKey string = "serviceApiKey"
+)
+
+const (
+	EndpointTypeSlack     endpointType = "Slack"
+	EndpointTypeCustom    endpointType = "Custom"
+	EndpointTypePagerDuty endpointType = "PagerDuty"
+	EndpointTypeBigPanda  endpointType = "BigPanda"
+	EndpointTypeDataDog   endpointType = "Datadog"
+	EndpointTypeVictorOps endpointType = "VictorOps"
+)
+
+type (
+	endpointType string
+)
+
+type Endpoint struct {
+	Id            int64             // all
+	EndpointType  endpointType      // all
+	Title         string            // all
+	Description   string            // all
+	Url           string            // custom & slack
+	Method        string            // custom
+	Headers       map[string]string // custom
+	BodyTemplate  interface{}       // custom
+	Message       string            // n.b. this is a hack to determine if there was an error (despite a 200 being returned)
+	ServiceKey    string            // pager-duty
+	ApiToken      string            // big-panda
+	AppKey        string            // big-panda
+	ApiKey        string            // data-dog
+	RoutingKey    string            // victorops
+	MessageType   string            // victorops
+	ServiceApiKey string            // victorops
+}
+
+func jsonEndpointToEndpoint(jsonEndpoint map[string]interface{}) Endpoint {
+	t := jsonEndpoint[fldEndpointType].(string)
+
+	endpoint := Endpoint{
+		Id:           int64(jsonEndpoint[fldEndpointId].(float64)),
+		EndpointType: endpointType(t),
+		Title:        jsonEndpoint[fldEndpointTitle].(string),
+	}
+
+	if jsonEndpoint[fldEndpointDescription] != nil {
+		endpoint.Description = jsonEndpoint[fldEndpointDescription].(string)
+	}
+
+	switch endpoint.EndpointType {
+	case EndpointTypeSlack:
+		endpoint.Url = jsonEndpoint[fldEndpointUrl].(string)
+	case EndpointTypeCustom:
+		endpoint.Url = jsonEndpoint[fldEndpointUrl].(string)
+		endpoint.BodyTemplate = jsonEndpoint[fldEndpointBodyTemplate]
+		headerMap := make(map[string]string)
+		headerString := jsonEndpoint[fldEndpointHeaders].(string)
+		headers := strings.Split(headerString, ",")
+		for _, header := range headers {
+			kv := strings.Split(header, "=")
+			headerMap[kv[0]] = kv[1]
+		}
+		endpoint.Headers = headerMap
+		endpoint.Method = jsonEndpoint[fldEndpointMethod].(string)
+	case EndpointTypePagerDuty:
+		endpoint.ServiceKey = jsonEndpoint[fldEndpointServiceKey].(string)
+	case EndpointTypeBigPanda:
+		endpoint.ApiToken = jsonEndpoint[fldEndpointApiToken].(string)
+		endpoint.AppKey = jsonEndpoint[fldEndpointAppKey].(string)
+	case EndpointTypeDataDog:
+		endpoint.ApiKey = jsonEndpoint[fldEndpointApiKey].(string)
+	case EndpointTypeVictorOps:
+		endpoint.RoutingKey = jsonEndpoint[fldEndpointRoutingKey].(string)
+		endpoint.MessageType = jsonEndpoint[fldEndpointMessageType].(string)
+		endpoint.ServiceApiKey = jsonEndpoint[fldEndpointServiceApiKey].(string)
+	default:
+		panic(fmt.Sprintf("unsupported endpoint type %s", endpoint.EndpointType))
+	}
+
+	return endpoint
+}
+
+type EndpointsClient struct {
+	*client.Client
+}
+
+func New(apiToken, baseUrl string) (*EndpointsClient, error) {
+	if len(apiToken) == 0 {
+		return nil, fmt.Errorf("API token not defined")
+	}
+	if len(baseUrl) == 0 {
+		return nil, fmt.Errorf("Base URL not defined")
+	}
+	c := &EndpointsClient{
+		Client: client.New(apiToken, baseUrl),
+	}
+	return c, nil
+}
+
+type endpointValidator = func(e Endpoint) bool
+type endpointBuilder = func(a string, t endpointType, e Endpoint) (*http.Request, error)
+type endpointChecker = func(b []byte) error
+
+func (c *EndpointsClient) makeEndpointRequest(endpoint interface{}, validator endpointValidator, builder endpointBuilder, checker endpointChecker) ([]byte, error, bool) {
+	e := endpoint.(Endpoint)
+	if !validator(e) {
+		return nil, errors.New("the passed in endpoint is not valid"), false
+	}
+	req, _ := builder(c.ApiToken, e.EndpointType, e)
+	httpClient := client.GetHttpClient(req)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err, false
+	}
+	defer resp.Body.Close()
+	jsonBytes, _ := ioutil.ReadAll(resp.Body)
+	if !logzio_client.CheckValidStatus(resp, []int{http.StatusOK}) {
+		return nil, fmt.Errorf(errorCreateEndpointApiCallFailed, resp.StatusCode, jsonBytes), false
+	}
+	err = checker(jsonBytes)
+	if err != nil {
+		return nil, err, false
+	}
+	return jsonBytes, nil, true
+}
+
+func (c *EndpointsClient) getURLByType(t endpointType) string {
+	switch t {
+	case EndpointTypeSlack:
+		return "slack"
+	case EndpointTypeCustom:
+		return "custom"
+	case EndpointTypePagerDuty:
+		return "pager-duty"
+	case EndpointTypeBigPanda:
+		return "big-panda"
+	case EndpointTypeDataDog:
+		return "data-dog"
+	case EndpointTypeVictorOps:
+		return "victorops"
+	default:
+		panic(fmt.Sprintf("unsupported endpoint type %s", t))
+	}
+}

--- a/vendor/github.com/jonboydell/logzio_client/endpoints/client_endpoints_create.go
+++ b/vendor/github.com/jonboydell/logzio_client/endpoints/client_endpoints_create.go
@@ -1,0 +1,113 @@
+package endpoints
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/jonboydell/logzio_client"
+)
+
+const (
+	createEndpointServiceUrl    string = endpointServiceEndpoint + "/%s"
+	createEndpointServiceMethod string = http.MethodPost
+)
+
+const (
+	errorCreateEndpointApiCallFailed = "API call CreateEndpoint failed with status code %d, data: %s"
+)
+
+func buildCreateEndpointRequest(endpoint Endpoint) map[string]interface{} {
+	var createEndpoint = map[string]interface{}{}
+
+	createEndpoint[fldEndpointTitle] = endpoint.Title
+	createEndpoint[fldEndpointDescription] = endpoint.Description
+
+	if endpoint.EndpointType == EndpointTypeSlack {
+		createEndpoint[fldEndpointUrl] = endpoint.Url
+	}
+
+	if endpoint.EndpointType == EndpointTypeCustom {
+		createEndpoint[fldEndpointUrl] = endpoint.Url
+		createEndpoint[fldEndpointMethod] = endpoint.Method
+		headers := endpoint.Headers
+		headerStrings := []string{}
+		for k, v := range headers {
+			headerStrings = append(headerStrings, fmt.Sprintf("%s=%s", k, v))
+		}
+		headerString := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(headerStrings)), ","), "[]")
+		createEndpoint[fldEndpointHeaders] = headerString
+		createEndpoint[fldEndpointBodyTemplate] = endpoint.BodyTemplate
+	}
+
+	if endpoint.EndpointType == EndpointTypePagerDuty {
+		createEndpoint[fldEndpointServiceKey] = endpoint.ServiceKey
+	}
+
+	if endpoint.EndpointType == EndpointTypeBigPanda {
+		createEndpoint[fldEndpointApiToken] = endpoint.ApiToken
+		createEndpoint[fldEndpointAppKey] = endpoint.AppKey
+	}
+
+	if endpoint.EndpointType == EndpointTypeDataDog {
+		createEndpoint[fldEndpointApiKey] = endpoint.ApiKey
+	}
+
+	if endpoint.EndpointType == EndpointTypeVictorOps {
+		createEndpoint[fldEndpointRoutingKey] = endpoint.RoutingKey
+		createEndpoint[fldEndpointMessageType] = endpoint.MessageType
+		createEndpoint[fldEndpointServiceApiKey] = endpoint.ServiceApiKey
+	}
+
+	return createEndpoint
+}
+
+func (c *EndpointsClient) buildCreateEndpointApiRequest(apiToken string, endpointType endpointType, endpoint Endpoint) (*http.Request, error) {
+	createEndpoint := buildCreateEndpointRequest(endpoint)
+
+	jsonBytes, err := json.Marshal(createEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	baseUrl := c.BaseUrl
+	url := fmt.Sprintf(createEndpointServiceUrl, baseUrl, c.getURLByType(endpointType))
+	req, err := http.NewRequest(createEndpointServiceMethod, url, bytes.NewBuffer(jsonBytes))
+	logzio_client.AddHttpHeaders(apiToken, req)
+
+	return req, err
+}
+
+// Creates an endpoint, given the endpoint definition and the service to create the endpoint against
+// Returns the endpoint object if successful (hopefully with an ID) and a non-nil error if not
+func (c *EndpointsClient) CreateEndpoint(endpoint Endpoint) (*Endpoint, error) {
+	if jsonBytes, err, ok := c.makeEndpointRequest(endpoint, ValidateEndpointRequest, c.buildCreateEndpointApiRequest, func(b []byte) error {
+		var data map[string]interface{}
+		json.Unmarshal(b, &data)
+
+		if val, ok := data["errorCode"]; ok {
+			return fmt.Errorf("%v", val)
+		}
+
+		if val, ok := data["message"]; ok {
+			return fmt.Errorf("%v", val)
+		}
+
+		if strings.Contains(fmt.Sprintf("%s", b), errorCreateEndpointApiCallFailed) {
+			return fmt.Errorf(errorCreateEndpointApiCallFailed, 200, errorCreateEndpointApiCallFailed)
+		}
+		return nil
+	}); !ok {
+		return nil, err
+	} else {
+		var target Endpoint
+		err = json.Unmarshal(jsonBytes, &target)
+		if err != nil {
+			return nil, err
+		}
+
+		return &target, nil
+	}
+}

--- a/vendor/github.com/jonboydell/logzio_client/endpoints/client_endpoints_delete.go
+++ b/vendor/github.com/jonboydell/logzio_client/endpoints/client_endpoints_delete.go
@@ -1,0 +1,46 @@
+package endpoints
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/jonboydell/logzio_client"
+)
+
+const (
+	deleteEndpointServiceUrl    string = endpointServiceEndpoint + "/%d"
+	deleteEndpointServiceMethod string = http.MethodDelete
+	deleteEndpointMethodSuccess int    = 200
+)
+
+const (
+	errorDeleteEndpointDoesntExist = "API call DeleteEndpoint failed as endpoint with id:%d doesn't exist, data:%s"
+)
+
+func validateDeleteEndpoint(endpoint Endpoint) bool {
+	return true
+}
+
+func (c *EndpointsClient) buildDeleteEndpointApiRequest(apiToken string, service endpointType, endpoint Endpoint) (*http.Request, error) {
+	baseUrl := c.BaseUrl
+	req, err := http.NewRequest(deleteEndpointServiceMethod, fmt.Sprintf(deleteEndpointServiceUrl, baseUrl, endpoint.Id), nil)
+	logzio_client.AddHttpHeaders(apiToken, req)
+	return req, err
+}
+
+// Deletes an endpoint with the given id, returns a non nil error otherwise
+func (c *EndpointsClient) DeleteEndpoint(endpointId int64) error {
+	if _, err, ok := c.makeEndpointRequest(Endpoint{Id: endpointId}, validateDeleteEndpoint, c.buildDeleteEndpointApiRequest, func(body []byte) error {
+		if strings.Contains(fmt.Sprintf("%s", body), "endpoints/FORBIDDEN_OPERATION") {
+			return fmt.Errorf(errorDeleteEndpointDoesntExist, endpointId, body)
+		}
+		if strings.Contains(fmt.Sprintf("%s", body), "endpoints/UNKNOWN_ENDPOINT") {
+			return fmt.Errorf(errorDeleteEndpointDoesntExist, endpointId, body)
+		}
+		return nil
+	}); !ok {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/jonboydell/logzio_client/endpoints/client_endpoints_get.go
+++ b/vendor/github.com/jonboydell/logzio_client/endpoints/client_endpoints_get.go
@@ -1,0 +1,79 @@
+package endpoints
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/jonboydell/logzio_client"
+	"github.com/jonboydell/logzio_client/client"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+const getEndpointsServiceUrl string = endpointServiceEndpoint + "/%d"
+const getEndpointsServiceMethod string = http.MethodGet
+const getEndpointsMethodSuccess int = 200
+
+const apiGetEndpointNoEndpoint = "The endpoint doesn't exist"
+
+const errorGetEndpointApiCallFailed = "API call GetEndpoint failed with status code:%d, data:%s"
+const errorGetEndpointDoesntExist = "API call GetEndpoint failed as endpoint with id:%d doesn't exist, data:%s"
+
+func (c *EndpointsClient) buildGetEnpointApiRequest(apiToken string, notificationId int64) (*http.Request, error) {
+	baseUrl := c.BaseUrl
+	req, err := http.NewRequest(getEndpointsServiceMethod, fmt.Sprintf(getEndpointsServiceUrl, baseUrl, notificationId), nil)
+	logzio_client.AddHttpHeaders(apiToken, req)
+
+	return req, err
+}
+
+// Returns an endpoint, given it's name.  Returns nil (and an error) if an endpoint with the specified name can't be found
+func (c *EndpointsClient) GetEndpointByName(endpointName string) (*Endpoint, error) {
+	list, err := c.ListEndpoints()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, endpoint := range list {
+		if endpoint.Title == endpointName {
+			return &endpoint, nil
+		}
+	}
+
+	return nil, err
+}
+
+// Returns an endpoint, given it's identity.  Returns nul (and an error) if an endpoint with the specified id can't be found
+func (c *EndpointsClient) GetEndpoint(endpointId int64) (*Endpoint, error) {
+	req, _ := c.buildGetEnpointApiRequest(c.ApiToken, endpointId)
+
+	httpClient := client.GetHttpClient(req)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// @todo: this isn't the idiomatic way to read a response body
+	jsonBytes, _ := ioutil.ReadAll(resp.Body)
+
+	if !logzio_client.CheckValidStatus(resp, []int{getEndpointsMethodSuccess}) {
+		return nil, fmt.Errorf(errorGetEndpointApiCallFailed, resp.StatusCode, jsonBytes)
+	}
+
+	// sometimes logz.io returns a string rather than a json object (and a 200 status code), even though the call has failed
+	// @todo: can this be refactored?
+	str := fmt.Sprintf("%s", jsonBytes)
+	if strings.Contains(str, apiGetEndpointNoEndpoint) {
+		return nil, fmt.Errorf(errorGetEndpointDoesntExist, endpointId, str)
+	}
+
+	var jsonEndpoint map[string]interface{}
+	err = json.Unmarshal([]byte(jsonBytes), &jsonEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := jsonEndpointToEndpoint(jsonEndpoint)
+
+	return &endpoint, nil
+}

--- a/vendor/github.com/jonboydell/logzio_client/endpoints/client_endpoints_list.go
+++ b/vendor/github.com/jonboydell/logzio_client/endpoints/client_endpoints_list.go
@@ -1,0 +1,53 @@
+package endpoints
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/jonboydell/logzio_client"
+	"github.com/jonboydell/logzio_client/client"
+	"io/ioutil"
+	"net/http"
+)
+
+const listEndpointsServiceUrl string = endpointServiceEndpoint
+const listEndpointsServiceMethod string = http.MethodGet
+const listEndpointsMethodSuccess int = 200
+
+const errorListEndpointApiCallFailed = "API call ListEndpoints failed with status code:%d, data:%s"
+
+func (c *EndpointsClient) buildListEndpointsApiRequest(apiToken string) (*http.Request, error) {
+	baseUrl := c.BaseUrl
+	req, err := http.NewRequest(listEndpointsServiceMethod, fmt.Sprintf(listEndpointsServiceUrl, baseUrl), nil)
+	logzio_client.AddHttpHeaders(apiToken, req)
+
+	return req, err
+}
+
+// Lists all the current endpoints in an array, returns an error otherwise
+func (c *EndpointsClient) ListEndpoints() ([]Endpoint, error) {
+	req, _ := c.buildListEndpointsApiRequest(c.ApiToken)
+
+	httpClient := client.GetHttpClient(req)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonBytes, _ := ioutil.ReadAll(resp.Body)
+
+	if !logzio_client.CheckValidStatus(resp, []int{listEndpointsMethodSuccess}) {
+		return nil, fmt.Errorf(errorListEndpointApiCallFailed, resp.StatusCode, jsonBytes)
+	}
+
+	var arr []Endpoint
+	var jsonResponse []interface{}
+	err = json.Unmarshal([]byte(jsonBytes), &jsonResponse)
+
+	for _, json := range jsonResponse {
+		jsonEndpoint := json.(map[string]interface{})
+		endpoint := jsonEndpointToEndpoint(jsonEndpoint)
+		arr = append(arr, endpoint)
+	}
+
+	return arr, nil
+}

--- a/vendor/github.com/jonboydell/logzio_client/endpoints/client_endpoints_update.go
+++ b/vendor/github.com/jonboydell/logzio_client/endpoints/client_endpoints_update.go
@@ -1,0 +1,104 @@
+package endpoints
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/jonboydell/logzio_client"
+)
+
+const (
+	updateEndpointServiceUrl    string = endpointServiceEndpoint + "/%s/%d"
+	updateEndpointServiceMethod string = http.MethodPut
+	updateEndpointMethodSuccess int    = 200
+)
+
+const (
+	errorUpdateEndpointApiCallFailed = "API call UpdateEndpoint failed with status code:%d, data:%s"
+	errorUpdateEndpointDoesntExist   = "API call UpdateEndpoint failed as endpoint with id:%d doesn't exist, data:%s"
+)
+
+func (c *EndpointsClient) buildUpdateEndpointApiRequest(apiToken string, endpointType endpointType, endpoint Endpoint) (*http.Request, error) {
+	jsonObject, err := buildUpdateEndpointRequest(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonBytes, err := json.Marshal(jsonObject)
+	if err != nil {
+		return nil, err
+	}
+
+	baseUrl := c.BaseUrl
+	id := endpoint.Id
+	req, err := http.NewRequest(updateEndpointServiceMethod, fmt.Sprintf(updateEndpointServiceUrl, baseUrl, strings.ToLower(c.getURLByType(endpointType)), id), bytes.NewBuffer(jsonBytes))
+	logzio_client.AddHttpHeaders(apiToken, req)
+
+	return req, err
+}
+
+func buildUpdateEndpointRequest(endpoint Endpoint) (map[string]interface{}, error) {
+	var updateEndpoint = map[string]interface{}{}
+
+	updateEndpoint[fldEndpointTitle] = endpoint.Title
+	updateEndpoint[fldEndpointDescription] = endpoint.Description
+
+	switch endpoint.EndpointType {
+	case EndpointTypeSlack:
+		updateEndpoint[fldEndpointUrl] = endpoint.Url
+	case EndpointTypeCustom:
+		updateEndpoint[fldEndpointUrl] = endpoint.Url
+		updateEndpoint[fldEndpointMethod] = endpoint.Method
+		headers := endpoint.Headers
+		headerStrings := []string{}
+		for k, v := range headers {
+			headerStrings = append(headerStrings, fmt.Sprintf("%s=%s", k, v))
+		}
+		headerString := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(headerStrings)), ","), "[]")
+		updateEndpoint[fldEndpointHeaders] = headerString
+		updateEndpoint[fldEndpointBodyTemplate] = endpoint.BodyTemplate
+	case EndpointTypePagerDuty:
+		updateEndpoint[fldEndpointServiceKey] = endpoint.ServiceKey
+	case EndpointTypeBigPanda:
+		updateEndpoint[fldEndpointApiToken] = endpoint.ApiToken
+		updateEndpoint[fldEndpointAppKey] = endpoint.AppKey
+	case EndpointTypeDataDog:
+		updateEndpoint[fldEndpointApiKey] = endpoint.ApiKey
+	case EndpointTypeVictorOps:
+		updateEndpoint[fldEndpointRoutingKey] = endpoint.RoutingKey
+		updateEndpoint[fldEndpointMessageType] = endpoint.MessageType
+		updateEndpoint[fldEndpointServiceApiKey] = endpoint.ServiceApiKey
+	default:
+		return nil, fmt.Errorf("don't recognise endpoint type %s", endpoint.EndpointType)
+	}
+
+	return updateEndpoint, nil
+}
+
+// Updates an existing endpoint, returns the updated endpoint if successful, an error otherwise
+func (c *EndpointsClient) UpdateEndpoint(id int64, endpoint Endpoint) (*Endpoint, error) {
+
+	endpoint.Id = id
+	if jsonBytes, err, ok := c.makeEndpointRequest(endpoint, ValidateEndpointRequest, c.buildUpdateEndpointApiRequest, func(b []byte) error {
+		if strings.Contains(fmt.Sprintf("%s", b), "Insufficient privileges") {
+			return fmt.Errorf("API call %s failed for endpoint %d, data: %s", "UpdateEndpoint", id, b)
+		}
+		if strings.Contains(fmt.Sprintf("%s", b), "errorCode") {
+			return fmt.Errorf("API call %s failed for endpoint %d, data: %s", "UpdateEndpoint", id, b)
+		}
+
+		return nil
+	}); ok {
+		var target Endpoint
+		err = json.Unmarshal(jsonBytes, &target)
+		if err != nil {
+			return nil, err
+		}
+		return &endpoint, nil
+	} else {
+		return nil, err
+	}
+}

--- a/vendor/github.com/jonboydell/logzio_client/endpoints/client_endpoints_validate.go
+++ b/vendor/github.com/jonboydell/logzio_client/endpoints/client_endpoints_validate.go
@@ -1,0 +1,57 @@
+package endpoints
+
+func validSlackEndpoint(endpointType Endpoint) bool {
+	return len(endpointType.Title) > 0 &&
+		len(endpointType.Url) > 0 && len(endpointType.Description) > 0
+}
+
+func validCustomEndpoint(endpointType Endpoint) bool {
+	return len(endpointType.Title) > 0 &&
+		len(endpointType.Url) > 0 && len(endpointType.Description) > 0 &&
+		len(endpointType.Method) > 0
+}
+
+func validPagerDutyEndpoint(endpointType Endpoint) bool {
+	return len(endpointType.Title) > 0 &&
+		len(endpointType.Description) > 0 &&
+		len(endpointType.ServiceKey) > 0
+}
+
+func validBigPandaEndpoint(endpointType Endpoint) bool {
+	return len(endpointType.Title) > 0 &&
+		len(endpointType.Description) > 0 &&
+		len(endpointType.ApiToken) > 0 && len(endpointType.AppKey) > 0
+}
+
+func validDataDogEndpoint(endpointType Endpoint) bool {
+	return len(endpointType.Title) > 0 &&
+		len(endpointType.Description) > 0 &&
+		len(endpointType.ApiKey) > 0
+}
+
+func validVictorOpsEndpoint(endpointType Endpoint) bool {
+	return len(endpointType.Title) > 0 &&
+		len(endpointType.Description) > 0 &&
+		len(endpointType.RoutingKey) > 0 && len(endpointType.MessageType) > 0 && len(endpointType.ServiceApiKey) > 0
+}
+
+// ValidateEndpointRequest validates an endpoint request for correctness given its type,
+// returns FALSE if validation failed, true otherwise
+func ValidateEndpointRequest(endpoint Endpoint) bool {
+	switch endpoint.EndpointType {
+	case EndpointTypeSlack:
+		return validSlackEndpoint(endpoint)
+	case EndpointTypeCustom:
+		return validCustomEndpoint(endpoint)
+	case EndpointTypePagerDuty:
+		return validPagerDutyEndpoint(endpoint)
+	case EndpointTypeBigPanda:
+		return validBigPandaEndpoint(endpoint)
+	case EndpointTypeDataDog:
+		return validDataDogEndpoint(endpoint)
+	case EndpointTypeVictorOps:
+		return validVictorOpsEndpoint(endpoint)
+	default:
+		return false
+	}
+}

--- a/vendor/github.com/jonboydell/logzio_client/go.mod
+++ b/vendor/github.com/jonboydell/logzio_client/go.mod
@@ -1,0 +1,8 @@
+module github.com/jonboydell/logzio_client
+
+go 1.12
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/stretchr/testify v1.3.0
+)

--- a/vendor/github.com/jonboydell/logzio_client/go.sum
+++ b/vendor/github.com/jonboydell/logzio_client/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/vendor/github.com/jonboydell/logzio_client/utils.go
+++ b/vendor/github.com/jonboydell/logzio_client/utils.go
@@ -1,0 +1,28 @@
+package logzio_client
+
+import (
+	"net/http"
+)
+
+func AddHttpHeaders(apiToken string, req *http.Request) {
+	req.Header.Add("X-API-TOKEN", apiToken)
+	req.Header.Add("Content-Type", "application/json")
+}
+
+func Contains(slice []string, s string) bool {
+	for _, value := range slice {
+		if value == s {
+			return true
+		}
+	}
+	return false
+}
+
+func CheckValidStatus(response *http.Response, status []int) bool {
+	for x := 0; x < len(status); x++ {
+		if response.StatusCode == status[x] {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -494,6 +494,11 @@ github.com/inconshreveable/mousetrap
 github.com/jen20/awspolicyequivalence
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 github.com/jmespath/go-jmespath
+# github.com/jonboydell/logzio_client v0.0.0-20190726085421-c93d6b149c1e
+github.com/jonboydell/logzio_client/alerts
+github.com/jonboydell/logzio_client/endpoints
+github.com/jonboydell/logzio_client
+github.com/jonboydell/logzio_client/client
 # github.com/joyent/triton-go v0.0.0-20180628001255-830d2b111e62
 github.com/joyent/triton-go
 github.com/joyent/triton-go/authentication


### PR DESCRIPTION
### Example

```
LOGZIO_API_TOKEN=foobar LOGZIO_BASE_URL=https://api-eu.logz.io ./terraformer import logzio -r=alerts,alert_notification_endpoints // Import Logz.io alerts and alert notification endpoints
```

### Provider
logzio provider >=1.1.1 - [here](https://github.com/jonboydell/logzio_terraform_provider/)

### List of supported Logz.io resources:

 * `alerts`
    * `logzio_alert`
* `alert notification endpoint`
    * `logzio_endpoint`