### PR TITLE
Add AWS Route Table Importing Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,8 @@ List of supported AWS services:
     * `aws_kinesis_firehose_delivery_stream`
 *   `glue`
     * `glue_crawler`
+*   `route_table`
+    * `aws_route_table`
 
 ### Use with OpenStack
 

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -66,6 +66,9 @@ func (p AWSProvider) GetResourceConnections() map[string]map[string][]string {
 			"sg":     []string{"vpc_security_group_ids", "id"},
 			"subnet": []string{"subnet_id", "id"},
 		},
+		"route_table": {
+			"vpc":    []string{"vpc_id", "id"},
+		},
 	}
 }
 func (p AWSProvider) GetProviderData(arg ...string) map[string]interface{} {
@@ -133,5 +136,6 @@ func (p *AWSProvider) GetSupportedService() map[string]terraform_utils.ServiceGe
 		"ec2_instance":   &Ec2Generator{},
 		"firehose":       &FirehoseGenerator{},
 		"glue":           &GlueGenerator{},
+		"route_table":    &RouteTableGenerator{},
 	}
 }

--- a/providers/aws/route_table.go
+++ b/providers/aws/route_table.go
@@ -1,0 +1,69 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"log"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+var rtbAllowEmptyValues = []string{"tags."}
+
+type RouteTableGenerator struct {
+	AWSService
+}
+
+func (g RouteTableGenerator) createRouteTablesResources(svc *ec2.EC2) []terraform_utils.Resource {
+	resources := []terraform_utils.Resource{}
+	err := svc.DescribeRouteTablesPages(
+		&ec2.DescribeRouteTablesInput{},
+		func(tables *ec2.DescribeRouteTablesOutput, lastPage bool) bool {
+			for _, table := range tables.RouteTables {
+				resources = append(resources, terraform_utils.NewResource(
+					aws.StringValue(table.RouteTableId),
+					aws.StringValue(table.RouteTableId),
+					"aws_route_table",
+					"aws",
+					map[string]string{},
+					rtbAllowEmptyValues,
+					map[string]string{},
+				))
+			}
+			return true
+		},
+	)
+
+	if err != nil {
+		log.Println(err)
+		return resources
+	}
+
+	return resources
+}
+
+// Generate TerraformResources from AWS API,
+// create terraform resource for each route tables
+func (g *RouteTableGenerator) InitResources() error {
+	sess := g.generateSession()
+	svc := ec2.New(sess)
+
+	g.Resources = g.createRouteTablesResources(svc)
+	g.PopulateIgnoreKeys()
+	return nil
+}


### PR DESCRIPTION
This PR adds support for importing AWS Route Table ([`aws_route_table`](https://www.terraform.io/docs/providers/aws/r/route_table.html)).