### PR TITLE
Support Heroku provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A CLI tool that generates `tf` and `tfstate` files based on existing infrastruct
     * [Cloudflare](#use-with-cloudflare)
     * [Logzio](#use-with-logzio)
     * [NewRelic](#use-with-newrelic)
+    * [Heroku](#use-with-heroku)
 - [Contributing](#contributing)
 - [Developing](#developing)
 - [Infrastructure](#infrastructure)
@@ -593,6 +594,22 @@ List of supported NewRelic resources:
 * `synthetics`
     * `newrelic_synthetics_monitor`
     * `newrelic_synthetics_alert_condition`
+
+### Use with Heroku
+Example:
+
+```
+export HEROKU_EMAIL=[HEROKU_EMAIL]
+export HEROKU_API_KEY=[HEROKU_API_KEY]
+./terraformer import heroku -r app,addon
+```
+
+List of supported Heroku resources:
+
+* `addon`
+    * `heroku_addon`
+* `app`
+    * `heroku_app`
 
 ## Contributing
 

--- a/cmd/heroku.go
+++ b/cmd/heroku.go
@@ -1,0 +1,52 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cmd
+
+import (
+	heroku_terraforming "github.com/GoogleCloudPlatform/terraformer/providers/heroku"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/spf13/cobra"
+)
+
+func newCmdHerokuImporter(options ImportOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "heroku",
+		Short: "Import current State to terraform configuration from Heroku",
+		Long:  "Import current State to terraform configuration from Heroku",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			provider := newHerokuProvider()
+			err := Import(provider, options, []string{})
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.AddCommand(listCmd(newHerokuProvider()))
+	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
+	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "app,addon")
+	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
+	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
+	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
+	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
+	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "heroku_app=name1:name2:name3")
+
+	return cmd
+}
+
+func newHerokuProvider() terraform_utils.ProviderGenerator {
+	return &heroku_terraforming.HerokuProvider{}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,6 +47,7 @@ func providerImporterSubcommands() []func(options ImportOptions) *cobra.Command 
 		newCmdCloudflareImporter,
 		newCmdLogzioImporter,
 		newCmdNewRelicImporter,
+		newCmdHerokuImporter,
 	}
 }
 
@@ -61,6 +62,7 @@ func providerGenerators() map[string]func() terraform_utils.ProviderGenerator {
 		newDataDogProvider,
 		newLogzioProvider,
 		newNewRelicProvider,
+		newHerokuProvider,
 	} {
 		list[providerGen().GetName()] = providerGen
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.13
 require (
 	cloud.google.com/go v0.36.0
 	github.com/aws/aws-sdk-go v1.22.0
-	github.com/cenkalti/backoff v2.1.1+incompatible // indirect
 	github.com/cloudflare/cloudflare-go v0.9.4
 	github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142 // indirect
 	github.com/dollarshaveclub/new-relic-synthetics-go v0.0.0-20170605224734-4dc3dd6ae884
@@ -20,6 +19,7 @@ require (
 	github.com/hashicorp/hcl v1.0.1-0.20190611123218-cf7d376da96d
 	github.com/hashicorp/hcl2 v0.0.0-20190821123243-0c888d1241f6
 	github.com/hashicorp/terraform v0.12.8
+	github.com/heroku/heroku-go/v5 v5.1.0
 	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c // indirect
 	github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365
 	github.com/imdario/mergo v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -216,6 +216,7 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
+github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v0.0.0-20161107002406-da06d194a00e/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
@@ -355,6 +356,9 @@ github.com/hashicorp/vault v0.10.4/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bA
 github.com/hashicorp/yamux v0.0.0-20160720233140-d1caa6c97c9f/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/heroku/heroku-go v5.1.0+incompatible h1:iUIrzlb/imNcjEWDwC+L4Shsd0MqPaIHPyuANtUwNu8=
+github.com/heroku/heroku-go/v5 v5.1.0 h1:3Qx1MxjzczSakhAZN4yRsvCI7kP0ldijK1XvfoYa4DE=
+github.com/heroku/heroku-go/v5 v5.1.0/go.mod h1:d+1QrZyjbnQJG1f8xIoVvMQRFLt3XRVZOdlm26Sr73U=
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c h1:kQWxfPIHVLbgLzphqk3QUflDy9QdksZR4ygR807bpy0=
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
@@ -365,6 +369,7 @@ github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/interagent/schematic v0.0.0-20180830170528-b5e8ba7aa570/go.mod h1:4X9u5iNUePRrRDdwjok6skjlQBXTcNfWa4C3uS1+5SQ=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -512,6 +517,8 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c h1:Lgl0gzECD8GnQ5
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/paultyng/go-newrelic v3.1.0+incompatible h1:Rk4tqa9X79e8mII/Wb2LkhTRdkr7N+YtaGtMY5IxdwE=
 github.com/paultyng/go-newrelic v3.1.0+incompatible/go.mod h1:6qjEGgk2sMkCb981StHKqGU65WZqOrLtxX6LZwRAyZo=
+github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
+github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.0.0-20170505043639-c605e284fe17/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/providers/heroku/addon.go
+++ b/providers/heroku/addon.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package heroku
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	heroku "github.com/heroku/heroku-go/v5"
+)
+
+type AddonGenerator struct {
+	HerokuService
+}
+
+func (g AddonGenerator) createResources(addOnList []heroku.AddOn) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, addOn := range addOnList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			addOn.ID,
+			addOn.Name,
+			"heroku_addon",
+			"heroku",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *AddonGenerator) InitResources() error {
+	svc := g.generateService()
+	output, err := svc.AddOnList(context.TODO(), &heroku.ListRange{Field: "id"})
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/heroku/app.go
+++ b/providers/heroku/app.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package heroku
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	heroku "github.com/heroku/heroku-go/v5"
+)
+
+type AppGenerator struct {
+	HerokuService
+}
+
+func (g AppGenerator) createResources(appList []heroku.App) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, app := range appList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			app.ID,
+			app.Name,
+			"heroku_app",
+			"heroku",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *AppGenerator) InitResources() error {
+	svc := g.generateService()
+	output, err := svc.AppList(context.TODO(), &heroku.ListRange{Field: "id"})
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/heroku/heroku_provider.go
+++ b/providers/heroku/heroku_provider.go
@@ -1,0 +1,86 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package heroku
+
+import (
+	"errors"
+	"os"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+)
+
+const herokuProviderVersion = "~> 2.2.1"
+
+type HerokuProvider struct {
+	terraform_utils.Provider
+	email  string
+	apiKey string
+}
+
+func (p *HerokuProvider) Init(args []string) error {
+	if os.Getenv("HEROKU_EMAIL") == "" {
+		return errors.New("set HEROKU_EMAIL env var")
+	}
+	p.email = os.Getenv("HEROKU_EMAIL")
+
+	if os.Getenv("HEROKU_API_KEY") == "" {
+		return errors.New("set HEROKU_API_KEY env var")
+	}
+	p.apiKey = os.Getenv("HEROKU_API_KEY")
+
+	return nil
+}
+
+func (p *HerokuProvider) GetName() string {
+	return "heroku"
+}
+
+func (p *HerokuProvider) GetProviderData(arg ...string) map[string]interface{} {
+	return map[string]interface{}{
+		"provider": map[string]interface{}{
+			"heroku": map[string]interface{}{
+				"version": herokuProviderVersion,
+				"email":   p.email,
+				"api_key": p.apiKey,
+			},
+		},
+	}
+}
+
+func (HerokuProvider) GetResourceConnections() map[string]map[string][]string {
+	return map[string]map[string][]string{}
+}
+
+func (p *HerokuProvider) GetSupportedService() map[string]terraform_utils.ServiceGenerator {
+	return map[string]terraform_utils.ServiceGenerator{
+		"app":   &AppGenerator{},
+		"addon": &AddonGenerator{},
+	}
+}
+
+func (p *HerokuProvider) InitService(serviceName string) error {
+	var isSupported bool
+	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+		return errors.New("heroku: " + serviceName + " not supported service")
+	}
+	p.Service = p.GetSupportedService()[serviceName]
+	p.Service.SetName(serviceName)
+	p.Service.SetProviderName(p.GetName())
+	p.Service.SetArgs(map[string]interface{}{
+		"email":   p.email,
+		"api_key": p.apiKey,
+	})
+	return nil
+}

--- a/providers/heroku/heroku_service.go
+++ b/providers/heroku/heroku_service.go
@@ -1,0 +1,30 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package heroku
+
+import (
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	heroku "github.com/heroku/heroku-go/v5"
+)
+
+type HerokuService struct {
+	terraform_utils.Service
+}
+
+func (s *HerokuService) generateService() *heroku.Service {
+	heroku.DefaultTransport.Username = s.Args["email"].(string)
+	heroku.DefaultTransport.Password = s.Args["api_key"].(string)
+	return heroku.NewService(heroku.DefaultClient)
+}


### PR DESCRIPTION
Adds support for the [Heroku provider](https://www.terraform.io/docs/providers/heroku/index.html). Also adds the following resources:

- [`heroku_app`](https://www.terraform.io/docs/providers/heroku/r/app.html)
- [`heroku_addon`](https://www.terraform.io/docs/providers/heroku/r/addon.html)