### PR TITLE
fix: add Datadog dashboard service in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,8 @@ List of supported Datadog services:
     * `datadog_downtime`
 * `monitor`
     * `datadog_monitor`
+* `dashboard`
+    * `datadog_dashboard`
 * `screenboard`
     * `datadog_screenboard`
 * `synthetics`


### PR DESCRIPTION
Add the new `Datadog dashboard service` in the readme. 

Dashboard endpoint in Datadog API unifies screenboard and timeboard APIs.