### PR TITLE
fix: add missing required field in aws_iam_group_membership

### DIFF
--- a/providers/aws/iam.go
+++ b/providers/aws/iam.go
@@ -216,7 +216,7 @@ func (g *IamGenerator) getGroups(svc *iam.IAM) error {
 					"group": resourceName,
 					"name":  resourceName,
 				},
-				IamAllowEmptyValues,
+				[]string{"tags.", "users."},
 				IamAdditionalFields))
 			_ = svc.ListGroupPoliciesPages(&iam.ListGroupPoliciesInput{GroupName: group.GroupName}, func(policyGroup *iam.ListGroupPoliciesOutput, lastPage bool) bool {
 				for _, policy := range policyGroup.PolicyNames {


### PR DESCRIPTION
The `aws_iam_group_membership` resource must have `users` field even if this field has an empty element.
So I added `users` to `AllowEmptyValues`.

See Also: https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_iam_group_membership.go#L28