### PR TITLE
Document AWS_SDK_LOAD_CONFIG to load profiles from the shared config

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,12 @@ Example:
  terraformer import aws --resources=vpc,subnet --filter=aws_vpc=vpc_id1:vpc_id2:vpc_id3 --regions=eu-west-1
 ```
 
+To load profiles from the shared AWS configuration file (typically `~/.aws/config`), set the `AWS_SDK_LOAD_CONFIG` to `true`:
+
+```
+AWS_SDK_LOAD_CONFIG=true terraformer import aws --resources=vpc,subnet --regions=eu-west-1 --profile=prod
+```
+
 List of supported AWS services:
 
 *   `elb`


### PR DESCRIPTION
To get terraformer to work with the AWS profiles I have in my `~/.aws/config` file, I had to set the `AWS_SDK_LOAD_CONFIG` to `true`.

Without that option, I get the following warning (with a ~25s delay) and nothing is imported:

```
# terraformer version
Terraformer v0.8.0

# terraformer import aws --resources=route53 --profile=myprofile --regions=eu-west-1
2019/09/27 17:00:01 aws importing region eu-west-1
2019/09/27 17:00:01 aws importing... route53
2019/09/27 17:00:25 NoCredentialProviders: no valid providers in chain. Deprecated.
        For verbose messaging see aws.Config.CredentialsChainVerboseErrors
2019/09/27 17:00:25 [TRACE] GRPCProvider: GetSchema
2019/09/27 17:00:25 [TRACE] GRPCProvider: Configure
2019/09/27 17:00:38 [TRACE] GRPCProvider: GetSchema
2019/09/27 17:00:38 [TRACE] GRPCProvider: GetSchema
2019/09/27 17:00:38 [TRACE] GRPCProvider: Configure
2019/09/27 17:00:50 aws Connecting.... 
2019/09/27 17:00:50 aws save route53
2019/09/27 17:00:50 [DEBUG] New state was assigned lineage "f607c9b7-28e7-961b-65eb-5869e7eae5b1"
2019/09/27 17:00:50 aws save tfstate for route53
```

This happens because the `SharedConfigState` is set to `session.SharedConfigStateFromEnv` (https://github.com/GoogleCloudPlatform/terraformer/blob/0.8/providers/aws/aws_service.go#L34), which makes `session.NewSessionWithOptions()` rely on that environment variable (https://github.com/aws/aws-sdk-go/blob/v1.22.0/aws/session/session.go#L251).

Adding the following trace emphasizes the issue:

```
diff --git a/providers/aws/aws_service.go b/providers/aws/aws_service.go
index 0e60673..8cbe598 100644
--- a/providers/aws/aws_service.go
+++ b/providers/aws/aws_service.go
@@ -15,6 +15,7 @@
 package aws

 import (
+       "log"
        "os"

        "github.com/GoogleCloudPlatform/terraformer/terraform_utils"
@@ -39,5 +40,7 @@ func (s *AWSService) generateSession() *session.Session {
        os.Setenv("AWS_SECRET_ACCESS_KEY", creds.SecretAccessKey)
        os.Setenv("AWS_SESSION_TOKEN", creds.SessionToken)

+       log.Printf("[TRACE] generateSession: %v", creds)
+
        return sess
 }
```

```
# terraformer import aws --resources=route53 --profile myprofile --regions=eu-west-1                                                                                           
2019/09/27 17:08:46 aws importing region eu-west-1
2019/09/27 17:08:46 aws importing... route53
2019/09/27 17:08:58 [TRACE] generateSession: {   }
2019/09/27 17:09:10 NoCredentialProviders: no valid providers in chain. Deprecated.
        For verbose messaging see aws.Config.CredentialsChainVerboseErrors
2019/09/27 17:09:10 [TRACE] GRPCProvider: GetSchema
2019/09/27 17:09:10 [TRACE] GRPCProvider: Configure
2019/09/27 17:09:22 [TRACE] GRPCProvider: GetSchema
2019/09/27 17:09:23 [TRACE] GRPCProvider: GetSchema
2019/09/27 17:09:23 [TRACE] GRPCProvider: Configure
2019/09/27 17:09:35 aws Connecting....
2019/09/27 17:09:35 aws save route53
2019/09/27 17:09:35 [DEBUG] New state was assigned lineage "f90f6697-b18b-3fcd-5b38-61b7ce0e8e66"                                                                                       
2019/09/27 17:09:35 aws save tfstate for route53
```

With `AWS_SDK_LOAD_CONFIG=true`:

```
AWS_SDK_LOAD_CONFIG=true terraformer import aws --resources=route53 --profile=myprofile --regions=eu-west-1                                                                   
2019/09/27 17:10:52 aws importing region eu-west-1                                                                                                                                       
2019/09/27 17:10:52 aws importing... route53                                                                                                                                             
2019/09/27 17:10:53 [TRACE] generateSession: {ASIA******, cWLD******=, AssumeRoleProvider}
2019/09/27 17:10:54 [TRACE] GRPCProvider: GetSchema                                                                                                                                      
2019/09/27 17:10:54 [TRACE] GRPCProvider: Configure                                                                                                                                      
2019/09/27 17:10:57 [TRACE] GRPCProvider: GetSchema                                                                                                                                      
2019/09/27 17:10:57 [TRACE] GRPCProvider: GetSchema                                                                                                                                      
2019/09/27 17:10:57 [TRACE] GRPCProvider: Configure                                                                                                                                      
2019/09/27 17:10:59 Refreshing state... aws_route53_record.Z******-mydomain--_SOA_                                                               
...
2019/09/27 17:11:01 [TRACE] GRPCProvider: GetSchema
2019/09/27 17:11:01 [TRACE] GRPCProvider: ReadResource
2019/09/27 17:11:05 aws Connecting....
2019/09/27 17:11:05 aws save route53
2019/09/27 17:11:05 [DEBUG] New state was assigned lineage "6ae3cbde-0d88-adaa-b9c1-5aa5c3afb7e9"                                                                                       
2019/09/27 17:11:05 aws save tfstate for route53
```