### PR TITLE
Allowed filtering by all fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,19 +97,6 @@ terraformer import aws --resources=vpc,subnet --filter=aws_vpc=myvpcid --regions
 ```
 Will only import the vpc with id `myvpcid`. This form of filters can help when it's necessary to select resources by its identifiers.
 
-##### Resources attributes
-
-Attribute filters allow filtering across different resource types by its attributes.
-
-```
-terraformer import aws --resources=ec2_instance,ebs --filter=Name=tags.costCenter;Value=20000:'20001:1' --regions=eu-west-1
-```
-Will only import AWS EC2 instances along with EBS volumes annotated with tag `costCenter` with values `20000` or `20001:1`. Attribute filters are by default applicable to all resource types although it's possible to specify to what resource type a given filter should be applicable to by providing `Type=<type>` parameter. For example:
-```
-terraformer import aws --resources=ec2_instance,ebs --filter=Type=ec2_instance;Name=tags.costCenter;Value=20000:'20001:1' --regions=eu-west-1
-```
-Will work as same as example above with a change the filter will be applicable only to `ec2_instance` resources.
-
 #### Planning
 
 The `plan` command generates a planfile that contains all the resources set to be imported. By modifying the planfile before running the `import` command, you can rename or filter the resources you'd like to import.
@@ -335,6 +322,8 @@ Example:
  terraformer import aws --resources=vpc,subnet --filter=aws_vpc=vpc_id1:vpc_id2:vpc_id3 --regions=eu-west-1
 ```
 
+#### Profiles support
+
 To load profiles from the shared AWS configuration file (typically `~/.aws/config`), set the `AWS_SDK_LOAD_CONFIG` to `true`:
 
 ```
@@ -347,7 +336,7 @@ terraformer import aws --resources=cloudfront --profile=prod
 ```
 In that case terraformer will not know with which region resources are associated with and will not assume any region. That scenario is useful in case of global resources (e.g. CloudFront distributions or Route 53 records) and when region is passed implicitly through environmental variables or metadata service.
 
-List of supported AWS services:
+#### Supported services
 
 *   `acm`
     * `aws_acm_certificate`
@@ -451,6 +440,8 @@ List of supported AWS services:
 *   `vpn_gateway`
     * `aws_vpn_gateway`
 
+#### Global services
+
 AWS services that are global will be imported without specified region even if several regions will be passed. It is to ensure only one representation of an AWS resource is imported.
 
 List of global AWS services:
@@ -458,6 +449,19 @@ List of global AWS services:
 *   `iam`
 *   `organization`
 *   `route53`
+
+#### Attribute filters
+
+Attribute filters allow filtering across different resource types by its attributes.
+
+```
+terraformer import aws --resources=ec2_instance,ebs --filter=Name=tags.costCenter;Value=20000:'20001:1' --regions=eu-west-1
+```
+Will only import AWS EC2 instances along with EBS volumes annotated with tag `costCenter` with values `20000` or `20001:1`. Attribute filters are by default applicable to all resource types although it's possible to specify to what resource type a given filter should be applicable to by providing `Type=<type>` parameter. For example:
+```
+terraformer import aws --resources=ec2_instance,ebs --filter=Type=ec2_instance;Name=tags.costCenter;Value=20000:'20001:1' --regions=eu-west-1
+```
+Will work as same as example above with a change the filter will be applicable only to `ec2_instance` resources.
 
 ### Use with Azure
 

--- a/README.md
+++ b/README.md
@@ -82,19 +82,33 @@ Read-only permissions
 
 #### Filtering
 
