### PR TITLE
aws: Fix firehose import bug

### DIFF
--- a/providers/aws/firehose.go
+++ b/providers/aws/firehose.go
@@ -29,7 +29,6 @@ func (g FirehoseGenerator) createResources(sess *session.Session, streamNames []
 	var resources []terraform_utils.Resource
 	for _, streamName := range streamNames {
 		resourceName := aws.StringValue(streamName)
-
 		resources = append(resources, terraform_utils.NewResource(
 			resourceName,
 			resourceName,
@@ -62,5 +61,16 @@ func (g *FirehoseGenerator) InitResources() error {
 	g.Resources = g.createResources(sess, streamNames)
 
 	g.PopulateIgnoreKeys()
+	return nil
+}
+
+func (g *FirehoseGenerator) PostConvertHook() error {
+	for _, resource := range g.Resources {
+		_, hasExtendedS3Configuration := resource.Item["extended_s3_configuration"]
+		_, hasS3Configuration := resource.Item["s3_configuration"]
+		if hasExtendedS3Configuration && hasS3Configuration {
+			delete(resource.Item,"s3_configuration")
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
I found `terraformer import aws -r firehose` failed in specific case (using S3 bucket as destination).
This code fix that bug.

# About bug
`aws_kinesis_firehose_delivery_stream` can have either  `extended_s3_configuration` or `s3_configuration` attribute but this bug is not follow this constraint.
https://www.terraform.io/docs/providers/aws/r/kinesis_firehose_delivery_stream.html

bug sample (`import-test` has both of `extended_s3_configuration` and `s3_configuration` in following case)
```
% terraform plan
Error: "extended_s3_configuration": conflicts with s3_configuration

  on kinesis_firehose_delivery_stream.tf line 1, in resource "aws_kinesis_firehose_delivery_stream" "import-test":
   1: resource "aws_kinesis_firehose_delivery_stream" "import-test" {
```