### PR TITLE
Add support for the new dashboard API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,6 @@ require (
 	github.com/sirupsen/logrus v1.2.0 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/stoewer/go-strcase v1.0.2 // indirect
-	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/terraform-providers/terraform-provider-aws v1.48.0 // indirect
 	github.com/terraform-providers/terraform-provider-google v1.20.0 // indirect
 	github.com/terraform-providers/terraform-provider-kubernetes v1.4.0
@@ -88,7 +87,7 @@ require (
 	github.com/ugorji/go v1.1.2-0.20180728093225-eeb0478a81ae // indirect
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
 	github.com/zclconf/go-cty v0.0.0-20181017232614-01c5aba823a6 // indirect
-	github.com/zorkian/go-datadog-api v2.20.0+incompatible
+	github.com/zorkian/go-datadog-api v2.21.1-0.20190802113207-d0ce49abc107+incompatible
 	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421
 	google.golang.org/api v0.5.1-0.20190510010909-bbbc0e98e3cc
 	google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19

--- a/go.sum
+++ b/go.sum
@@ -266,8 +266,6 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
-github.com/jonboydell/logzio_client v0.0.0-20190719124443-5e42bfdf749f h1:kASfbngq48p4bXixKJGRrP4EhGKTUJ/ETLBVOYn6Jbw=
-github.com/jonboydell/logzio_client v0.0.0-20190719124443-5e42bfdf749f/go.mod h1:ZXJYF4M9/chuG+4fQDS9BN6CqXqokUjtQOjdMqzGC/Y=
 github.com/jonboydell/logzio_client v0.0.0-20190726085421-c93d6b149c1e h1:+fjlEMEatpz35dZ4rMa18HEXdsZ9ZOCkmcIAZJgilDM=
 github.com/jonboydell/logzio_client v0.0.0-20190726085421-c93d6b149c1e/go.mod h1:ZXJYF4M9/chuG+4fQDS9BN6CqXqokUjtQOjdMqzGC/Y=
 github.com/joyent/triton-go v0.0.0-20180313100802-d8f9c0314926/go.mod h1:U+RSyWxWd04xTqnuOQxnai7XGS2PrPY2cfGoDKtMHjA=
@@ -428,7 +426,6 @@ github.com/stoewer/go-strcase v1.0.2 h1:l3iQ2FPu8+36ars/7syO1dQAkjwMCb1IE3J+Th0o
 github.com/stoewer/go-strcase v1.0.2/go.mod h1:eLfe5bL3qbL7ep/KafHzthxejrOF5J3xmt03uL5tzek=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
@@ -473,8 +470,8 @@ github.com/zclconf/go-cty v0.0.0-20180328152515-d006e4534bc4/go.mod h1:LnDKxj8gN
 github.com/zclconf/go-cty v0.0.0-20180815031001-58bb2bc0302a/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v0.0.0-20181017232614-01c5aba823a6 h1:Y9SzKuDy2J5QLFPmFk7/ZIzbu4/FrQK9Zwv4vjivNiM=
 github.com/zclconf/go-cty v0.0.0-20181017232614-01c5aba823a6/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
-github.com/zorkian/go-datadog-api v2.20.0+incompatible h1:zfITezz+b9lZuYghMXTdAXBdJe7HRAyU72kKnx876k8=
-github.com/zorkian/go-datadog-api v2.20.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
+github.com/zorkian/go-datadog-api v2.21.1-0.20190802113207-d0ce49abc107+incompatible h1:CUiImFW4MzEoGHPAeeUSanQfGv0hQxk2ZucM2AglK7A=
+github.com/zorkian/go-datadog-api v2.21.1-0.20190802113207-d0ce49abc107+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 golang.org/x/crypto v0.0.0-20180211211603-9de5f2eaf759/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/providers/datadog/dashboard.go
+++ b/providers/datadog/dashboard.go
@@ -1,0 +1,73 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datadog
+
+import (
+	"fmt"
+
+	datadog "github.com/zorkian/go-datadog-api"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+)
+
+var (
+	// DashboardAllowEmptyValues ...
+	DashboardAllowEmptyValues = []string{"tags."}
+	// DashboardAttributes ...
+	DashboardAttributes = map[string]string{}
+	// DashboardAdditionalFields ...
+	DashboardAdditionalFields = map[string]string{}
+)
+
+// DashboardGenerator ...
+type DashboardGenerator struct {
+	DatadogService
+}
+
+func (DashboardGenerator) createResources(dashboards []datadog.BoardLite) []terraform_utils.Resource {
+	resources := []terraform_utils.Resource{}
+	for _, dashboard := range dashboards {
+		resourceName := dashboard.GetId()
+		resources = append(resources, terraform_utils.NewResource(
+			resourceName,
+			fmt.Sprintf("dashboard_%s", resourceName),
+			"datadog_dashboard",
+			"datadog",
+			DashboardAttributes,
+			DashboardAllowEmptyValues,
+			DashboardAdditionalFields,
+		))
+	}
+
+	return resources
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each dashboard create 1 TerraformResource.
+// Need Dashboard ID as ID for terraform resource
+func (g *DashboardGenerator) InitResources() error {
+	client := datadog.NewClient(g.Args["api-key"].(string), g.Args["app-key"].(string))
+	_, err := client.Validate()
+	if err != nil {
+		return err
+	}
+	boards, err := client.GetBoards()
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(boards)
+	g.PopulateIgnoreKeys()
+	return nil
+}

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -92,6 +92,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraform_utils.Servi
 		"synthetics":  &SyntheticsGenerator{},
 		"timeboard":   &TimeboardGenerator{},
 		"user":        &UserGenerator{},
+		"dashboard":   &DashboardGenerator{},
 	}
 }
 


### PR DESCRIPTION
Added support for new dashboard resource: https://www.terraform.io/docs/providers/datadog/r/dashboard.html

`> client.GetBoards()` is not in the **v2.21.0** release, so this is in draft mode for now. Will update go.mod after **v2.22.0** is out.
https://github.com/zorkian/go-datadog-api/releases



