### PR TITLE
Add AWS Elastic IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,8 @@ List of supported AWS services:
     * `aws_cloudfront_distribution`
 *   `ec2_instance`
     * `aws_instance`
+*   `eip`
+    * `aws_eip`
 *   `firehose`
     * `aws_kinesis_firehose_delivery_stream`
 *   `glue`

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -194,6 +194,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraform_utils.ServiceGe
 		"acm":            &ACMGenerator{},
 		"cloudfront":     &CloudFrontGenerator{},
 		"ec2_instance":   &Ec2Generator{},
+		"eip":            &ElasticIpGenerator{},
 		"firehose":       &FirehoseGenerator{},
 		"glue":           &GlueGenerator{},
 		"route_table":    &RouteTableGenerator{},

--- a/providers/aws/eip.go
+++ b/providers/aws/eip.go
@@ -1,0 +1,62 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"log"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+var eipAllowEmptyValues = []string{"tags."}
+
+type ElasticIpGenerator struct {
+	AWSService
+}
+
+func (g ElasticIpGenerator) createElasticIpsResources(svc *ec2.EC2) []terraform_utils.Resource {
+	resources := []terraform_utils.Resource{}
+	addresses, err := svc.DescribeAddresses(&ec2.DescribeAddressesInput{})
+
+	if err != nil {
+		log.Println(err)
+		return resources
+	}
+
+	for _, eip := range addresses.Addresses {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			aws.StringValue(eip.AllocationId),
+			aws.StringValue(eip.AllocationId),
+			"aws_eip",
+			"aws",
+			eipAllowEmptyValues,
+		))
+	}
+
+	return resources
+}
+
+// Generate TerraformResources from AWS API,
+// create terraform resource for each elastic IPs
+func (g *ElasticIpGenerator) InitResources() error {
+	sess := g.generateSession()
+	svc := ec2.New(sess)
+
+	g.Resources = g.createElasticIpsResources(svc)
+	return nil
+}


### PR DESCRIPTION
This PR adds support for importing [`aws_eip` resource](https://www.terraform.io/docs/providers/aws/r/eip.html) which corresponds to [Elastic IP](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html) allocation on AWS.