### PR TITLE
adjust setting datadog api & app key. Update zorkain/go-datadog-api library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/unknwon/com v0.0.0-20181010210213-41959bdd855f // indirect
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
 	github.com/zclconf/go-cty v1.0.1-0.20190708163926-19588f92a98f
-	github.com/zorkian/go-datadog-api v2.21.1-0.20190802113207-d0ce49abc107+incompatible
+	github.com/zorkian/go-datadog-api v2.24.0+incompatible
 	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421
 	google.golang.org/api v0.5.1-0.20190510010909-bbbc0e98e3cc
 	google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19

--- a/go.sum
+++ b/go.sum
@@ -657,6 +657,8 @@ github.com/zclconf/go-cty-yaml v1.0.1 h1:up11wlgAaDvlAGENcFDnZgkn0qUJurso7k6EpUR
 github.com/zclconf/go-cty-yaml v1.0.1/go.mod h1:IP3Ylp0wQpYm50IHK8OZWKMu6sPJIUgKa8XhiVHura0=
 github.com/zorkian/go-datadog-api v2.21.1-0.20190802113207-d0ce49abc107+incompatible h1:CUiImFW4MzEoGHPAeeUSanQfGv0hQxk2ZucM2AglK7A=
 github.com/zorkian/go-datadog-api v2.21.1-0.20190802113207-d0ce49abc107+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
+github.com/zorkian/go-datadog-api v2.24.0+incompatible h1:conz6t5Vu0nIVigLpinYudl6uYc+xhajR6WuX+tD21I=
+github.com/zorkian/go-datadog-api v2.24.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -23,7 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 )
 
-const datadogProviderVersion = ">2.1.0"
+const datadogProviderVersion = ">2.4.0"
 
 type DatadogProvider struct {
 	terraform_utils.Provider
@@ -64,8 +64,8 @@ func (p *DatadogProvider) GetName() string {
 // GetConfig return map of provider config for Datadog
 func (p *DatadogProvider) GetConfig() cty.Value {
 	return cty.ObjectVal(map[string]cty.Value{
-		"api-key": cty.StringVal(p.apiKey),
-		"app-key": cty.StringVal(p.appKey),
+		"api_key": cty.StringVal(p.apiKey),
+		"app_key": cty.StringVal(p.appKey),
 	})
 }
 


### PR DESCRIPTION
The 0.7.9 build only takes api & app keys as environment variables, it does not respect the `--api-key` or `--app-key` flag. An `import` operation errors with:
```
2019/09/24 13:34:07 plugin error 1: Invalid or missing credentials provided to the Datadog Provider. Please confirm your API and APP keys are valid and see https://terraform.io/docs/providers/datadog/index.html for more information on providing credentials for the Datadog Provider
```

