### PR TITLE
import AWS global resources only once

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,14 @@ List of supported AWS services:
 * `kinesis`
     * `aws_kinesis_stream`
 
+AWS services that are global will be imported without specified region even if several regions will be passed. It is to ensure only one representation of an AWS resource is imported.
+
+List of global AWS services:
+*   `iam`
+*   `route53`
+*   `cloudfront`
+*   `organization`
+
 ### Use with OpenStack
 
 Example:

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -21,29 +21,41 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// global resources should be bound to a default region. AWS doesn't specify in which region default services are
+// placed (see  https://docs.aws.amazon.com/general/latest/gr/rande.html), so we shouldn't assume any region as well
+var supportedGlobalResources = []string{"iam", "route53", "cloudfront", "organization"}
+
+const defaultRegion = ""
+
 func newCmdAwsImporter(options ImportOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "aws",
 		Short: "Import current State to terraform configuration from aws",
 		Long:  "Import current State to terraform configuration from aws",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			originalResources := options.Resources
+			originalRegions := options.Regions
 			originalPathPattern := options.PathPattern
-			if len(options.Regions) == 0 {
-				provider := newAWSProvider()
-				log.Println(provider.GetName() + " importing default region")
-				err := Import(provider, options, []string{"", options.Profile})
-				if err != nil {
-					return err
-				}
-			}
 
-			for _, region := range options.Regions {
-				provider := newAWSProvider()
-				options.PathPattern = originalPathPattern
-				options.PathPattern += region + "/"
-				log.Println(provider.GetName() + " importing region " + region)
-				profile := options.Profile
-				err := Import(provider, options, []string{region, profile})
+			if len(options.Regions) > 0 {
+				options.Resources = parseGlobalResources(originalResources)
+				options.Regions = []string{defaultRegion}
+				e := importGlobalResources(options)
+				if e != nil {
+					return e
+				}
+
+				options.Resources = parseRegionalResources(originalResources)
+				options.Regions = originalRegions
+				for _, region := range originalRegions {
+					e := importRegionResources(options, originalPathPattern, region)
+					if e != nil {
+						return e
+					}
+				}
+				return nil
+			} else {
+				err := importRegionResources(options, options.PathPattern, defaultRegion)
 				if err != nil {
 					return err
 				}
@@ -64,6 +76,59 @@ func newCmdAwsImporter(options ImportOptions) *cobra.Command {
 	return cmd
 }
 
+func parseGlobalResources(allResources []string) []string {
+	var globalResources []string
+	for _, resourceName := range allResources {
+		if contains(supportedGlobalResources, resourceName) {
+			globalResources = append(globalResources, resourceName)
+		}
+	}
+	return globalResources
+}
+
+func importGlobalResources(options ImportOptions) error {
+	if len(options.Resources) > 0 {
+		return importRegionResources(options, options.PathPattern, defaultRegion)
+	} else {
+		return nil
+	}
+}
+
+func parseRegionalResources(allResources []string) []string {
+	var localResources []string
+	for _, resourceName := range allResources {
+		if !contains(supportedGlobalResources, resourceName) {
+			localResources = append(localResources, resourceName)
+		}
+	}
+	return localResources
+}
+
+func importRegionResources(options ImportOptions, originalPathPattern string, region string) error {
+	provider := newAWSProvider()
+	options.PathPattern = originalPathPattern
+	if region != "" {
+		options.PathPattern += region + "/"
+		log.Println(provider.GetName() + " importing region " + region)
+	} else {
+		log.Println(provider.GetName() + " importing default region")
+	}
+	err := Import(provider, options, []string{region, options.Profile})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func newAWSProvider() terraform_utils.ProviderGenerator {
 	return &aws_terraforming.AWSProvider{}
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
We should import global resources only once, without bounding with a specific region, as described in AWS docs (https://docs.amazonaws.cn/en_us/general/latest/gr/rande.html):
_Some services, such as IAM, do not support Regions. Thus, the endpoints for those services do not include a Region._

Ref #211 