### PR TITLE
Add AWS VPC Peering Connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,8 @@ List of supported AWS services:
     * `aws_subnet`
 *   `vpc`
     * `aws_vpc`
+*   `vpc_peering`
+    * `aws_vpc_peering_connection`
 *   `vpn_connection`
     * `aws_vpn_connection`
 *   `vpn_gateway`

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -177,6 +177,7 @@ func (p *AWSProvider) InitService(serviceName string) error {
 func (p *AWSProvider) GetSupportedService() map[string]terraform_utils.ServiceGenerator {
 	return map[string]terraform_utils.ServiceGenerator{
 		"vpc":            &VpcGenerator{},
+		"vpc_peering":    &VpcPeeringConnectionGenerator{},
 		"sg":             &SecurityGenerator{},
 		"subnet":         &SubnetGenerator{},
 		"igw":            &IgwGenerator{},

--- a/providers/aws/vpc_peering.go
+++ b/providers/aws/vpc_peering.go
@@ -23,7 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
-var ngwAllowEmptyValues = []string{"tags."}
+var peeringAllowEmptyValues = []string{"tags."}
 
 type VpcPeeringConnectionGenerator struct {
 	AWSService
@@ -33,14 +33,14 @@ func (g VpcPeeringConnectionGenerator) createVpcPeeringConnectionsResources(svc 
 	resources := []terraform_utils.Resource{}
 	err := svc.DescribeVpcPeeringConnectionsPages(
 		&ec2.DescribeVpcPeeringConnectionsInput{},
-		func(ngws *ec2.DescribeVpcPeeringConnectionsOutput, lastPage bool) bool {
-			for _, ngw := range ngws.VpcPeeringConnections {
+		func(peerings *ec2.DescribeVpcPeeringConnectionsOutput, lastPage bool) bool {
+			for _, peering := range peerings.VpcPeeringConnections {
 				resources = append(resources, terraform_utils.NewSimpleResource(
-					aws.StringValue(ngw.VpcPeeringConnectionId),
-					aws.StringValue(ngw.VpcPeeringConnectionId),
+					aws.StringValue(peering.VpcPeeringConnectionId),
+					aws.StringValue(peering.VpcPeeringConnectionId),
 					"aws_vpc_peering_connection",
 					"aws",
-					ngwAllowEmptyValues,
+					peeringAllowEmptyValues,
 				))
 			}
 			return true

--- a/providers/aws/vpc_peering.go
+++ b/providers/aws/vpc_peering.go
@@ -1,0 +1,66 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"log"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+var ngwAllowEmptyValues = []string{"tags."}
+
+type VpcPeeringConnectionGenerator struct {
+	AWSService
+}
+
+func (g VpcPeeringConnectionGenerator) createVpcPeeringConnectionsResources(svc *ec2.EC2) []terraform_utils.Resource {
+	resources := []terraform_utils.Resource{}
+	err := svc.DescribeVpcPeeringConnectionsPages(
+		&ec2.DescribeVpcPeeringConnectionsInput{},
+		func(ngws *ec2.DescribeVpcPeeringConnectionsOutput, lastPage bool) bool {
+			for _, ngw := range ngws.VpcPeeringConnections {
+				resources = append(resources, terraform_utils.NewSimpleResource(
+					aws.StringValue(ngw.VpcPeeringConnectionId),
+					aws.StringValue(ngw.VpcPeeringConnectionId),
+					"aws_vpc_peering_connection",
+					"aws",
+					ngwAllowEmptyValues,
+				))
+			}
+			return true
+		},
+	)
+
+	if err != nil {
+		log.Println(err)
+		return resources
+	}
+
+	return resources
+}
+
+// Generate TerraformResources from AWS API,
+// create terraform resource for each VPC Peering Connection
+func (g *VpcPeeringConnectionGenerator) InitResources() error {
+	sess := g.generateSession()
+	svc := ec2.New(sess)
+
+	g.Resources = g.createVpcPeeringConnectionsResources(svc)
+	return nil
+}


### PR DESCRIPTION
This PR adds support for importing [`aws_vpc_peering_connection ` resource](https://www.terraform.io/docs/providers/aws/r/vpc_peering.html) which corresponds to [VPC Peering](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-peering.html) connection on AWS.