### PR TITLE
Support Linode provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A CLI tool that generates `tf` and `tfstate` files based on existing infrastruct
     * Cloud
         * [DigitalOcean](#use-with-digitalocean)
         * [Heroku](#use-with-heroku)
+        * [Linode](#use-with-linode)
         * [OpenStack](#use-with-openstack)
     * Infrastructure Software
         * [Kubernetes](#use-with-kubernetes)
@@ -163,6 +164,7 @@ Links to download Terraform Providers:
 * Cloud
     * DigitalOcean provider >1.9.1 - [here](https://releases.hashicorp.com/terraform-provider-digitalocean/)
     * Heroku provider >2.2.1 - [here](https://releases.hashicorp.com/terraform-provider-heroku/)
+    * Linode provider >1.8.0 - [here](https://releases.hashicorp.com/terraform-provider-linode/)
     * OpenStack provider >1.21.1 - [here](https://releases.hashicorp.com/terraform-provider-openstack/)
 * Infrastructure Software
     * Kubernetes provider >=1.9.0 - [here](https://releases.hashicorp.com/terraform-provider-kubernetes/)
@@ -633,6 +635,32 @@ List of supported Heroku resources:
     * `heroku_team_collaborator`
 *   `team_member`
     * `heroku_team_member`
+
+### Use with Linode
+
+Example:
+
+```
+export LINODE_TOKEN=[LINODE_TOKEN]
+./terraformer import linode -r instance
+```
+
+List of supported Linode resources:
+
+*   `domain`
+    * `linode_domain`
+*   `image`
+    * `linode_image`
+*   `instance`
+    * `linode_instance`
+*   `nodebalancer`
+    * `linode_nodebalancer`
+*   `sshkey`
+    * `linode_sshkey`
+*   `token`
+    * `linode_token`
+*   `volume`
+    * `linode_volume`
 
 ### Use with OpenStack
 

--- a/cmd/provider_cmd_linode.go
+++ b/cmd/provider_cmd_linode.go
@@ -1,0 +1,52 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cmd
+
+import (
+	linode_terraforming "github.com/GoogleCloudPlatform/terraformer/providers/linode"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/spf13/cobra"
+)
+
+func newCmdLinodeImporter(options ImportOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "linode",
+		Short: "Import current state to Terraform configuration from Linode",
+		Long:  "Import current state to Terraform configuration from Linode",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			provider := newLinodeProvider()
+			err := Import(provider, options, []string{})
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.AddCommand(listCmd(newLinodeProvider()))
+	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
+	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "instance")
+	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
+	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
+	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
+	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
+	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "linode_instance=name1:name2:name3")
+
+	return cmd
+}
+
+func newLinodeProvider() terraform_utils.ProviderGenerator {
+	return &linode_terraforming.LinodeProvider{}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,7 @@ func providerImporterSubcommands() []func(options ImportOptions) *cobra.Command 
 		// Cloud
 		newCmdDigitalOceanImporter,
 		newCmdHerokuImporter,
+		newCmdLinodeImporter,
 		newCmdOpenStackImporter,
 		// Infrastructure Software
 		newCmdKubernetesImporter,
@@ -72,6 +73,7 @@ func providerGenerators() map[string]func() terraform_utils.ProviderGenerator {
 		// Cloud
 		newDigitalOceanProvider,
 		newHerokuProvider,
+		newLinodeProvider,
 		newOpenStackProvider,
 		// Infrastructure Software
 		newKubernetesProvider,

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 	github.com/jonboydell/logzio_client v1.2.0
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/linode/linodego v0.12.0
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,7 @@ github.com/dimchansky/utfbom v1.0.0 h1:fGC2kkf4qOoKqZ4q7iIh+Vef4ubC1c38UDsEyZynZ
 github.com/dimchansky/utfbom v1.0.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.0 h1:FcM3g+nofKgUteL8dm/UpdRXNC9KmADgTpLKsu0TRo4=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
+github.com/dnaeon/go-vcr v0.0.0-20180814043457-aafff18a5cc2/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/dnaeon/go-vcr v0.0.0-20180920040454-5637cf3d8a31/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
@@ -343,6 +344,8 @@ github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LE
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/linode/linodego v0.12.0 h1:xFjPwUOiBB9l+dTqjwnYlQ4c9mRXMiaXln20BVD/Z4U=
+github.com/linode/linodego v0.12.0/go.mod h1:cQFzVqVu5KeFy2ZSTWTA/qVNYYa9ZY8uePJZsFG7EYs=
 github.com/lusis/go-artifactory v0.0.0-20160115162124-7e4ce345df82/go.mod h1:y54tfGmO3NKssKveTEFFzH8C/akrSOy/iW9qEAUDV84=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -541,6 +544,7 @@ golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCc
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20180611182652-db08ff08e862/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180811021610-c39426892332/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -673,6 +677,7 @@ gopkg.in/ini.v1 v1.42.0 h1:7N3gPTt50s8GuLortA00n8AqRTk75qOP98+mTPpgzRk=
 gopkg.in/ini.v1 v1.42.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v0 v0.4.1 h1:nLyQUfXkzQvM8OvGO9mcIfRQsYt4VFjrjesaM2jkhS0=
 gopkg.in/resty.v0 v0.4.1/go.mod h1:SoKE7c8eCdxGIKuwCiutqghw8XPJ9SmessKt5Y965OQ=
+gopkg.in/resty.v1 v1.9.1/go.mod h1:vo52Hzryw9PnPHcJfPsBiFW62XhNx5OczbV9y+IMpgc=
 gopkg.in/resty.v1 v1.11.0 h1:z5nqGs/W/h91PLOc+WZefPj8rRZe8Ctlgxg/AtbJ+NE=
 gopkg.in/resty.v1 v1.11.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/resty.v1 v1.12.0 h1:CuXP0Pjfw9rOuY6EP+UvtNvt5DSqHpIxILZKT/quCZI=

--- a/providers/linode/domain.go
+++ b/providers/linode/domain.go
@@ -1,0 +1,50 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linode
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/linode/linodego"
+)
+
+type DomainGenerator struct {
+	LinodeService
+}
+
+func (g DomainGenerator) createResources(domainList []linodego.Domain) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, domain := range domainList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			strconv.Itoa(domain.ID),
+			strconv.Itoa(domain.ID),
+			"linode_domain",
+			"linode",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *DomainGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := client.ListDomains(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/linode/image.go
+++ b/providers/linode/image.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linode
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/linode/linodego"
+)
+
+type ImageGenerator struct {
+	LinodeService
+}
+
+func (g ImageGenerator) createResources(imageList []linodego.Image) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, image := range imageList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			image.ID,
+			image.ID,
+			"linode_image",
+			"linode",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *ImageGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := client.ListImages(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/linode/instance.go
+++ b/providers/linode/instance.go
@@ -1,0 +1,50 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linode
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/linode/linodego"
+)
+
+type InstanceGenerator struct {
+	LinodeService
+}
+
+func (g InstanceGenerator) createResources(instanceList []linodego.Instance) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, instance := range instanceList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			strconv.Itoa(instance.ID),
+			strconv.Itoa(instance.ID),
+			"linode_instance",
+			"linode",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *InstanceGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := client.ListInstances(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/linode/linode_provider.go
+++ b/providers/linode/linode_provider.go
@@ -1,0 +1,82 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linode
+
+import (
+	"errors"
+	"os"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils/provider_wrapper"
+)
+
+type LinodeProvider struct {
+	terraform_utils.Provider
+	token string
+}
+
+func (p *LinodeProvider) Init(args []string) error {
+	if os.Getenv("LINODE_TOKEN") == "" {
+		return errors.New("set LINODE_TOKEN env var")
+	}
+	p.token = os.Getenv("LINODE_TOKEN")
+
+	return nil
+}
+
+func (p *LinodeProvider) GetName() string {
+	return "linode"
+}
+
+func (p *LinodeProvider) GetProviderData(arg ...string) map[string]interface{} {
+	return map[string]interface{}{
+		"provider": map[string]interface{}{
+			"linode": map[string]interface{}{
+				"version": provider_wrapper.GetProviderVersion(p.GetName()),
+				"token":   p.token,
+			},
+		},
+	}
+}
+
+func (LinodeProvider) GetResourceConnections() map[string]map[string][]string {
+	return map[string]map[string][]string{}
+}
+
+func (p *LinodeProvider) GetSupportedService() map[string]terraform_utils.ServiceGenerator {
+	return map[string]terraform_utils.ServiceGenerator{
+		"domain":       &DomainGenerator{},
+		"image":        &ImageGenerator{},
+		"instance":     &InstanceGenerator{},
+		"nodebalancer": &NodeBalancerGenerator{},
+		"sshkey":       &SSHKeyGenerator{},
+		"token":        &TokenGenerator{},
+		"volume":       &VolumeGenerator{},
+	}
+}
+
+func (p *LinodeProvider) InitService(serviceName string) error {
+	var isSupported bool
+	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+		return errors.New("linode: " + serviceName + " not supported service")
+	}
+	p.Service = p.GetSupportedService()[serviceName]
+	p.Service.SetName(serviceName)
+	p.Service.SetProviderName(p.GetName())
+	p.Service.SetArgs(map[string]interface{}{
+		"token": p.token,
+	})
+	return nil
+}

--- a/providers/linode/linode_service.go
+++ b/providers/linode/linode_service.go
@@ -1,0 +1,38 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linode
+
+import (
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/linode/linodego"
+	"golang.org/x/oauth2"
+)
+
+type LinodeService struct {
+	terraform_utils.Service
+}
+
+func (s *LinodeService) generateClient() linodego.Client {
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: s.Args["token"].(string)})
+	oauth2Client := &http.Client{
+		Transport: &oauth2.Transport{
+			Source: tokenSource,
+		},
+	}
+	linodeClient := linodego.NewClient(oauth2Client)
+	return linodeClient
+}

--- a/providers/linode/nodebalancer.go
+++ b/providers/linode/nodebalancer.go
@@ -1,0 +1,50 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linode
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/linode/linodego"
+)
+
+type NodeBalancerGenerator struct {
+	LinodeService
+}
+
+func (g NodeBalancerGenerator) createResources(nodeBalancerList []linodego.NodeBalancer) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, nodeBalancer := range nodeBalancerList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			strconv.Itoa(nodeBalancer.ID),
+			strconv.Itoa(nodeBalancer.ID),
+			"linode_nodebalancer",
+			"linode",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *NodeBalancerGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := client.ListNodeBalancers(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/linode/sshkey.go
+++ b/providers/linode/sshkey.go
@@ -1,0 +1,50 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linode
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/linode/linodego"
+)
+
+type SSHKeyGenerator struct {
+	LinodeService
+}
+
+func (g SSHKeyGenerator) createResources(keyList []linodego.SSHKey) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, key := range keyList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			strconv.Itoa(key.ID),
+			strconv.Itoa(key.ID),
+			"linode_sshkey",
+			"linode",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *SSHKeyGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := client.ListSSHKeys(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/linode/token.go
+++ b/providers/linode/token.go
@@ -1,0 +1,50 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linode
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/linode/linodego"
+)
+
+type TokenGenerator struct {
+	LinodeService
+}
+
+func (g TokenGenerator) createResources(tokenList []linodego.Token) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, token := range tokenList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			strconv.Itoa(token.ID),
+			strconv.Itoa(token.ID),
+			"linode_token",
+			"linode",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *TokenGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := client.ListTokens(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/linode/volume.go
+++ b/providers/linode/volume.go
@@ -1,0 +1,50 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linode
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/linode/linodego"
+)
+
+type VolumeGenerator struct {
+	LinodeService
+}
+
+func (g VolumeGenerator) createResources(volumeList []linodego.Volume) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, volume := range volumeList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			strconv.Itoa(volume.ID),
+			strconv.Itoa(volume.ID),
+			"linode_volume",
+			"linode",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *VolumeGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := client.ListVolumes(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}


### PR DESCRIPTION
Adds support for the [Linode provider](https://www.terraform.io/docs/providers/linode/index.html). Also adds the following resources:

* `linode_domain`
* `linode_image`
* `linode_instance`
* `linode_nodebalancer`
* `linode_sshkey`
* `linode_token`
* `linode_volume`
