### PR TITLE
Add support for Heroku resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Links to download terraform providers:
 * datadog provider >2.1.0 - [here](https://releases.hashicorp.com/terraform-provider-datadog/)
 * cloudflare provider >1.16 - [here](https://releases.hashicorp.com/terraform-provider-cloudflare/)
 * logzio provider >=1.1.1 - [here](https://github.com/jonboydell/logzio_terraform_provider/)
+* heroku provider >2.2.1 - [here](https://releases.hashicorp.com/terraform-provider-heroku/)
 
 Information on provider plugins:
 https://www.terraform.io/docs/configuration/providers.html
@@ -645,10 +646,36 @@ export HEROKU_API_KEY=[HEROKU_API_KEY]
 
 List of supported Heroku resources:
 
+* `account_feature`
+    * `heroku_account_feature`
 * `addon`
     * `heroku_addon`
+* `addon_attachment`
+    * `heroku_addon_attachment`
 * `app`
     * `heroku_app`
+* `app_config_association`
+    * `heroku_app_config_association`
+* `app_feature`
+    * `heroku_app_feature`
+* `app_webhook`
+    * `heroku_app_webhook`
+* `build`
+    * `heroku_build`
+* `domain`
+    * `heroku_domain`
+* `drain`
+    * `heroku_drain`
+* `formation`
+    * `heroku_formation`
+* `pipeline`
+    * `heroku_pipeline`
+* `pipeline_coupling`
+    * `heroku_pipeline_coupling`
+* `team_collaborator`
+    * `heroku_team_collaborator`
+* `team_member`
+    * `heroku_team_member`
 
 ## Contributing
 

--- a/providers/heroku/account_feature.go
+++ b/providers/heroku/account_feature.go
@@ -21,26 +21,28 @@ import (
 	heroku "github.com/heroku/heroku-go/v5"
 )
 
-type AddOnGenerator struct {
+type AccountFeatureGenerator struct {
 	HerokuService
 }
 
-func (g AddOnGenerator) createResources(addOnList []heroku.AddOn) []terraform_utils.Resource {
+func (g AccountFeatureGenerator) createResources(accountFeatureList []heroku.AccountFeature) []terraform_utils.Resource {
 	var resources []terraform_utils.Resource
-	for _, addOn := range addOnList {
-		resources = append(resources, terraform_utils.NewSimpleResource(
-			addOn.ID,
-			addOn.Name,
-			"heroku_addon",
+	for _, accountFeature := range accountFeatureList {
+		resources = append(resources, terraform_utils.NewResource(
+			accountFeature.ID,
+			accountFeature.Name,
+			"heroku_account_feature",
 			"heroku",
-			[]string{}))
+			map[string]string{"name": accountFeature.Name},
+			[]string{},
+			map[string]interface{}{}))
 	}
 	return resources
 }
 
-func (g *AddOnGenerator) InitResources() error {
+func (g *AccountFeatureGenerator) InitResources() error {
 	svc := g.generateService()
-	output, err := svc.AddOnList(context.TODO(), &heroku.ListRange{Field: "id"})
+	output, err := svc.AccountFeatureList(context.TODO(), &heroku.ListRange{Field: "id"})
 	if err != nil {
 		return err
 	}

--- a/providers/heroku/addon_attachment.go
+++ b/providers/heroku/addon_attachment.go
@@ -21,26 +21,26 @@ import (
 	heroku "github.com/heroku/heroku-go/v5"
 )
 
-type AddOnGenerator struct {
+type AddOnAttachmentGenerator struct {
 	HerokuService
 }
 
-func (g AddOnGenerator) createResources(addOnList []heroku.AddOn) []terraform_utils.Resource {
+func (g AddOnAttachmentGenerator) createResources(addOnAttachmentList []heroku.AddOnAttachment) []terraform_utils.Resource {
 	var resources []terraform_utils.Resource
-	for _, addOn := range addOnList {
+	for _, addOnAttachment := range addOnAttachmentList {
 		resources = append(resources, terraform_utils.NewSimpleResource(
-			addOn.ID,
-			addOn.Name,
-			"heroku_addon",
+			addOnAttachment.ID,
+			addOnAttachment.Name,
+			"heroku_addon_attachment",
 			"heroku",
 			[]string{}))
 	}
 	return resources
 }
 
-func (g *AddOnGenerator) InitResources() error {
+func (g *AddOnAttachmentGenerator) InitResources() error {
 	svc := g.generateService()
-	output, err := svc.AddOnList(context.TODO(), &heroku.ListRange{Field: "id"})
+	output, err := svc.AddOnAttachmentList(context.TODO(), &heroku.ListRange{Field: "id"})
 	if err != nil {
 		return err
 	}

--- a/providers/heroku/app_config_association.go
+++ b/providers/heroku/app_config_association.go
@@ -1,0 +1,63 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package heroku
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	heroku "github.com/heroku/heroku-go/v5"
+)
+
+type AppConfigAssociationGenerator struct {
+	HerokuService
+}
+
+func (g AppConfigAssociationGenerator) createResources(svc *heroku.Service, appList []heroku.App) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, app := range appList {
+		output, err := svc.ConfigVarInfoForApp(context.TODO(), app.ID)
+		if err != nil {
+			log.Println(err)
+		}
+		resources = append(resources, terraform_utils.NewResource(
+			fmt.Sprintf("%s-config-association", app.Name),
+			fmt.Sprintf("%s-config-association", app.Name),
+			"heroku_app_config_association",
+			"heroku",
+			map[string]string{
+				"app_id": app.ID,
+			},
+			[]string{},
+			map[string]interface{}{
+				// since Heroku does not distinguish between non-sensitive and sensitive config variables, set output to vars
+				"vars":           output,
+				"sensitive_vars": map[string]interface{}{},
+			}))
+	}
+	return resources
+}
+
+func (g *AppConfigAssociationGenerator) InitResources() error {
+	svc := g.generateService()
+	output, err := svc.AppList(context.TODO(), &heroku.ListRange{Field: "id"})
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(svc, output)
+	return nil
+}

--- a/providers/heroku/app_feature.go
+++ b/providers/heroku/app_feature.go
@@ -16,34 +16,42 @@ package heroku
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 	heroku "github.com/heroku/heroku-go/v5"
 )
 
-type AddOnGenerator struct {
+type AppFeatureGenerator struct {
 	HerokuService
 }
 
-func (g AddOnGenerator) createResources(addOnList []heroku.AddOn) []terraform_utils.Resource {
+func (g AppFeatureGenerator) createResources(svc *heroku.Service, appList []heroku.App) []terraform_utils.Resource {
 	var resources []terraform_utils.Resource
-	for _, addOn := range addOnList {
-		resources = append(resources, terraform_utils.NewSimpleResource(
-			addOn.ID,
-			addOn.Name,
-			"heroku_addon",
-			"heroku",
-			[]string{}))
+	for _, app := range appList {
+		output, err := svc.AppFeatureList(context.TODO(), app.ID, &heroku.ListRange{Field: "id"})
+		if err != nil {
+			log.Println(err)
+		}
+		for _, appFeature := range output {
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				fmt.Sprintf("%s:%s", app.Name, appFeature.ID),
+				appFeature.Name,
+				"heroku_app_feature",
+				"heroku",
+				[]string{}))
+		}
 	}
 	return resources
 }
 
-func (g *AddOnGenerator) InitResources() error {
+func (g *AppFeatureGenerator) InitResources() error {
 	svc := g.generateService()
-	output, err := svc.AddOnList(context.TODO(), &heroku.ListRange{Field: "id"})
+	output, err := svc.AppList(context.TODO(), &heroku.ListRange{Field: "id"})
 	if err != nil {
 		return err
 	}
-	g.Resources = g.createResources(output)
+	g.Resources = g.createResources(svc, output)
 	return nil
 }

--- a/providers/heroku/build.go
+++ b/providers/heroku/build.go
@@ -16,34 +16,43 @@ package heroku
 
 import (
 	"context"
+	"log"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 	heroku "github.com/heroku/heroku-go/v5"
 )
 
-type AddOnGenerator struct {
+type BuildGenerator struct {
 	HerokuService
 }
 
-func (g AddOnGenerator) createResources(addOnList []heroku.AddOn) []terraform_utils.Resource {
+func (g BuildGenerator) createResources(svc *heroku.Service, appList []heroku.App) []terraform_utils.Resource {
 	var resources []terraform_utils.Resource
-	for _, addOn := range addOnList {
-		resources = append(resources, terraform_utils.NewSimpleResource(
-			addOn.ID,
-			addOn.Name,
-			"heroku_addon",
-			"heroku",
-			[]string{}))
+	for _, app := range appList {
+		output, err := svc.BuildList(context.TODO(), app.ID, &heroku.ListRange{Field: "id"})
+		if err != nil {
+			log.Println(err)
+		}
+		for _, build := range output {
+			resources = append(resources, terraform_utils.NewResource(
+				build.ID,
+				build.ID,
+				"heroku_build",
+				"heroku",
+				map[string]string{"app": app.Name},
+				[]string{},
+				map[string]interface{}{}))
+		}
 	}
 	return resources
 }
 
-func (g *AddOnGenerator) InitResources() error {
+func (g *BuildGenerator) InitResources() error {
 	svc := g.generateService()
-	output, err := svc.AddOnList(context.TODO(), &heroku.ListRange{Field: "id"})
+	output, err := svc.AppList(context.TODO(), &heroku.ListRange{Field: "id"})
 	if err != nil {
 		return err
 	}
-	g.Resources = g.createResources(output)
+	g.Resources = g.createResources(svc, output)
 	return nil
 }

--- a/providers/heroku/domain.go
+++ b/providers/heroku/domain.go
@@ -16,34 +16,43 @@ package heroku
 
 import (
 	"context"
+	"log"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 	heroku "github.com/heroku/heroku-go/v5"
 )
 
-type AddOnGenerator struct {
+type DomainGenerator struct {
 	HerokuService
 }
 
-func (g AddOnGenerator) createResources(addOnList []heroku.AddOn) []terraform_utils.Resource {
+func (g DomainGenerator) createResources(svc *heroku.Service, appList []heroku.App) []terraform_utils.Resource {
 	var resources []terraform_utils.Resource
-	for _, addOn := range addOnList {
-		resources = append(resources, terraform_utils.NewSimpleResource(
-			addOn.ID,
-			addOn.Name,
-			"heroku_addon",
-			"heroku",
-			[]string{}))
+	for _, app := range appList {
+		output, err := svc.DomainList(context.TODO(), app.ID, &heroku.ListRange{Field: "id"})
+		if err != nil {
+			log.Println(err)
+		}
+		for _, domain := range output {
+			resources = append(resources, terraform_utils.NewResource(
+				domain.ID,
+				domain.ID,
+				"heroku_domain",
+				"heroku",
+				map[string]string{"app": app.Name},
+				[]string{},
+				map[string]interface{}{}))
+		}
 	}
 	return resources
 }
 
-func (g *AddOnGenerator) InitResources() error {
+func (g *DomainGenerator) InitResources() error {
 	svc := g.generateService()
-	output, err := svc.AddOnList(context.TODO(), &heroku.ListRange{Field: "id"})
+	output, err := svc.AppList(context.TODO(), &heroku.ListRange{Field: "id"})
 	if err != nil {
 		return err
 	}
-	g.Resources = g.createResources(output)
+	g.Resources = g.createResources(svc, output)
 	return nil
 }

--- a/providers/heroku/formation.go
+++ b/providers/heroku/formation.go
@@ -16,34 +16,43 @@ package heroku
 
 import (
 	"context"
+	"log"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 	heroku "github.com/heroku/heroku-go/v5"
 )
 
-type AddOnGenerator struct {
+type FormationGenerator struct {
 	HerokuService
 }
 
-func (g AddOnGenerator) createResources(addOnList []heroku.AddOn) []terraform_utils.Resource {
+func (g FormationGenerator) createResources(svc *heroku.Service, appList []heroku.App) []terraform_utils.Resource {
 	var resources []terraform_utils.Resource
-	for _, addOn := range addOnList {
-		resources = append(resources, terraform_utils.NewSimpleResource(
-			addOn.ID,
-			addOn.Name,
-			"heroku_addon",
-			"heroku",
-			[]string{}))
+	for _, app := range appList {
+		output, err := svc.FormationList(context.TODO(), app.ID, &heroku.ListRange{Field: "id"})
+		if err != nil {
+			log.Println(err)
+		}
+		for _, formation := range output {
+			resources = append(resources, terraform_utils.NewResource(
+				formation.ID,
+				formation.ID,
+				"heroku_formation",
+				"heroku",
+				map[string]string{"app": app.Name},
+				[]string{},
+				map[string]interface{}{}))
+		}
 	}
 	return resources
 }
 
-func (g *AddOnGenerator) InitResources() error {
+func (g *FormationGenerator) InitResources() error {
 	svc := g.generateService()
-	output, err := svc.AddOnList(context.TODO(), &heroku.ListRange{Field: "id"})
+	output, err := svc.AppList(context.TODO(), &heroku.ListRange{Field: "id"})
 	if err != nil {
 		return err
 	}
-	g.Resources = g.createResources(output)
+	g.Resources = g.createResources(svc, output)
 	return nil
 }

--- a/providers/heroku/heroku_provider.go
+++ b/providers/heroku/heroku_provider.go
@@ -65,8 +65,21 @@ func (HerokuProvider) GetResourceConnections() map[string]map[string][]string {
 
 func (p *HerokuProvider) GetSupportedService() map[string]terraform_utils.ServiceGenerator {
 	return map[string]terraform_utils.ServiceGenerator{
-		"app":   &AppGenerator{},
-		"addon": &AddonGenerator{},
+		"account_feature":        &AccountFeatureGenerator{},
+		"addon":                  &AddOnGenerator{},
+		"addon_attachment":       &AddOnAttachmentGenerator{},
+		"app":                    &AppGenerator{},
+		"app_config_association": &AppConfigAssociationGenerator{},
+		"app_feature":            &AppFeatureGenerator{},
+		"app_webhook":            &AppWebhookGenerator{},
+		"build":                  &BuildGenerator{},
+		"domain":                 &DomainGenerator{},
+		"drain":                  &DrainGenerator{},
+		"formation":              &FormationGenerator{},
+		"pipeline":               &PipelineGenerator{},
+		"pipeline_coupling":      &PipelineCouplingGenerator{},
+		"team_collaborator":      &TeamCollaboratorGenerator{},
+		"team_member":            &TeamMemberGenerator{},
 	}
 }
 

--- a/providers/heroku/pipeline.go
+++ b/providers/heroku/pipeline.go
@@ -21,26 +21,26 @@ import (
 	heroku "github.com/heroku/heroku-go/v5"
 )
 
-type AddOnGenerator struct {
+type PipelineGenerator struct {
 	HerokuService
 }
 
-func (g AddOnGenerator) createResources(addOnList []heroku.AddOn) []terraform_utils.Resource {
+func (g PipelineGenerator) createResources(pipelineList []heroku.Pipeline) []terraform_utils.Resource {
 	var resources []terraform_utils.Resource
-	for _, addOn := range addOnList {
+	for _, pipeline := range pipelineList {
 		resources = append(resources, terraform_utils.NewSimpleResource(
-			addOn.ID,
-			addOn.Name,
-			"heroku_addon",
+			pipeline.ID,
+			pipeline.Name,
+			"heroku_pipeline",
 			"heroku",
 			[]string{}))
 	}
 	return resources
 }
 
-func (g *AddOnGenerator) InitResources() error {
+func (g *PipelineGenerator) InitResources() error {
 	svc := g.generateService()
-	output, err := svc.AddOnList(context.TODO(), &heroku.ListRange{Field: "id"})
+	output, err := svc.PipelineList(context.TODO(), &heroku.ListRange{Field: "id"})
 	if err != nil {
 		return err
 	}

--- a/providers/heroku/pipeline_coupling.go
+++ b/providers/heroku/pipeline_coupling.go
@@ -21,26 +21,26 @@ import (
 	heroku "github.com/heroku/heroku-go/v5"
 )
 
-type AddOnGenerator struct {
+type PipelineCouplingGenerator struct {
 	HerokuService
 }
 
-func (g AddOnGenerator) createResources(addOnList []heroku.AddOn) []terraform_utils.Resource {
+func (g PipelineCouplingGenerator) createResources(pipelineCouplingList []heroku.PipelineCoupling) []terraform_utils.Resource {
 	var resources []terraform_utils.Resource
-	for _, addOn := range addOnList {
+	for _, pipelineCoupling := range pipelineCouplingList {
 		resources = append(resources, terraform_utils.NewSimpleResource(
-			addOn.ID,
-			addOn.Name,
-			"heroku_addon",
+			pipelineCoupling.ID,
+			pipelineCoupling.ID,
+			"heroku_pipeline_coupling",
 			"heroku",
 			[]string{}))
 	}
 	return resources
 }
 
-func (g *AddOnGenerator) InitResources() error {
+func (g *PipelineCouplingGenerator) InitResources() error {
 	svc := g.generateService()
-	output, err := svc.AddOnList(context.TODO(), &heroku.ListRange{Field: "id"})
+	output, err := svc.PipelineCouplingList(context.TODO(), &heroku.ListRange{Field: "id"})
 	if err != nil {
 		return err
 	}

--- a/providers/heroku/team_collaborator.go
+++ b/providers/heroku/team_collaborator.go
@@ -1,0 +1,64 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package heroku
+
+import (
+	"context"
+	"log"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	heroku "github.com/heroku/heroku-go/v5"
+)
+
+type TeamCollaboratorGenerator struct {
+	HerokuService
+}
+
+func (g TeamCollaboratorGenerator) createResources(svc *heroku.Service, teamList []heroku.Team) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, team := range teamList {
+		apps, err := svc.TeamAppListByTeam(context.TODO(), team.ID, &heroku.ListRange{Field: "id"})
+		if err != nil {
+			log.Println(err)
+		}
+		for _, app := range apps {
+			collaborators, err := svc.TeamAppCollaboratorList(context.TODO(), app.ID, &heroku.ListRange{Field: "id"})
+			if err != nil {
+				log.Println(err)
+			}
+			for _, collaborator := range collaborators {
+				resources = append(resources, terraform_utils.NewResource(
+					collaborator.ID,
+					collaborator.ID,
+					"heroku_team_collaborator",
+					"heroku",
+					map[string]string{"app": app.Name},
+					[]string{},
+					map[string]interface{}{}))
+			}
+		}
+	}
+	return resources
+}
+
+func (g *TeamCollaboratorGenerator) InitResources() error {
+	svc := g.generateService()
+	output, err := svc.TeamList(context.TODO(), &heroku.ListRange{Field: "id"})
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(svc, output)
+	return nil
+}


### PR DESCRIPTION
Adds support for a majority of Heroku resources. List of resources added:

* `heroku_account_feature`
* `heroku_addon_attachment`
* `heroku_app_config_association`
* `heroku_app_feature`
* `heroku_app_webhook`
* `heroku_build`
* `heroku_domain`
* `heroku_drain`
* `heroku_formation`
* `heroku_pipeline`
* `heroku_pipeline_coupling`
* `heroku_team_collaborator`
* `heroku_team_member`