### PR TITLE
Support DigitalOcean provider 🦈

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A CLI tool that generates `tf` and `tfstate` files based on existing infrastruct
         * [Azure](#use-with-azure)
         * [AliCloud](#use-with-alicloud)
     * Cloud
+        * [DigitalOcean](#use-with-digitalocean)
         * [Heroku](#use-with-heroku)
         * [OpenStack](#use-with-openstack)
     * Infrastructure Software
@@ -160,6 +161,7 @@ Links to download Terraform Providers:
     * Azure provider >1.35.0 - [here](https://releases.hashicorp.com/terraform-provider-azurerm/)
     * Alicloud provider >1.57.1 - [here](https://releases.hashicorp.com/terraform-provider-alicloud/)
 * Cloud
+    * DigitalOcean provider >1.9.1 - [here](https://releases.hashicorp.com/terraform-provider-digitalocean/)
     * Heroku provider >2.2.1 - [here](https://releases.hashicorp.com/terraform-provider-heroku/)
     * OpenStack provider >1.21.1 - [here](https://releases.hashicorp.com/terraform-provider-openstack/)
 * Infrastructure Software
@@ -548,6 +550,36 @@ List of supported AliCloud resources:
   * `alicloud_vpc`
 * `vswitch`
   * `alicloud_vswitch`
+
+### Use with DigitalOcean
+
+Example:
+
+```
+export DIGITALOCEAN_TOKEN=[DIGITALOCEAN_TOKEN]
+./terraformer import digitalocean -r project,droplet
+```
+
+List of supported DigitalOcean resources:
+
+*   `database_cluster`
+    * `digitalocean_database_cluster`
+*   `domain`
+    * `digitalocean_domain`
+*   `droplet`
+    * `digitalocean_droplet`
+*   `firewall`
+    * `digitalocean_firewall`
+*   `floating_ip`
+    * `digitalocean_floating_ip`
+*   `kubernetes_cluster`
+    * `digitalocean_kubernetes_cluster`
+*   `loadbalancer`
+    * `digitalocean_loadbalancer`
+*   `project`
+    * `digitalocean_project`
+*   `volume`
+    * `digitalocean_volume`
 
 ### Use with Heroku
 

--- a/cmd/provider_cmd_digitalocean.go
+++ b/cmd/provider_cmd_digitalocean.go
@@ -1,0 +1,52 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cmd
+
+import (
+	digitalocean_terraforming "github.com/GoogleCloudPlatform/terraformer/providers/digitalocean"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/spf13/cobra"
+)
+
+func newCmdDigitalOceanImporter(options ImportOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "digitalocean",
+		Short: "Import current state to Terraform configuration from DigitalOcean",
+		Long:  "Import current state to Terraform configuration from DigitalOcean",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			provider := newDigitalOceanProvider()
+			err := Import(provider, options, []string{})
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.AddCommand(listCmd(newDigitalOceanProvider()))
+	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
+	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "project,droplet")
+	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
+	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
+	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
+	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
+	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "digitalocean_project=name1:name2:name3")
+
+	return cmd
+}
+
+func newDigitalOceanProvider() terraform_utils.ProviderGenerator {
+	return &digitalocean_terraforming.DigitalOceanProvider{}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,6 +44,7 @@ func providerImporterSubcommands() []func(options ImportOptions) *cobra.Command 
 		newCmdAzureImporter,
 		newCmdAliCloudImporter,
 		// Cloud
+		newCmdDigitalOceanImporter,
 		newCmdHerokuImporter,
 		newCmdOpenStackImporter,
 		// Infrastructure Software
@@ -69,6 +70,7 @@ func providerGenerators() map[string]func() terraform_utils.ProviderGenerator {
 		newAzureProvider,
 		newAliCloudProvider,
 		// Cloud
+		newDigitalOceanProvider,
 		newHerokuProvider,
 		newOpenStackProvider,
 		// Infrastructure Software

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cloudflare/cloudflare-go v0.10.4
 	github.com/denverdino/aliyungo v0.0.0-20190924033012-e8e08fe22cb2
+	github.com/digitalocean/godo v1.22.0
 	github.com/dollarshaveclub/new-relic-synthetics-go v0.0.0-20170605224734-4dc3dd6ae884
 	github.com/go-resty/resty v0.0.0-00010101000000-000000000000 // indirect
 	github.com/gogo/protobuf v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,8 @@ github.com/denverdino/aliyungo v0.0.0-20190924033012-e8e08fe22cb2 h1:D1yicshpcOe
 github.com/denverdino/aliyungo v0.0.0-20190924033012-e8e08fe22cb2/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/digitalocean/godo v1.22.0 h1:bVFBKXW2TlynZ9SqmlM6ZSW6UPEzFckltSIUT5NC8L4=
+github.com/digitalocean/godo v1.22.0/go.mod h1:iJnN9rVu6K5LioLxLimlq0uRI+y/eAQjROUmeU/r0hY=
 github.com/dimchansky/utfbom v1.0.0 h1:fGC2kkf4qOoKqZ4q7iIh+Vef4ubC1c38UDsEyZynZPc=
 github.com/dimchansky/utfbom v1.0.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.0 h1:FcM3g+nofKgUteL8dm/UpdRXNC9KmADgTpLKsu0TRo4=
@@ -561,6 +563,7 @@ golang.org/x/net v0.0.0-20191009170851-d66e71096ffb h1:TR699M2v0qoKTOHxeLgp6zPqa
 golang.org/x/net v0.0.0-20191009170851-d66e71096ffb/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/providers/digitalocean/database_cluster.go
+++ b/providers/digitalocean/database_cluster.go
@@ -1,0 +1,81 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package digitalocean
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/digitalocean/godo"
+)
+
+type DatabaseClusterGenerator struct {
+	DigitalOceanService
+}
+
+func (g DatabaseClusterGenerator) listDatabaseClusters(ctx context.Context, client *godo.Client) ([]godo.Database, error) {
+	list := []godo.Database{}
+
+	// create options. initially, these will be blank
+	opt := &godo.ListOptions{}
+	for {
+		clusters, resp, err := client.Databases.List(ctx, opt)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, cluster := range clusters {
+			list = append(list, cluster)
+		}
+
+		// if we are at the last page, break out the for loop
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+
+		// set the page we want for the next request
+		opt.Page = page + 1
+	}
+
+	return list, nil
+}
+
+func (g DatabaseClusterGenerator) createResources(clusterList []godo.Database) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, cluster := range clusterList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			cluster.ID,
+			cluster.Name,
+			"digitalocean_database_cluster",
+			"digitalocean",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *DatabaseClusterGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := g.listDatabaseClusters(context.TODO(), client)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/digitalocean/digitalocean_provider.go
+++ b/providers/digitalocean/digitalocean_provider.go
@@ -1,0 +1,85 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package digitalocean
+
+import (
+	"errors"
+	"os"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+)
+
+const digitalOceanProviderVersion = "~> 1.9.1"
+
+type DigitalOceanProvider struct {
+	terraform_utils.Provider
+	token string
+}
+
+func (p *DigitalOceanProvider) Init(args []string) error {
+	if os.Getenv("DIGITALOCEAN_TOKEN") == "" {
+		return errors.New("set DIGITALOCEAN_TOKEN env var")
+	}
+	p.token = os.Getenv("DIGITALOCEAN_TOKEN")
+
+	return nil
+}
+
+func (p *DigitalOceanProvider) GetName() string {
+	return "digitalocean"
+}
+
+func (p *DigitalOceanProvider) GetProviderData(arg ...string) map[string]interface{} {
+	return map[string]interface{}{
+		"provider": map[string]interface{}{
+			"digitalocean": map[string]interface{}{
+				"version": digitalOceanProviderVersion,
+				"token":   p.token,
+			},
+		},
+	}
+}
+
+func (DigitalOceanProvider) GetResourceConnections() map[string]map[string][]string {
+	return map[string]map[string][]string{}
+}
+
+func (p *DigitalOceanProvider) GetSupportedService() map[string]terraform_utils.ServiceGenerator {
+	return map[string]terraform_utils.ServiceGenerator{
+		"database_cluster":   &DatabaseClusterGenerator{},
+		"domain":             &DomainGenerator{},
+		"droplet":            &DropletGenerator{},
+		"firewall":           &FirewallGenerator{},
+		"floating_ip":        &FloatingIPGenerator{},
+		"kubernetes_cluster": &KubernetesClusterGenerator{},
+		"loadbalancer":       &LoadBalancerGenerator{},
+		"project":            &ProjectGenerator{},
+		"volume":             &VolumeGenerator{},
+	}
+}
+
+func (p *DigitalOceanProvider) InitService(serviceName string) error {
+	var isSupported bool
+	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+		return errors.New("digitalocean: " + serviceName + " not supported service")
+	}
+	p.Service = p.GetSupportedService()[serviceName]
+	p.Service.SetName(serviceName)
+	p.Service.SetProviderName(p.GetName())
+	p.Service.SetArgs(map[string]interface{}{
+		"token": p.token,
+	})
+	return nil
+}

--- a/providers/digitalocean/digitalocean_service.go
+++ b/providers/digitalocean/digitalocean_service.go
@@ -1,0 +1,36 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package digitalocean
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/digitalocean/godo"
+	"golang.org/x/oauth2"
+)
+
+type DigitalOceanService struct {
+	terraform_utils.Service
+}
+
+func (s *DigitalOceanService) generateClient() *godo.Client {
+	tokenSource := &TokenSource{
+		AccessToken: s.Args["token"].(string),
+	}
+	oauthClient := oauth2.NewClient(context.Background(), tokenSource)
+	client := godo.NewClient(oauthClient)
+	return client
+}

--- a/providers/digitalocean/domain.go
+++ b/providers/digitalocean/domain.go
@@ -1,0 +1,81 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package digitalocean
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/digitalocean/godo"
+)
+
+type DomainGenerator struct {
+	DigitalOceanService
+}
+
+func (g DomainGenerator) listDomains(ctx context.Context, client *godo.Client) ([]godo.Domain, error) {
+	list := []godo.Domain{}
+
+	// create options. initially, these will be blank
+	opt := &godo.ListOptions{}
+	for {
+		domains, resp, err := client.Domains.List(ctx, opt)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, domain := range domains {
+			list = append(list, domain)
+		}
+
+		// if we are at the last page, break out the for loop
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+
+		// set the page we want for the next request
+		opt.Page = page + 1
+	}
+
+	return list, nil
+}
+
+func (g DomainGenerator) createResources(domainList []godo.Domain) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, domain := range domainList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			domain.Name,
+			domain.Name,
+			"digitalocean_domain",
+			"digitalocean",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *DomainGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := g.listDomains(context.TODO(), client)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/digitalocean/droplet.go
+++ b/providers/digitalocean/droplet.go
@@ -1,0 +1,82 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package digitalocean
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/digitalocean/godo"
+)
+
+type DropletGenerator struct {
+	DigitalOceanService
+}
+
+func (g DropletGenerator) listDroplets(ctx context.Context, client *godo.Client) ([]godo.Droplet, error) {
+	list := []godo.Droplet{}
+
+	// create options. initially, these will be blank
+	opt := &godo.ListOptions{}
+	for {
+		droplets, resp, err := client.Droplets.List(ctx, opt)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, droplet := range droplets {
+			list = append(list, droplet)
+		}
+
+		// if we are at the last page, break out the for loop
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+
+		// set the page we want for the next request
+		opt.Page = page + 1
+	}
+
+	return list, nil
+}
+
+func (g DropletGenerator) createResources(dropletList []godo.Droplet) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, droplet := range dropletList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			strconv.Itoa(droplet.ID),
+			droplet.Name,
+			"digitalocean_droplet",
+			"digitalocean",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *DropletGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := g.listDroplets(context.TODO(), client)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/digitalocean/firewall.go
+++ b/providers/digitalocean/firewall.go
@@ -1,0 +1,81 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package digitalocean
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/digitalocean/godo"
+)
+
+type FirewallGenerator struct {
+	DigitalOceanService
+}
+
+func (g FirewallGenerator) listFirewalls(ctx context.Context, client *godo.Client) ([]godo.Firewall, error) {
+	list := []godo.Firewall{}
+
+	// create options. initially, these will be blank
+	opt := &godo.ListOptions{}
+	for {
+		firewalls, resp, err := client.Firewalls.List(ctx, opt)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, firewall := range firewalls {
+			list = append(list, firewall)
+		}
+
+		// if we are at the last page, break out the for loop
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+
+		// set the page we want for the next request
+		opt.Page = page + 1
+	}
+
+	return list, nil
+}
+
+func (g FirewallGenerator) createResources(firewallList []godo.Firewall) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, firewall := range firewallList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			firewall.ID,
+			firewall.Name,
+			"digitalocean_firewall",
+			"digitalocean",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *FirewallGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := g.listFirewalls(context.TODO(), client)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/digitalocean/floating_ip.go
+++ b/providers/digitalocean/floating_ip.go
@@ -1,0 +1,81 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package digitalocean
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/digitalocean/godo"
+)
+
+type FloatingIPGenerator struct {
+	DigitalOceanService
+}
+
+func (g FloatingIPGenerator) listFloatingIPs(ctx context.Context, client *godo.Client) ([]godo.FloatingIP, error) {
+	list := []godo.FloatingIP{}
+
+	// create options. initially, these will be blank
+	opt := &godo.ListOptions{}
+	for {
+		floatingIPs, resp, err := client.FloatingIPs.List(ctx, opt)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, floatingIP := range floatingIPs {
+			list = append(list, floatingIP)
+		}
+
+		// if we are at the last page, break out the for loop
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+
+		// set the page we want for the next request
+		opt.Page = page + 1
+	}
+
+	return list, nil
+}
+
+func (g FloatingIPGenerator) createResources(floatingIPList []godo.FloatingIP) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, floatingIP := range floatingIPList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			floatingIP.IP,
+			floatingIP.IP,
+			"digitalocean_floating_ip",
+			"digitalocean",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *FloatingIPGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := g.listFloatingIPs(context.TODO(), client)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/digitalocean/kubernetes_cluster.go
+++ b/providers/digitalocean/kubernetes_cluster.go
@@ -1,0 +1,81 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package digitalocean
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/digitalocean/godo"
+)
+
+type KubernetesClusterGenerator struct {
+	DigitalOceanService
+}
+
+func (g KubernetesClusterGenerator) listKubernetesClusters(ctx context.Context, client *godo.Client) ([]*godo.KubernetesCluster, error) {
+	list := []*godo.KubernetesCluster{}
+
+	// create options. initially, these will be blank
+	opt := &godo.ListOptions{}
+	for {
+		clusters, resp, err := client.Kubernetes.List(ctx, opt)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, cluster := range clusters {
+			list = append(list, cluster)
+		}
+
+		// if we are at the last page, break out the for loop
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+
+		// set the page we want for the next request
+		opt.Page = page + 1
+	}
+
+	return list, nil
+}
+
+func (g KubernetesClusterGenerator) createResources(clusterList []*godo.KubernetesCluster) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, cluster := range clusterList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			cluster.ID,
+			cluster.Name,
+			"digitalocean_kubernetes_cluster",
+			"digitalocean",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *KubernetesClusterGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := g.listKubernetesClusters(context.TODO(), client)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/digitalocean/loadbalancer.go
+++ b/providers/digitalocean/loadbalancer.go
@@ -1,0 +1,81 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package digitalocean
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/digitalocean/godo"
+)
+
+type LoadBalancerGenerator struct {
+	DigitalOceanService
+}
+
+func (g LoadBalancerGenerator) listLoadBalancers(ctx context.Context, client *godo.Client) ([]godo.LoadBalancer, error) {
+	list := []godo.LoadBalancer{}
+
+	// create options. initially, these will be blank
+	opt := &godo.ListOptions{}
+	for {
+		loadBalancers, resp, err := client.LoadBalancers.List(ctx, opt)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, loadBalancer := range loadBalancers {
+			list = append(list, loadBalancer)
+		}
+
+		// if we are at the last page, break out the for loop
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+
+		// set the page we want for the next request
+		opt.Page = page + 1
+	}
+
+	return list, nil
+}
+
+func (g LoadBalancerGenerator) createResources(loadBalancerList []godo.LoadBalancer) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, loadBalancer := range loadBalancerList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			loadBalancer.ID,
+			loadBalancer.Name,
+			"digitalocean_loadbalancer",
+			"digitalocean",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *LoadBalancerGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := g.listLoadBalancers(context.TODO(), client)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/digitalocean/project.go
+++ b/providers/digitalocean/project.go
@@ -1,0 +1,81 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package digitalocean
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/digitalocean/godo"
+)
+
+type ProjectGenerator struct {
+	DigitalOceanService
+}
+
+func (g ProjectGenerator) listProjects(ctx context.Context, client *godo.Client) ([]godo.Project, error) {
+	list := []godo.Project{}
+
+	// create options. initially, these will be blank
+	opt := &godo.ListOptions{}
+	for {
+		projects, resp, err := client.Projects.List(ctx, opt)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, project := range projects {
+			list = append(list, project)
+		}
+
+		// if we are at the last page, break out the for loop
+		if resp.Links == nil || resp.Links.Pages == nil || resp.Links.Pages.Next == "" {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+
+		// set the page we want for the next request
+		opt.Page = page + 1
+	}
+
+	return list, nil
+}
+
+func (g ProjectGenerator) createResources(projectList []godo.Project) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, project := range projectList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			project.ID,
+			project.Name,
+			"digitalocean_project",
+			"digitalocean",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *ProjectGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := g.listProjects(context.TODO(), client)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/digitalocean/token_source.go
+++ b/providers/digitalocean/token_source.go
@@ -1,0 +1,28 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package digitalocean
+
+import "golang.org/x/oauth2"
+
+type TokenSource struct {
+	AccessToken string
+}
+
+func (t *TokenSource) Token() (*oauth2.Token, error) {
+	token := &oauth2.Token{
+		AccessToken: t.AccessToken,
+	}
+	return token, nil
+}

--- a/providers/digitalocean/volume.go
+++ b/providers/digitalocean/volume.go
@@ -1,0 +1,81 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package digitalocean
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/digitalocean/godo"
+)
+
+type VolumeGenerator struct {
+	DigitalOceanService
+}
+
+func (g VolumeGenerator) listVolumes(ctx context.Context, client *godo.Client) ([]godo.Volume, error) {
+	list := []godo.Volume{}
+
+	// create options. initially, these will be blank
+	opt := &godo.ListVolumeParams{}
+	for {
+		volumes, resp, err := client.Storage.ListVolumes(ctx, opt)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, volume := range volumes {
+			list = append(list, volume)
+		}
+
+		// if we are at the last page, break out the for loop
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+
+		// set the page we want for the next request
+		opt.ListOptions.Page = page + 1
+	}
+
+	return list, nil
+}
+
+func (g VolumeGenerator) createResources(volumeList []godo.Volume) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, volume := range volumeList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			volume.ID,
+			volume.Name,
+			"digitalocean_volume",
+			"digitalocean",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *VolumeGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := g.listVolumes(context.TODO(), client)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}


### PR DESCRIPTION
Adds support for the [DigitalOcean provider](https://www.terraform.io/docs/providers/do/index.html). Also adds the following resources:

* `digitalocean_database_cluster`
* `digitalocean_domain`
* `digitalocean_droplet`
* `digitalocean_firewall`
* `digitalocean_floating_ip`
* `digitalocean_kubernetes_cluster`
* `digitalocean_loadbalancer`
* `digitalocean_project`
* `digitalocean_volume`