-Filters are a way to choose which resources `terraformer` imports.
-
-For example:
-```
-terraformer import aws --resources=vpc,subnet --filter=aws_vpc=myvpcid --regions=eu-west-1
-```
-will only import the VPC with id `myvpcid`.
+Filters are a way to choose which resources `terraformer` imports. It's possible to filter resources by its identifiers or attributes. Multiple filtering values are separated by `:`. If an identifier contains this symbol, value should be wrapped in `'` e.g. `--filter=resource=id1:'project:dataset_id'`. Identifier based filters will be executed before Terraformer will try to refresh remote state.
 
 ##### Resource ID
 
 Filtering is based on Terraform resource ID patterns. To find valid ID patterns for your resource, check the import part of the [Terraform documentation][terraform-providers].
 
 [terraform-providers]: https://www.terraform.io/docs/providers/
+
+Example usage:
+
+```
+terraformer import aws --resources=vpc,subnet --filter=aws_vpc=myvpcid --regions=eu-west-1
+```
+Will only import the vpc with id `myvpcid`. This form of filters can help when it's necessary to select resources by its identifiers.
+
+##### Resources attributes
+
+Attribute filters allow filtering across different resource types by its attributes.
+
+```
+terraformer import aws --resources=ec2_instance,ebs --filter=Name=tags.costCenter;Value=20000:'20001:1' --regions=eu-west-1
+```
+Will only import AWS EC2 instances along with EBS volumes annotated with tag `costCenter` with values `20000` or `20001:1`. Attribute filters are by default applicable to all resource types although it's possible to specify to what resource type a given filter should be applicable to by providing `Type=<type>` parameter. For example:
+```
+terraformer import aws --resources=ec2_instance,ebs --filter=Type=ec2_instance;Name=tags.costCenter;Value=20000:'20001:1' --regions=eu-west-1
+```
+Will work as same as example above with a change the filter will be applicable only to `ec2_instance` resources.
 
 #### Planning
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -94,10 +94,7 @@ func Import(provider terraform_utils.ProviderGenerator, options ImportOptions, a
 			return err
 		}
 
-		if len(options.Filter) != 0 {
-			provider.GetService().ParseFilter(options.Filter)
-			provider.GetService().CleanupWithFilter()
-		}
+		provider.GetService().ParseAndInitialCleanup(options.Filter)
 
 		providerWrapper, err := provider_wrapper.NewProviderWrapper(provider.GetName(), provider.GetConfig())
 		if err != nil {
@@ -118,6 +115,8 @@ func Import(provider terraform_utils.ProviderGenerator, options ImportOptions, a
 		}
 
 		providerWrapper.Kill()
+
+		provider.GetService().PostRefreshCleanup()
 
 		// change structs with additional data for each resource
 		err = provider.GetService().PostConvertHook()

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -88,13 +88,13 @@ func Import(provider terraform_utils.ProviderGenerator, options ImportOptions, a
 		if err != nil {
 			return err
 		}
+		provider.GetService().ParseFilters(options.Filter)
 		err = provider.GetService().InitResources()
 		provider.GetService().PopulateIgnoreKeys(provider.GetBasicConfig())
 		if err != nil {
 			return err
 		}
-
-		provider.GetService().ParseAndInitialCleanup(options.Filter)
+		provider.GetService().InitialCleanup()
 
 		providerWrapper, err := provider_wrapper.NewProviderWrapper(provider.GetName(), provider.GetConfig())
 		if err != nil {

--- a/providers/aws/ebs.go
+++ b/providers/aws/ebs.go
@@ -40,7 +40,7 @@ func (g *EbsGenerator) InitResources() error {
 	svc := ec2.New(sess)
 	var filters []*ec2.Filter
 	for _, filter := range g.Filter {
-		if strings.HasPrefix(filter.FieldPath, "tags.") && filter.ResourceName == "aws_ebs_volume" {
+		if strings.HasPrefix(filter.FieldPath, "tags.") && filter.IsApplicable("aws_ebs_volume") {
 			filters = append(filters, &ec2.Filter{
 				Name:   aws.String("tag:" + strings.TrimPrefix(filter.FieldPath, "tags.")),
 				Values: aws.StringSlice(filter.AcceptableValues),

--- a/providers/aws/ebs.go
+++ b/providers/aws/ebs.go
@@ -16,6 +16,7 @@ package aws
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 	"github.com/aws/aws-sdk-go/aws"
@@ -37,8 +38,19 @@ func (g EbsGenerator) volumeAttachmentId(device, volumeID, instanceID string) st
 func (g *EbsGenerator) InitResources() error {
 	sess := g.generateSession()
 	svc := ec2.New(sess)
-
-	err := svc.DescribeVolumesPages(&ec2.DescribeVolumesInput{}, func(volumes *ec2.DescribeVolumesOutput, lastPage bool) bool {
+	var filters []*ec2.Filter
+	for _, filter := range g.Filter {
+		if strings.HasPrefix(filter.FieldPath, "tags.") && filter.ResourceName == "aws_ebs_volume" {
+			filters = append(filters, &ec2.Filter{
+				Name:   aws.String("tag:" + strings.TrimPrefix(filter.FieldPath, "tags.")),
+				Values: aws.StringSlice(filter.AcceptableValues),
+			})
+		}
+	}
+	input := ec2.DescribeVolumesInput{
+		Filters:filters,
+	}
+	err := svc.DescribeVolumesPages(&input, func(volumes *ec2.DescribeVolumesOutput, lastPage bool) bool {
 		for _, volume := range volumes.Volumes {
 
 			isRootDevice := false // Let's leave root device configuration to be done in ec2_instance resources

--- a/providers/aws/ec2.go
+++ b/providers/aws/ec2.go
@@ -34,7 +34,7 @@ func (g *Ec2Generator) InitResources() error {
 	svc := ec2.New(sess)
 	var filters []*ec2.Filter
 	for _, filter := range g.Filter {
-		if strings.HasPrefix(filter.FieldPath, "tags.") && filter.ResourceName == "aws_instance" {
+		if strings.HasPrefix(filter.FieldPath, "tags.") && filter.IsApplicable("aws_instance") {
 			filters = append(filters, &ec2.Filter{
 				Name:   aws.String("tag:" + strings.TrimPrefix(filter.FieldPath, "tags.")),
 				Values: aws.StringSlice(filter.AcceptableValues),

--- a/terraform_utils/resource.go
+++ b/terraform_utils/resource.go
@@ -36,14 +36,19 @@ type Resource struct {
 	AdditionalFields map[string]interface{} `json:",omitempty"`
 }
 
+type ApplicableFilter interface {
+	IsApplicable(resourceName string) bool
+}
+
 type ResourceFilter struct {
+	ApplicableFilter
 	ResourceName     string
 	FieldPath        string
 	AcceptableValues []string
 }
 
 func (rf *ResourceFilter) Filter(resource Resource) bool {
-	if resource.InstanceInfo.Type != rf.ResourceName {
+	if !rf.IsApplicable(resource.InstanceInfo.Type) {
 		return true
 	}
 	var vals []interface{}
@@ -63,6 +68,10 @@ func (rf *ResourceFilter) Filter(resource Resource) bool {
 		}
 	}
 	return false
+}
+
+func (rf *ResourceFilter) IsApplicable(resourceName string) bool {
+	return rf.ResourceName == "" || rf.ResourceName == resourceName
 }
 
 func (rf *ResourceFilter) isInitial() bool {

--- a/terraform_utils/service.go
+++ b/terraform_utils/service.go
@@ -26,13 +26,14 @@ type ServiceGenerator interface {
 	GetResources() []Resource
 	SetResources(resources []Resource)
 	ParseFilter(rawFilter string) []ResourceFilter
+	ParseFilters(rawFilters []string)
 	PostConvertHook() error
 	GetArgs() map[string]interface{}
 	SetArgs(args map[string]interface{})
 	SetName(name string)
 	SetProviderName(name string)
 	GetName() string
-	ParseAndInitialCleanup(rawFilters []string)
+	InitialCleanup()
 	PopulateIgnoreKeys(cty.Value)
 	PostRefreshCleanup()
 }
@@ -104,11 +105,8 @@ func (s *Service) GetName() string {
 	return s.Name
 }
 
-func (s *Service) ParseAndInitialCleanup(rawFilters []string) {
-	if len(rawFilters) != 0 {
-		s.ParseFilters(rawFilters)
-		FilterCleanup(s, true)
-	}
+func (s *Service) InitialCleanup() {
+	FilterCleanup(s, true)
 }
 
 func (s *Service) PostRefreshCleanup() {

--- a/terraform_utils/service.go
+++ b/terraform_utils/service.go
@@ -25,15 +25,16 @@ type ServiceGenerator interface {
 	InitResources() error
 	GetResources() []Resource
 	SetResources(resources []Resource)
-	ParseFilter(rawFilter []string)
+	ParseFilter(rawFilter string) []ResourceFilter
 	PostConvertHook() error
 	GetArgs() map[string]interface{}
 	SetArgs(args map[string]interface{})
 	SetName(name string)
 	SetProviderName(name string)
 	GetName() string
-	CleanupWithFilter()
+	ParseAndInitialCleanup(rawFilters []string)
 	PopulateIgnoreKeys(cty.Value)
+	PostRefreshCleanup()
 }
 
 type Service struct {
@@ -41,24 +42,59 @@ type Service struct {
 	Resources    []Resource
 	ProviderName string
 	Args         map[string]interface{}
-	Filter       map[string][]string
+	Filter       []ResourceFilter
 }
 
 func (s *Service) SetProviderName(providerName string) {
 	s.ProviderName = providerName
 }
 
-func (s *Service) ParseFilter(rawFilter []string) {
-	s.Filter = map[string][]string{}
-	for _, resource := range rawFilter {
-		t := strings.Split(resource, "=")
-		if len(t) != 2 {
-			log.Println("Pattern for filter must be resource_type=id1:id2:id4")
-			continue
+func (s *Service) ParseFilters(rawFilters []string) {
+	s.Filter = []ResourceFilter{}
+	for _, rawFilter := range rawFilters {
+		filters := s.ParseFilter(rawFilter)
+		for _, resourceFilter := range filters {
+			s.Filter = append(s.Filter, resourceFilter)
 		}
-		resourceName, resourcesID := t[0], t[1]
-		s.Filter[resourceName] = strings.Split(resourcesID, ":")
 	}
+}
+
+func (s *Service) ParseFilter(rawFilter string) []ResourceFilter {
+	var filters []ResourceFilter
+	if len(strings.Split(rawFilter, "=")) == 2 {
+		parts := strings.Split(rawFilter, "=")
+		resourceName, resourcesID := parts[0], parts[1]
+		filters = append(filters, ResourceFilter{
+			ResourceName:     resourceName,
+			FieldPath:        "id",
+			AcceptableValues: ParseFilterValues(resourcesID),
+		})
+	} else {
+		parts := strings.Split(rawFilter, ";")
+		if len(parts) != 2 && len(parts) != 3 {
+			log.Print("Invalid filter: " + rawFilter)
+			return filters
+		}
+		var ResourceNamePart string
+		var FieldPathPart string
+		var AcceptableValuesPart string
+		if len(parts) == 2 {
+			ResourceNamePart = ""
+			FieldPathPart = parts[0]
+			AcceptableValuesPart = parts[1]
+		} else {
+			ResourceNamePart = strings.TrimPrefix(parts[0], "Type=")
+			FieldPathPart = parts[1]
+			AcceptableValuesPart = parts[2]
+		}
+
+		filters = append(filters, ResourceFilter{
+			ResourceName:     ResourceNamePart,
+			FieldPath:        strings.TrimPrefix(FieldPathPart, "Name="),
+			AcceptableValues: ParseFilterValues(strings.TrimPrefix(AcceptableValuesPart, "Value=")),
+		})
+	}
+	return filters
 }
 
 func (s *Service) SetName(name string) {
@@ -68,21 +104,17 @@ func (s *Service) GetName() string {
 	return s.Name
 }
 
-func (s *Service) CleanupWithFilter() {
-	if len(s.Filter) == 0 {
-		return
+func (s *Service) ParseAndInitialCleanup(rawFilters []string) {
+	if len(rawFilters) != 0 {
+		s.ParseFilters(rawFilters)
+		FilterCleanup(s, true)
 	}
-	newListOfResources := []Resource{}
-	for _, v := range s.Resources {
-		if _, exist := s.Filter[v.InstanceInfo.Type]; exist {
-			for _, r := range s.Filter[v.InstanceInfo.Type] {
-				if v.InstanceState.ID == r {
-					newListOfResources = append(newListOfResources, v)
-				}
-			}
-		}
+}
+
+func (s *Service) PostRefreshCleanup() {
+	if len(s.Filter) != 0 {
+		FilterCleanup(s, false)
 	}
-	s.Resources = newListOfResources
 }
 
 func (s *Service) GetArgs() map[string]interface{} {

--- a/terraform_utils/service_test.go
+++ b/terraform_utils/service_test.go
@@ -73,7 +73,8 @@ func TestServiceIdCleanupWithFilter(t *testing.T) {
 				ID: "myid",
 			}}},
 	}
-	service.ParseAndInitialCleanup([]string{"type1=:otherId"})
+	service.ParseFilters([]string{"type1=:otherId"})
+	service.InitialCleanup()
 
 	if !reflect.DeepEqual(len(service.Resources), 1) {
 		t.Errorf("failed to cleanup")

--- a/terraform_utils/service_test.go
+++ b/terraform_utils/service_test.go
@@ -1,0 +1,103 @@
+package terraform_utils
+
+import (
+	"github.com/hashicorp/terraform/terraform"
+	"reflect"
+	"testing"
+)
+
+func TestEmptyFiltersParsing(t *testing.T) {
+	service := Service{}
+	service.ParseFilters([]string{})
+
+	if !reflect.DeepEqual(service.Filter, []ResourceFilter{}) {
+		t.Errorf("failed to parse, got %v", service.Filter)
+	}
+}
+
+func TestIdFiltersParsing(t *testing.T) {
+	service := Service{}
+	service.ParseFilters([]string{"aws_vpc=myid"})
+
+	if !reflect.DeepEqual(service.Filter, []ResourceFilter{
+		{
+			ResourceName:     "aws_vpc",
+			FieldPath:        "id",
+			AcceptableValues: []string{"myid"},
+		}}) {
+		t.Errorf("failed to parse, got %v", service.Filter)
+	}
+}
+
+func TestComplexIdFiltersParsing(t *testing.T) {
+	service := Service{}
+	service.ParseFilters([]string{"resource=id1:'project:dataset_id'"})
+
+	if !reflect.DeepEqual(service.Filter, []ResourceFilter{
+		{
+			ResourceName:     "resource",
+			FieldPath:        "id",
+			AcceptableValues: []string{"id1", "project:dataset_id"},
+		}}) {
+		t.Errorf("failed to parse, got %v", service.Filter)
+	}
+}
+
+func TestEdgeIdFiltersParsing(t *testing.T) {
+	service := Service{}
+	service.ParseFilters([]string{"aws_vpc=:myid"})
+
+	if !reflect.DeepEqual(service.Filter, []ResourceFilter{
+		{
+			ResourceName:     "aws_vpc",
+			FieldPath:        "id",
+			AcceptableValues: []string{"myid"},
+		}}) {
+		t.Errorf("failed to parse, got %v", service.Filter)
+	}
+}
+
+func TestServiceIdCleanupWithFilter(t *testing.T) {
+	service := Service{
+		Resources: []Resource{{
+			InstanceInfo: &terraform.InstanceInfo{
+				Type: "type1",
+			},
+			InstanceState: &terraform.InstanceState{
+				ID: "myid",
+			}}, {
+			InstanceInfo: &terraform.InstanceInfo{
+				Type: "type2",
+			},
+			InstanceState: &terraform.InstanceState{
+				ID: "myid",
+			}}},
+	}
+	service.ParseAndInitialCleanup([]string{"type1=:otherId"})
+
+	if !reflect.DeepEqual(len(service.Resources), 1) {
+		t.Errorf("failed to cleanup")
+	}
+}
+
+func TestServiceAttributeCleanupWithFilter(t *testing.T) {
+	service := Service{
+		Resources: []Resource{
+			{
+				InstanceInfo: &terraform.InstanceInfo{
+					Type: "aws_vpc",
+				},
+				Item: mapI("tags", mapI("Name", "some"))},
+			{
+				InstanceInfo: &terraform.InstanceInfo{
+					Type: "aws_vpc",
+				},
+				Item: mapI("tags", mapI("Name", "default"))}},
+	}
+	service.ParseFilters([]string{"Name=tags.Name;Value=default"})
+	service.PostRefreshCleanup()
+
+	if !reflect.DeepEqual(len(service.Resources), 1) {
+		t.Errorf("failed to cleanup")
+	}
+}


### PR DESCRIPTION
Things done:
- It's possible to apply filters on all fields e.g. tags (ref #196 )
- Calls to fetch AWS EC2 and EBS resources take tag filters into account
- Filter values can contain `:` (ref #152 ) if value is wrapped in apostrophes `'`