### PR TITLE
Improved import/plan parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ You can also provide no regions when importing resources:
 ```
 terraformer import aws --resources=cloudfront --profile=prod
 ```
-In that case terraformer will not know with which region resources are associated with and will not assume any region. That scenario is useful in case of global resources (e.g. CloudFront distributions or Route 53 records) and when region is passed implicitly through environmental variables or metadata service
+In that case terraformer will not know with which region resources are associated with and will not assume any region. That scenario is useful in case of global resources (e.g. CloudFront distributions or Route 53 records) and when region is passed implicitly through environmental variables or metadata service.
 
 List of supported AWS services:
 

--- a/README.md
+++ b/README.md
@@ -305,6 +305,12 @@ To load profiles from the shared AWS configuration file (typically `~/.aws/confi
 AWS_SDK_LOAD_CONFIG=true terraformer import aws --resources=vpc,subnet --regions=eu-west-1 --profile=prod
 ```
 
+You can also provide no regions when importing resources:
+```
+terraformer import aws --resources=cloudfront --profile=prod
+```
+In that case terraformer will not know with which region resources are associated with and will not assume any region. That scenario is useful in case of global resources (e.g. CloudFront distributions or Route 53 records) and when region is passed implicitly through environmental variables or metadata service
+
 List of supported AWS services:
 
 *   `elb`

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -28,6 +28,15 @@ func newCmdAwsImporter(options ImportOptions) *cobra.Command {
 		Long:  "Import current State to terraform configuration from aws",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			originalPathPattern := options.PathPattern
+			if len(options.Regions) == 0 {
+				provider := newAWSProvider()
+				log.Println(provider.GetName() + " importing default region")
+				err := Import(provider, options, []string{"", options.Profile})
+				if err != nil {
+					return err
+				}
+			}
+
 			for _, region := range options.Regions {
 				provider := newAWSProvider()
 				options.PathPattern = originalPathPattern

--- a/cmd/google.go
+++ b/cmd/google.go
@@ -54,6 +54,7 @@ func newCmdGoogleImporter(options ImportOptions) *cobra.Command {
 	cmd.PersistentFlags().StringSliceVarP(&options.Regions, "regions", "z", []string{"global"}, "europe-west1,")
 	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "google_compute_firewall=id1:id2:id4")
 	cmd.PersistentFlags().StringSliceVarP(&options.Projects, "projects", "", []string{}, "")
+	_ = cmd.MarkPersistentFlagRequired("projects")
 	return cmd
 }
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -59,7 +59,9 @@ func newImportCmd() *cobra.Command {
 
 	cmd.AddCommand(newCmdPlanImporter(options))
 	for _, subcommand := range providerImporterSubcommands() {
-		cmd.AddCommand(subcommand(options))
+		providerCommand := subcommand(options)
+		_ = providerCommand.MarkPersistentFlagRequired("resources")
+		cmd.AddCommand(providerCommand)
 	}
 	return cmd
 }

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -83,6 +83,7 @@ func Import(provider terraform_utils.ProviderGenerator, options ImportOptions, a
 			return err
 		}
 		err = provider.GetService().InitResources()
+		provider.GetService().PopulateIgnoreKeys(provider.GetBasicConfig())
 		if err != nil {
 			return err
 		}

--- a/providers/aws/acm.go
+++ b/providers/aws/acm.go
@@ -71,7 +71,6 @@ func (g *ACMGenerator) InitResources() error {
 	svc := acm.New(sess)
 
 	g.Resources = g.createCertificatesResources(svc)
-	g.PopulateIgnoreKeys()
 	return nil
 }
 

--- a/providers/aws/alb.go
+++ b/providers/aws/alb.go
@@ -180,7 +180,6 @@ func (g *AlbGenerator) InitResources() error {
 	if err := g.loadLBTargetGroup(svc); err != nil {
 		return err
 	}
-	g.PopulateIgnoreKeys()
 	return nil
 }
 

--- a/providers/aws/autoscaling.go
+++ b/providers/aws/autoscaling.go
@@ -121,7 +121,6 @@ func (g *AutoScalingGenerator) InitResources() error {
 	if err := g.loadLaunchTemplates(sess); err != nil {
 		return err
 	}
-	g.PopulateIgnoreKeys()
 	return nil
 }
 

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -15,6 +15,7 @@
 package aws
 
 import (
+	"github.com/zclconf/go-cty/cty"
 	"os"
 	"strconv"
 
@@ -95,15 +96,35 @@ func (p AWSProvider) GetResourceConnections() map[string]map[string][]string {
 	}
 }
 func (p AWSProvider) GetProviderData(arg ...string) map[string]interface{} {
+	awsConfig := map[string]interface{}{
+		"version": awsProviderVersion,
+	}
+
+	if p.region != "" {
+		awsConfig["region"] = p.region
+	}
+
 	return map[string]interface{}{
 		"provider": map[string]interface{}{
-			"aws": map[string]interface{}{
-				"version": awsProviderVersion,
-				"region":  p.region,
-			},
+			"aws": awsConfig,
 		},
 	}
 }
+
+func (p *AWSProvider) GetConfig() cty.Value {
+	return cty.ObjectVal(map[string]cty.Value{
+		"region": cty.StringVal(p.region),
+		"skip_region_validation": cty.True,
+	})
+}
+
+
+func (p *AWSProvider) GetBasicConfig() cty.Value {
+	return cty.ObjectVal(map[string]cty.Value{
+		"region": cty.StringVal(p.region),
+		"skip_region_validation": cty.True,
+	})}
+
 
 // check projectName in env params
 func (p *AWSProvider) Init(args []string) error {
@@ -113,13 +134,15 @@ func (p *AWSProvider) Init(args []string) error {
 	// Terraformer accepts region and profile configuration, so we must detect what env variables to adjust to make Go SDK rely on them. AWS_SDK_LOAD_CONFIG here must be checked to determine correct variable to set.
 	enableSharedConfig, _ := strconv.ParseBool(os.Getenv("AWS_SDK_LOAD_CONFIG"))
 	var err error
-	if enableSharedConfig {
-		err = os.Setenv("AWS_DEFAULT_REGION", p.region)
-	} else {
-		err = os.Setenv("AWS_REGION", p.region)
-	}
-	if err != nil {
-		return err
+	if p.region != "" {
+		if enableSharedConfig {
+			err = os.Setenv("AWS_DEFAULT_REGION", p.region)
+		} else {
+			err = os.Setenv("AWS_REGION", p.region)
+		}
+		if err != nil {
+			return err
+		}
 	}
 
 	if p.profile != "default" && p.profile != "" {
@@ -149,6 +172,7 @@ func (p *AWSProvider) InitService(serviceName string) error {
 	p.Service.SetProviderName(p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
 		"region":  p.region,
+		"skip_region_validation": true,
 	})
 	return nil
 }

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -118,13 +118,9 @@ func (p *AWSProvider) GetConfig() cty.Value {
 	})
 }
 
-
 func (p *AWSProvider) GetBasicConfig() cty.Value {
-	return cty.ObjectVal(map[string]cty.Value{
-		"region": cty.StringVal(p.region),
-		"skip_region_validation": cty.True,
-	})}
-
+	return p.GetConfig()
+}
 
 // check projectName in env params
 func (p *AWSProvider) Init(args []string) error {

--- a/providers/aws/cloud_front.go
+++ b/providers/aws/cloud_front.go
@@ -50,7 +50,6 @@ func (g *CloudFrontGenerator) InitResources() error {
 	if err != nil {
 		return err
 	}
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/aws/dynamodb.go
+++ b/providers/aws/dynamodb.go
@@ -46,7 +46,6 @@ func (g *DynamoDbGenerator) InitResources() error {
 	if err != nil {
 		return err
 	}
-	g.PopulateIgnoreKeys()
 	return nil
 }
 

--- a/providers/aws/ebs.go
+++ b/providers/aws/ebs.go
@@ -94,6 +94,5 @@ func (g *EbsGenerator) InitResources() error {
 	if err != nil {
 		return err
 	}
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/aws/ec2.go
+++ b/providers/aws/ec2.go
@@ -71,7 +71,6 @@ func (g *Ec2Generator) InitResources() error {
 	if err != nil {
 		return err
 	}
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/aws/ecs.go
+++ b/providers/aws/ecs.go
@@ -126,6 +126,5 @@ func (g *EcsGenerator) InitResources() error {
 		return err
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/aws/elasticache.go
+++ b/providers/aws/elasticache.go
@@ -145,7 +145,6 @@ func (g *ElastiCacheGenerator) InitResources() error {
 		return err
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/aws/elb.go
+++ b/providers/aws/elb.go
@@ -53,7 +53,6 @@ func (g *ElbGenerator) InitResources() error {
 	if err != nil {
 		return err
 	}
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/aws/es.go
+++ b/providers/aws/es.go
@@ -50,6 +50,5 @@ func (g *EsGenerator) InitResources() error {
 		))
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/aws/firehose.go
+++ b/providers/aws/firehose.go
@@ -60,7 +60,6 @@ func (g *FirehoseGenerator) InitResources() error {
 
 	g.Resources = g.createResources(sess, streamNames)
 
-	g.PopulateIgnoreKeys()
 	return nil
 }
 

--- a/providers/aws/glue.go
+++ b/providers/aws/glue.go
@@ -56,7 +56,6 @@ func (g *GlueGenerator) InitResources() error {
 	if err := g.loadGlueCrawlers(svc); err != nil {
 		return err
 	}
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/aws/iam.go
+++ b/providers/aws/iam.go
@@ -58,7 +58,6 @@ func (g *IamGenerator) InitResources() error {
 		log.Println(err)
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 }
 

--- a/providers/aws/igw.go
+++ b/providers/aws/igw.go
@@ -52,7 +52,6 @@ func (g *IgwGenerator) InitResources() error {
 		return err
 	}
 	g.Resources = g.createResources(igws)
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/aws/nacl.go
+++ b/providers/aws/nacl.go
@@ -52,7 +52,6 @@ func (g *NaclGenerator) InitResources() error {
 
 	}
 	g.Resources = g.createResources(nacls)
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/aws/organization.go
+++ b/providers/aws/organization.go
@@ -149,6 +149,5 @@ func (g *OrganizationGenerator) InitResources() error {
 		return err
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/aws/rds.go
+++ b/providers/aws/rds.go
@@ -142,7 +142,6 @@ func (g *RDSGenerator) InitResources() error {
 		return err
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/aws/route53.go
+++ b/providers/aws/route53.go
@@ -111,7 +111,6 @@ func (g *Route53Generator) InitResources() error {
 	svc := route53.New(sess)
 
 	g.Resources = g.createZonesResources(svc)
-	g.PopulateIgnoreKeys()
 	return nil
 }
 

--- a/providers/aws/route_table.go
+++ b/providers/aws/route_table.go
@@ -62,6 +62,5 @@ func (g *RouteTableGenerator) InitResources() error {
 	svc := ec2.New(sess)
 
 	g.Resources = g.createRouteTablesResources(svc)
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/aws/s3.go
+++ b/providers/aws/s3.go
@@ -98,7 +98,6 @@ func (g *S3Generator) InitResources() error {
 		return err
 	}
 	g.Resources = g.createResources(sess, buckets, g.GetArgs()["region"].(string))
-	g.PopulateIgnoreKeys()
 	return nil
 }
 

--- a/providers/aws/sg.go
+++ b/providers/aws/sg.go
@@ -75,7 +75,6 @@ func (g *SecurityGenerator) InitResources() error {
 		}
 	}
 	g.Resources = g.createResources(securityGroups)
-	g.PopulateIgnoreKeys()
 	return nil
 }
 

--- a/providers/aws/sns.go
+++ b/providers/aws/sns.go
@@ -77,6 +77,5 @@ func (g *SnsGenerator) InitResources() error {
 	if err != nil {
 		return err
 	}
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/aws/sqs.go
+++ b/providers/aws/sqs.go
@@ -51,6 +51,5 @@ func (g *SqsGenerator) InitResources() error {
 		))
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/aws/subnet.go
+++ b/providers/aws/subnet.go
@@ -55,7 +55,6 @@ func (g *SubnetGenerator) InitResources() error {
 		return err
 	}
 	g.Resources = g.createResources(subnets)
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/aws/vgw.go
+++ b/providers/aws/vgw.go
@@ -52,7 +52,6 @@ func (g *VpnGatewayGenerator) InitResources() error {
 		return err
 	}
 	g.Resources = g.createResources(vpnGws)
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/aws/vpc.go
+++ b/providers/aws/vpc.go
@@ -52,6 +52,5 @@ func (g *VpcGenerator) InitResources() error {
 		return err
 	}
 	g.Resources = g.createResources(vpcs)
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/aws/vpn_connection.go
+++ b/providers/aws/vpn_connection.go
@@ -52,7 +52,6 @@ func (g *VpnConnectionGenerator) InitResources() error {
 		return err
 	}
 	g.Resources = g.createResources(vpncs)
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/cloudflare/access.go
+++ b/providers/cloudflare/access.go
@@ -70,6 +70,5 @@ func (g *AccessGenerator) InitResources() error {
 		g.Resources = append(g.Resources, tmpRes...)
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/cloudflare/dns.go
+++ b/providers/cloudflare/dns.go
@@ -107,7 +107,6 @@ func (g *DNSGenerator) InitResources() error {
 			g.Resources = append(g.Resources, tmpRes...)
 		}
 	}
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/cloudflare/firewall.go
+++ b/providers/cloudflare/firewall.go
@@ -173,7 +173,6 @@ func (g *FirewallGenerator) InitResources() error {
 		}
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 }
 

--- a/providers/datadog/dashboard.go
+++ b/providers/datadog/dashboard.go
@@ -62,6 +62,5 @@ func (g *DashboardGenerator) InitResources() error {
 		return err
 	}
 	g.Resources = g.createResources(boards)
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/datadog/downtime.go
+++ b/providers/datadog/downtime.go
@@ -63,6 +63,5 @@ func (g *DowntimeGenerator) InitResources() error {
 		return err
 	}
 	g.Resources = g.createResources(downtimes)
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/datadog/monitor.go
+++ b/providers/datadog/monitor.go
@@ -63,6 +63,5 @@ func (g *MonitorGenerator) InitResources() error {
 		return err
 	}
 	g.Resources = g.createResources(monitors)
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/datadog/screenboard.go
+++ b/providers/datadog/screenboard.go
@@ -63,6 +63,5 @@ func (g *ScreenboardGenerator) InitResources() error {
 		return err
 	}
 	g.Resources = g.createResources(screenboards)
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/datadog/synthetics.go
+++ b/providers/datadog/synthetics.go
@@ -62,6 +62,5 @@ func (g *SyntheticsGenerator) InitResources() error {
 		return err
 	}
 	g.Resources = g.createResources(syntheticsList)
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/datadog/timeboard.go
+++ b/providers/datadog/timeboard.go
@@ -63,6 +63,5 @@ func (g *TimeboardGenerator) InitResources() error {
 		return err
 	}
 	g.Resources = g.createResources(timeboards)
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/datadog/user.go
+++ b/providers/datadog/user.go
@@ -62,6 +62,5 @@ func (g *UserGenerator) InitResources() error {
 		return err
 	}
 	g.Resources = g.createResources(users)
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/gcp/addresses_gen.go
+++ b/providers/gcp/addresses_gen.go
@@ -71,7 +71,6 @@ func (g *AddressesGenerator) InitResources() error {
 	addressesList := computeService.Addresses.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
 	g.Resources = g.createResources(ctx, addressesList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/autoscalers_gen.go
+++ b/providers/gcp/autoscalers_gen.go
@@ -77,7 +77,6 @@ func (g *AutoscalersGenerator) InitResources() error {
 		g.Resources = append(g.Resources, g.createResources(ctx, autoscalersList, zone)...)
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/backendBuckets_gen.go
+++ b/providers/gcp/backendBuckets_gen.go
@@ -71,7 +71,6 @@ func (g *BackendBucketsGenerator) InitResources() error {
 	backendBucketsList := computeService.BackendBuckets.List(g.GetArgs()["project"].(string))
 	g.Resources = g.createResources(ctx, backendBucketsList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/backendServices_gen.go
+++ b/providers/gcp/backendServices_gen.go
@@ -70,7 +70,6 @@ func (g *BackendServicesGenerator) InitResources() error {
 	backendServicesList := computeService.BackendServices.List(g.GetArgs()["project"].(string))
 	g.Resources = g.createResources(ctx, backendServicesList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/bigquery.go
+++ b/providers/gcp/bigquery.go
@@ -96,7 +96,6 @@ func (g *BigQueryGenerator) InitResources() error {
 	datasetsList := bigQueryService.Datasets.List(g.GetArgs()["project"].(string))
 
 	g.Resources = g.createResources(datasetsList, ctx, bigQueryService)
-	g.PopulateIgnoreKeys()
 	return nil
 }
 

--- a/providers/gcp/cloudFunctions.go
+++ b/providers/gcp/cloudFunctions.go
@@ -68,7 +68,6 @@ func (g *CloudFunctionsGenerator) InitResources() error {
 	functionsList := cloudfunctionsService.Projects.Locations.Functions.List("projects/" + g.GetArgs()["project"].(string) + "/locations/" + g.GetArgs()["region"].(compute.Region).Name)
 
 	g.Resources = g.createResources(functionsList, ctx)
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/clouddns.go
+++ b/providers/gcp/clouddns.go
@@ -101,7 +101,6 @@ func (g *CloudDNSGenerator) InitResources() error {
 	}
 
 	g.Resources = g.createZonesResources(ctx, svc, project)
-	g.PopulateIgnoreKeys()
 	return nil
 }
 

--- a/providers/gcp/cloudsql.go
+++ b/providers/gcp/cloudsql.go
@@ -94,6 +94,5 @@ func (g *CloudSQLGenerator) InitResources() error {
 		return err
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/gcp/dataproc.go
+++ b/providers/gcp/dataproc.go
@@ -103,7 +103,6 @@ func (g *DataprocGenerator) InitResources() error {
 	//jobList := dataprocService.Projects.Regions.Jobs.List(g.GetArgs()["project"].(string), g.GetArgs()["region"])
 	//g.Resources = append(g.Resources, g.createJobResources(jobList, ctx)...)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/disks_gen.go
+++ b/providers/gcp/disks_gen.go
@@ -77,7 +77,6 @@ func (g *DisksGenerator) InitResources() error {
 		g.Resources = append(g.Resources, g.createResources(ctx, disksList, zone)...)
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/firewalls_gen.go
+++ b/providers/gcp/firewalls_gen.go
@@ -71,7 +71,6 @@ func (g *FirewallsGenerator) InitResources() error {
 	firewallsList := computeService.Firewalls.List(g.GetArgs()["project"].(string))
 	g.Resources = g.createResources(ctx, firewallsList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/forwardingRules_gen.go
+++ b/providers/gcp/forwardingRules_gen.go
@@ -71,7 +71,6 @@ func (g *ForwardingRulesGenerator) InitResources() error {
 	forwardingRulesList := computeService.ForwardingRules.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
 	g.Resources = g.createResources(ctx, forwardingRulesList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/gcs.go
+++ b/providers/gcp/gcs.go
@@ -184,7 +184,6 @@ func (g *GcsGenerator) InitResources() error {
 	//		return err
 	//	}
 	//g.Resources = append(g.Resources, g.createTransferJobsResources(ctx, storageTransferService)...)
-	g.PopulateIgnoreKeys()
 	return nil
 }
 

--- a/providers/gcp/gke.go
+++ b/providers/gcp/gke.go
@@ -105,7 +105,6 @@ func (g *GkeGenerator) InitResources() error {
 	}
 
 	g.Resources = g.initClusters(clusters, service)
-	g.PopulateIgnoreKeys()
 	return nil
 }
 

--- a/providers/gcp/globalAddresses_gen.go
+++ b/providers/gcp/globalAddresses_gen.go
@@ -71,7 +71,6 @@ func (g *GlobalAddressesGenerator) InitResources() error {
 	globalAddressesList := computeService.GlobalAddresses.List(g.GetArgs()["project"].(string))
 	g.Resources = g.createResources(ctx, globalAddressesList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/globalForwardingRules_gen.go
+++ b/providers/gcp/globalForwardingRules_gen.go
@@ -70,7 +70,6 @@ func (g *GlobalForwardingRulesGenerator) InitResources() error {
 	globalForwardingRulesList := computeService.GlobalForwardingRules.List(g.GetArgs()["project"].(string))
 	g.Resources = g.createResources(ctx, globalForwardingRulesList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/healthChecks_gen.go
+++ b/providers/gcp/healthChecks_gen.go
@@ -71,7 +71,6 @@ func (g *HealthChecksGenerator) InitResources() error {
 	healthChecksList := computeService.HealthChecks.List(g.GetArgs()["project"].(string))
 	g.Resources = g.createResources(ctx, healthChecksList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/httpHealthChecks_gen.go
+++ b/providers/gcp/httpHealthChecks_gen.go
@@ -71,7 +71,6 @@ func (g *HttpHealthChecksGenerator) InitResources() error {
 	httpHealthChecksList := computeService.HttpHealthChecks.List(g.GetArgs()["project"].(string))
 	g.Resources = g.createResources(ctx, httpHealthChecksList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/httpsHealthChecks_gen.go
+++ b/providers/gcp/httpsHealthChecks_gen.go
@@ -71,7 +71,6 @@ func (g *HttpsHealthChecksGenerator) InitResources() error {
 	httpsHealthChecksList := computeService.HttpsHealthChecks.List(g.GetArgs()["project"].(string))
 	g.Resources = g.createResources(ctx, httpsHealthChecksList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/iam.go
+++ b/providers/gcp/iam.go
@@ -66,7 +66,6 @@ func (g *IamGenerator) InitResources() error {
 	serviceAccountsIterator := client.ListServiceAccounts(ctx, &adminpb.ListServiceAccountsRequest{Name: "projects/" + projectID})
 
 	g.Resources = g.createResources(serviceAccountsIterator)
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/images_gen.go
+++ b/providers/gcp/images_gen.go
@@ -71,7 +71,6 @@ func (g *ImagesGenerator) InitResources() error {
 	imagesList := computeService.Images.List(g.GetArgs()["project"].(string))
 	g.Resources = g.createResources(ctx, imagesList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/instanceGroupManagers_gen.go
+++ b/providers/gcp/instanceGroupManagers_gen.go
@@ -77,7 +77,6 @@ func (g *InstanceGroupManagersGenerator) InitResources() error {
 		g.Resources = append(g.Resources, g.createResources(ctx, instanceGroupManagersList, zone)...)
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/instanceGroups_gen.go
+++ b/providers/gcp/instanceGroups_gen.go
@@ -77,7 +77,6 @@ func (g *InstanceGroupsGenerator) InitResources() error {
 		g.Resources = append(g.Resources, g.createResources(ctx, instanceGroupsList, zone)...)
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/instanceTemplates_gen.go
+++ b/providers/gcp/instanceTemplates_gen.go
@@ -71,7 +71,6 @@ func (g *InstanceTemplatesGenerator) InitResources() error {
 	instanceTemplatesList := computeService.InstanceTemplates.List(g.GetArgs()["project"].(string))
 	g.Resources = g.createResources(ctx, instanceTemplatesList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/instances_gen.go
+++ b/providers/gcp/instances_gen.go
@@ -79,7 +79,6 @@ func (g *InstancesGenerator) InitResources() error {
 		g.Resources = append(g.Resources, g.createResources(ctx, instancesList, zone)...)
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/interconnectAttachments_gen.go
+++ b/providers/gcp/interconnectAttachments_gen.go
@@ -71,7 +71,6 @@ func (g *InterconnectAttachmentsGenerator) InitResources() error {
 	interconnectAttachmentsList := computeService.InterconnectAttachments.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
 	g.Resources = g.createResources(ctx, interconnectAttachmentsList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/kms.go
+++ b/providers/gcp/kms.go
@@ -97,7 +97,6 @@ func (g *KmsGenerator) InitResources() error {
 	keyRingList := kmsService.Projects.Locations.KeyRings.List("projects/" + g.GetArgs()["project"].(string) + "/locations/global")
 
 	g.Resources = g.createKmsRingResources(ctx, keyRingList, kmsService)
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/logging.go
+++ b/providers/gcp/logging.go
@@ -72,6 +72,5 @@ func (g *LoggingGenerator) InitResources() error {
 		return err
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/gcp/memoryStore.go
+++ b/providers/gcp/memoryStore.go
@@ -74,6 +74,5 @@ func (g *MemoryStoreGenerator) InitResources() error {
 	redisInstancesList := redisService.Projects.Locations.Instances.List("projects/" + g.GetArgs()["project"].(string) + "/locations/" + g.GetArgs()["region"].(compute.Region).Name)
 
 	g.Resources = g.createResources(redisInstancesList, ctx)
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/gcp/monitoring.go
+++ b/providers/gcp/monitoring.go
@@ -202,6 +202,5 @@ func (g *MonitoringGenerator) InitResources() error {
 		return err
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/gcp/networkEndpointGroups_gen.go
+++ b/providers/gcp/networkEndpointGroups_gen.go
@@ -77,7 +77,6 @@ func (g *NetworkEndpointGroupsGenerator) InitResources() error {
 		g.Resources = append(g.Resources, g.createResources(ctx, networkEndpointGroupsList, zone)...)
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/networks_gen.go
+++ b/providers/gcp/networks_gen.go
@@ -71,7 +71,6 @@ func (g *NetworksGenerator) InitResources() error {
 	networksList := computeService.Networks.List(g.GetArgs()["project"].(string))
 	g.Resources = g.createResources(ctx, networksList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/nodeGroups_gen.go
+++ b/providers/gcp/nodeGroups_gen.go
@@ -77,7 +77,6 @@ func (g *NodeGroupsGenerator) InitResources() error {
 		g.Resources = append(g.Resources, g.createResources(ctx, nodeGroupsList, zone)...)
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/nodeTemplates_gen.go
+++ b/providers/gcp/nodeTemplates_gen.go
@@ -71,7 +71,6 @@ func (g *NodeTemplatesGenerator) InitResources() error {
 	nodeTemplatesList := computeService.NodeTemplates.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
 	g.Resources = g.createResources(ctx, nodeTemplatesList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/project.go
+++ b/providers/gcp/project.go
@@ -40,6 +40,5 @@ func (g *ProjectGenerator) InitResources() error {
 		projectAdditionalFields,
 	))
 
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/gcp/pubsub.go
+++ b/providers/gcp/pubsub.go
@@ -103,7 +103,6 @@ func (g *PubsubGenerator) InitResources() error {
 	g.Resources = append(g.Resources, subscriptionsResources...)
 	g.Resources = append(g.Resources, topicsResources...)
 
-	g.PopulateIgnoreKeys()
 	return nil
 }
 

--- a/providers/gcp/regionAutoscalers_gen.go
+++ b/providers/gcp/regionAutoscalers_gen.go
@@ -71,7 +71,6 @@ func (g *RegionAutoscalersGenerator) InitResources() error {
 	regionAutoscalersList := computeService.RegionAutoscalers.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
 	g.Resources = g.createResources(ctx, regionAutoscalersList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/regionBackendServices_gen.go
+++ b/providers/gcp/regionBackendServices_gen.go
@@ -71,7 +71,6 @@ func (g *RegionBackendServicesGenerator) InitResources() error {
 	regionBackendServicesList := computeService.RegionBackendServices.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
 	g.Resources = g.createResources(ctx, regionBackendServicesList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/regionDisks_gen.go
+++ b/providers/gcp/regionDisks_gen.go
@@ -71,7 +71,6 @@ func (g *RegionDisksGenerator) InitResources() error {
 	regionDisksList := computeService.RegionDisks.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
 	g.Resources = g.createResources(ctx, regionDisksList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/regionInstanceGroupManagers_gen.go
+++ b/providers/gcp/regionInstanceGroupManagers_gen.go
@@ -71,7 +71,6 @@ func (g *RegionInstanceGroupManagersGenerator) InitResources() error {
 	regionInstanceGroupManagersList := computeService.RegionInstanceGroupManagers.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
 	g.Resources = g.createResources(ctx, regionInstanceGroupManagersList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/routers_gen.go
+++ b/providers/gcp/routers_gen.go
@@ -71,7 +71,6 @@ func (g *RoutersGenerator) InitResources() error {
 	routersList := computeService.Routers.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
 	g.Resources = g.createResources(ctx, routersList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/routes_gen.go
+++ b/providers/gcp/routes_gen.go
@@ -71,7 +71,6 @@ func (g *RoutesGenerator) InitResources() error {
 	routesList := computeService.Routes.List(g.GetArgs()["project"].(string))
 	g.Resources = g.createResources(ctx, routesList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/schedulerJobs.go
+++ b/providers/gcp/schedulerJobs.go
@@ -72,6 +72,5 @@ func (g *SchedulerJobsGenerator) InitResources() error {
 	jobsList := cloudSchedulerService.Projects.Locations.Jobs.List("projects/" + g.GetArgs()["project"].(string) + "/locations/" + g.GetArgs()["region"].(compute.Region).Name)
 
 	g.Resources = g.createResources(jobsList, ctx)
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/gcp/securityPolicies_gen.go
+++ b/providers/gcp/securityPolicies_gen.go
@@ -71,7 +71,6 @@ func (g *SecurityPoliciesGenerator) InitResources() error {
 	securityPoliciesList := computeService.SecurityPolicies.List(g.GetArgs()["project"].(string))
 	g.Resources = g.createResources(ctx, securityPoliciesList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/sslPolicies_gen.go
+++ b/providers/gcp/sslPolicies_gen.go
@@ -71,7 +71,6 @@ func (g *SslPoliciesGenerator) InitResources() error {
 	sslPoliciesList := computeService.SslPolicies.List(g.GetArgs()["project"].(string))
 	g.Resources = g.createResources(ctx, sslPoliciesList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/subnetworks_gen.go
+++ b/providers/gcp/subnetworks_gen.go
@@ -71,7 +71,6 @@ func (g *SubnetworksGenerator) InitResources() error {
 	subnetworksList := computeService.Subnetworks.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
 	g.Resources = g.createResources(ctx, subnetworksList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/targetHttpProxies_gen.go
+++ b/providers/gcp/targetHttpProxies_gen.go
@@ -71,7 +71,6 @@ func (g *TargetHttpProxiesGenerator) InitResources() error {
 	targetHttpProxiesList := computeService.TargetHttpProxies.List(g.GetArgs()["project"].(string))
 	g.Resources = g.createResources(ctx, targetHttpProxiesList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/targetHttpsProxies_gen.go
+++ b/providers/gcp/targetHttpsProxies_gen.go
@@ -71,7 +71,6 @@ func (g *TargetHttpsProxiesGenerator) InitResources() error {
 	targetHttpsProxiesList := computeService.TargetHttpsProxies.List(g.GetArgs()["project"].(string))
 	g.Resources = g.createResources(ctx, targetHttpsProxiesList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/targetInstances_gen.go
+++ b/providers/gcp/targetInstances_gen.go
@@ -77,7 +77,6 @@ func (g *TargetInstancesGenerator) InitResources() error {
 		g.Resources = append(g.Resources, g.createResources(ctx, targetInstancesList, zone)...)
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/targetPools_gen.go
+++ b/providers/gcp/targetPools_gen.go
@@ -71,7 +71,6 @@ func (g *TargetPoolsGenerator) InitResources() error {
 	targetPoolsList := computeService.TargetPools.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
 	g.Resources = g.createResources(ctx, targetPoolsList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/targetSslProxies_gen.go
+++ b/providers/gcp/targetSslProxies_gen.go
@@ -71,7 +71,6 @@ func (g *TargetSslProxiesGenerator) InitResources() error {
 	targetSslProxiesList := computeService.TargetSslProxies.List(g.GetArgs()["project"].(string))
 	g.Resources = g.createResources(ctx, targetSslProxiesList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/targetTcpProxies_gen.go
+++ b/providers/gcp/targetTcpProxies_gen.go
@@ -71,7 +71,6 @@ func (g *TargetTcpProxiesGenerator) InitResources() error {
 	targetTcpProxiesList := computeService.TargetTcpProxies.List(g.GetArgs()["project"].(string))
 	g.Resources = g.createResources(ctx, targetTcpProxiesList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/targetVpnGateways_gen.go
+++ b/providers/gcp/targetVpnGateways_gen.go
@@ -71,7 +71,6 @@ func (g *TargetVpnGatewaysGenerator) InitResources() error {
 	targetVpnGatewaysList := computeService.TargetVpnGateways.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
 	g.Resources = g.createResources(ctx, targetVpnGatewaysList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/urlMaps_gen.go
+++ b/providers/gcp/urlMaps_gen.go
@@ -71,7 +71,6 @@ func (g *UrlMapsGenerator) InitResources() error {
 	urlMapsList := computeService.UrlMaps.List(g.GetArgs()["project"].(string))
 	g.Resources = g.createResources(ctx, urlMapsList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/gcp/vpnTunnels_gen.go
+++ b/providers/gcp/vpnTunnels_gen.go
@@ -71,7 +71,6 @@ func (g *VpnTunnelsGenerator) InitResources() error {
 	vpnTunnelsList := computeService.VpnTunnels.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
 	g.Resources = g.createResources(ctx, vpnTunnelsList)
 
-	g.PopulateIgnoreKeys()
 	return nil
 
 }

--- a/providers/github/members.go
+++ b/providers/github/members.go
@@ -52,6 +52,5 @@ func (g *MembersGenerator) InitResources() error {
 			[]string{},
 		))
 	}
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/github/organizationWebhooks.go
+++ b/providers/github/organizationWebhooks.go
@@ -53,6 +53,5 @@ func (g *OrganizationWebhooksGenerator) InitResources() error {
 			[]string{},
 		))
 	}
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/github/repositories.go
+++ b/providers/github/repositories.go
@@ -68,7 +68,6 @@ func (g *RepositoriesGenerator) InitResources() error {
 		}
 		opt.Page = resp.NextPage
 	}
-	g.PopulateIgnoreKeys()
 
 	return nil
 }

--- a/providers/github/teams.go
+++ b/providers/github/teams.go
@@ -97,7 +97,6 @@ func (g *TeamsGenerator) InitResources() error {
 		return nil
 	}
 	g.Resources = g.createTeamsResources(ctx, teams, client)
-	g.PopulateIgnoreKeys()
 	return nil
 }
 

--- a/providers/kubernetes/kind.go
+++ b/providers/kubernetes/kind.go
@@ -87,6 +87,5 @@ func (k *Kind) InitResources() error {
 			[]string{},
 		))
 	}
-	k.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/logzio/alert_notification_endpoints.go
+++ b/providers/logzio/alert_notification_endpoints.go
@@ -44,6 +44,5 @@ func (g *AlertNotificationEndpointsGenerator) InitResources() error {
 			[]string{},
 		))
 	}
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/logzio/alerts.go
+++ b/providers/logzio/alerts.go
@@ -45,6 +45,5 @@ func (g *AlertsGenerator) InitResources() error {
 			allowedEmptyValues,
 		))
 	}
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/newrelic/alert.go
+++ b/providers/newrelic/alert.go
@@ -104,7 +104,6 @@ func (g *AlertGenerator) InitResources() error {
 		}
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 }
 

--- a/providers/newrelic/dashboard.go
+++ b/providers/newrelic/dashboard.go
@@ -53,7 +53,6 @@ func (g *DashboardGenerator) InitResources() error {
 		return err
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 }
 

--- a/providers/newrelic/infra.go
+++ b/providers/newrelic/infra.go
@@ -67,6 +67,5 @@ func (g *InfraGenerator) InitResources() error {
 		return err
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/newrelic/synthetics.go
+++ b/providers/newrelic/synthetics.go
@@ -99,6 +99,5 @@ func (g *SyntheticsGenerator) InitResources() error {
 		return err
 	}
 
-	g.PopulateIgnoreKeys()
 	return nil
 }

--- a/providers/openstack/blockstorage.go
+++ b/providers/openstack/blockstorage.go
@@ -116,7 +116,6 @@ func (g *BlockStorageGenerator) InitResources() error {
 	list := volumes.List(client, nil)
 
 	g.Resources = g.createResources(&list, client.Type)
-	g.PopulateIgnoreKeys()
 
 	return nil
 }

--- a/providers/openstack/compute.go
+++ b/providers/openstack/compute.go
@@ -78,7 +78,6 @@ func (g *ComputeGenerator) InitResources() error {
 	list := servers.List(client, nil)
 
 	g.Resources = g.createResources(&list)
-	g.PopulateIgnoreKeys()
 
 	return nil
 }

--- a/providers/openstack/networking.go
+++ b/providers/openstack/networking.go
@@ -93,7 +93,6 @@ func (g *NetworkingGenerator) InitResources() error {
 	list := groups.List(client, groups.ListOpts{})
 
 	g.Resources = g.createSecgroupResources(&list)
-	g.PopulateIgnoreKeys()
 
 	return nil
 }

--- a/terraform_utils/base_provider.go
+++ b/terraform_utils/base_provider.go
@@ -24,6 +24,7 @@ type ProviderGenerator interface {
 	GetName() string
 	GetService() ServiceGenerator
 	GetConfig() cty.Value
+	GetBasicConfig() cty.Value
 	GetSupportedService() map[string]ServiceGenerator
 	GenerateFiles()
 	GetProviderData(arg ...string) map[string]interface{}
@@ -66,4 +67,8 @@ func (p *Provider) GetService() ServiceGenerator {
 
 func (p *Provider) GetSupportedService() map[string]ServiceGenerator {
 	panic("implement me")
+}
+
+func (p *Provider) GetBasicConfig() cty.Value {
+	return cty.ObjectVal(map[string]cty.Value{})
 }

--- a/terraform_utils/service.go
+++ b/terraform_utils/service.go
@@ -15,6 +15,7 @@
 package terraform_utils
 
 import (
+	"github.com/zclconf/go-cty/cty"
 	"log"
 	"strings"
 )
@@ -31,6 +32,7 @@ type ServiceGenerator interface {
 	SetProviderName(name string)
 	GetName() string
 	CleanupWithFilter()
+	PopulateIgnoreKeys(cty.Value)
 }
 
 type Service struct {
@@ -104,12 +106,12 @@ func (s *Service) PostConvertHook() error {
 	return nil
 }
 
-func (s *Service) PopulateIgnoreKeys() {
+func (s *Service) PopulateIgnoreKeys(providerConfig cty.Value) {
 	resourcesTypes := []string{}
 	for _, r := range s.Resources {
 		resourcesTypes = append(resourcesTypes, r.InstanceInfo.Type)
 	}
-	keys := IgnoreKeys(resourcesTypes, s.ProviderName)
+	keys := IgnoreKeys(resourcesTypes, s.ProviderName, providerConfig)
 	for k, v := range keys {
 		for i := range s.Resources {
 			if s.Resources[i].InstanceInfo.Type == k {

--- a/terraform_utils/utils.go
+++ b/terraform_utils/utils.go
@@ -101,8 +101,8 @@ func RefreshResourceWorker(input chan *Resource, wg *sync.WaitGroup, provider *p
 	}
 }
 
-func IgnoreKeys(resourcesTypes []string, providerName string) map[string][]string {
-	p, err := provider_wrapper.NewProviderWrapper(providerName, cty.ObjectVal(map[string]cty.Value{}))
+func IgnoreKeys(resourcesTypes []string, providerName string, providerConfig cty.Value) map[string][]string {
+	p, err := provider_wrapper.NewProviderWrapper(providerName, providerConfig)
 	if err != nil {
 		log.Println("plugin error 1:", err)
 		return map[string][]string{}

--- a/tests/aws/main.go
+++ b/tests/aws/main.go
@@ -17,7 +17,7 @@ package main
 import (
 	"log"
 	"os"
-	//"os/exec"
+	"os/exec"
 	"sort"
 
 	"github.com/GoogleCloudPlatform/terraformer/cmd"
@@ -28,7 +28,7 @@ import (
 const command = "terraform init && terraform plan"
 
 func main() {
-	//region := "ap-southeast-1"
+	region := "ap-southeast-1"
 	profile := "personal"
 	services := []string{}
 	provider := &aws_terraforming.AWSProvider{}
@@ -45,7 +45,7 @@ func main() {
 		services = append(services, service)
 
 	}
-	services = []string{"cloudfront"}
+	services = []string{"vpc", "subnet", "nacl"}
 	sort.Strings(services)
 	provider = &aws_terraforming.AWSProvider{
 		Provider: terraform_utils.Provider{},
@@ -56,26 +56,26 @@ func main() {
 		PathOutput:  cmd.DefaultPathOutput,
 		State:       "local",
 		Connect:     true,
-	}, []string{"", profile})
+	}, []string{region, profile})
 	if err != nil {
 		log.Println(err)
 		os.Exit(1)
 	}
-	//rootPath, _ := os.Getwd()
-	//for _, serviceName := range services {
-	//	currentPath := cmd.Path(cmd.DefaultPathPattern, provider.GetName(), serviceName, cmd.DefaultPathOutput)
-	//	if err := os.Chdir(currentPath); err != nil {
-	//		log.Println(err)
-	//		os.Exit(1)
-	//	}
-	//	cmd := exec.Command("sh", "-c", command)
-	//	cmd.Stdout = os.Stdout
-	//	cmd.Stderr = os.Stderr
-	//	err = cmd.Run()
-	//	if err != nil {
-	//		log.Println(err)
-	//		os.Exit(1)
-	//	}
-	//	os.Chdir(rootPath)
-	//}
+	rootPath, _ := os.Getwd()
+	for _, serviceName := range services {
+		currentPath := cmd.Path(cmd.DefaultPathPattern, provider.GetName(), serviceName, cmd.DefaultPathOutput)
+		if err := os.Chdir(currentPath); err != nil {
+			log.Println(err)
+			os.Exit(1)
+		}
+		cmd := exec.Command("sh", "-c", command)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err = cmd.Run()
+		if err != nil {
+			log.Println(err)
+			os.Exit(1)
+		}
+		os.Chdir(rootPath)
+	}
 }

--- a/tests/aws/main.go
+++ b/tests/aws/main.go
@@ -17,7 +17,7 @@ package main
 import (
 	"log"
 	"os"
-	"os/exec"
+	//"os/exec"
 	"sort"
 
 	"github.com/GoogleCloudPlatform/terraformer/cmd"
@@ -28,7 +28,7 @@ import (
 const command = "terraform init && terraform plan"
 
 func main() {
-	region := "ap-southeast-1"
+	//region := "ap-southeast-1"
 	profile := "personal"
 	services := []string{}
 	provider := &aws_terraforming.AWSProvider{}
@@ -45,7 +45,7 @@ func main() {
 		services = append(services, service)
 
 	}
-	services = []string{"vpc", "subnet", "nacl"}
+	services = []string{"cloudfront"}
 	sort.Strings(services)
 	provider = &aws_terraforming.AWSProvider{
 		Provider: terraform_utils.Provider{},
@@ -56,26 +56,26 @@ func main() {
 		PathOutput:  cmd.DefaultPathOutput,
 		State:       "local",
 		Connect:     true,
-	}, []string{region, profile})
+	}, []string{"", profile})
 	if err != nil {
 		log.Println(err)
 		os.Exit(1)
 	}
-	rootPath, _ := os.Getwd()
-	for _, serviceName := range services {
-		currentPath := cmd.Path(cmd.DefaultPathPattern, provider.GetName(), serviceName, cmd.DefaultPathOutput)
-		if err := os.Chdir(currentPath); err != nil {
-			log.Println(err)
-			os.Exit(1)
-		}
-		cmd := exec.Command("sh", "-c", command)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		err = cmd.Run()
-		if err != nil {
-			log.Println(err)
-			os.Exit(1)
-		}
-		os.Chdir(rootPath)
-	}
+	//rootPath, _ := os.Getwd()
+	//for _, serviceName := range services {
+	//	currentPath := cmd.Path(cmd.DefaultPathPattern, provider.GetName(), serviceName, cmd.DefaultPathOutput)
+	//	if err := os.Chdir(currentPath); err != nil {
+	//		log.Println(err)
+	//		os.Exit(1)
+	//	}
+	//	cmd := exec.Command("sh", "-c", command)
+	//	cmd.Stdout = os.Stdout
+	//	cmd.Stderr = os.Stderr
+	//	err = cmd.Run()
+	//	if err != nil {
+	//		log.Println(err)
+	//		os.Exit(1)
+	//	}
+	//	os.Chdir(rootPath)
+	//}
 }


### PR DESCRIPTION
Now it's required to pass `resources` parameter for all providers.

In case of Google provider - it's required to pass `projects` parameter.

In case of AWS provider - it should be possible to make use of implicit AWS region to be imported if no `regions` parameter is provided. 