### PR TITLE
Fix Issue #169

### DIFF
--- a/terraform_utils/hcl.go
+++ b/terraform_utils/hcl.go
@@ -187,9 +187,9 @@ func terraform12Adjustments(formatted []byte, mapsObjects map[string]struct{}) [
 
 // Sanitize name for terraform style
 func TfSanitize(name string) string {
-	name = strings.Replace(name, "*.", "", -1)
 	name = strings.Replace(name, " ", "", -1)
 	//name = strings.Replace(name, "-", "_", -1)
+	name = strings.Replace(name, "*", "--", -1)
 	name = strings.Replace(name, ".", "--", -1)
 	name = strings.Replace(name, ":", "--", -1)
 	name = strings.Replace(name, "/", "--", -1)


### PR DESCRIPTION
Route53 records `example.com` and `*.example.com` must have different identifiers, otherwise it will result:

```
[ERR]: duplicate resource found: aws_route53_record.ZZZZZZZZZZZZZZ_example.com_A_
```

This is fixed by removing `"*."` to `""` replace rule and then adding `"*"` to `"--"` replace rule. While `"."` will be handled by the `"."` to `"--"` existent rule.

The problem is described on Issue #169.