### PR TITLE
Allowed for more compacted options with output resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ Available Commands:
 Flags:
   -b, --bucket string         gs://terraform-state
   -c, --connect                (default true)
+  -t, --compact                (default false)
   -f, --filter strings        google_compute_firewall=id1:id2:id4
   -h, --help                  help for google
   -o, --path-output string     (default "generated")
-  -p, --path-pattern string   {output}/{provider}/custom/{service}/ (default "{output}/{provider}/{service}/")
+  -p, --path-pattern string   {output}/{provider}/ (default "{output}/{provider}/{service}/")
       --projects strings      
   -z, --regions strings       europe-west1, (default [global])
   -r, --resources strings     firewalls,networks

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -311,7 +311,7 @@ func listCmd(provider terraform_utils.ProviderGenerator) *cobra.Command {
 
 func baseProviderFlags(flag *pflag.FlagSet, options *ImportOptions, sampleRes, sampleFilters string) {
 	flag.BoolVarP(&options.Connect, "connect", "c", true, "")
-	flag.BoolVarP(&options.Compact, "compact", "ct", false, "")
+	flag.BoolVarP(&options.Compact, "compact", "C", false, "")
 	flag.StringSliceVarP(&options.Resources, "resources", "r", []string{}, sampleRes)
 	flag.StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/")
 	flag.StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")

--- a/cmd/provider_cmd_alicloud.go
+++ b/cmd/provider_cmd_alicloud.go
@@ -43,15 +43,9 @@ func newCmdAliCloudImporter(options ImportOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(listCmd(newAliCloudProvider()))
-	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
-	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "vpc,subnet,nacl")
-	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
-	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
-	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
-	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "vpc,subnet,nacl", "alicloud_slb=id1:id2:id4")
 	cmd.PersistentFlags().StringVar(&options.Profile, "profile", "default", "prod")
 	cmd.PersistentFlags().StringSliceVarP(&options.Regions, "regions", "", []string{}, "cn-hangzhou")
-	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "alicloud_slb=id1:id2:id4") // TODO: Not implemented
 	return cmd
 }
 

--- a/cmd/provider_cmd_aws.go
+++ b/cmd/provider_cmd_aws.go
@@ -60,15 +60,10 @@ func newCmdAwsImporter(options ImportOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(listCmd(newAWSProvider()))
-	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
-	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "vpc,subnet,nacl")
-	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
-	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
-	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
-	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
-	cmd.PersistentFlags().StringVar(&options.Profile, "profile", "default", "prod")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "vpc,subnet,nacl", "aws_elb=id1:id2:id4")
+
+	cmd.PersistentFlags().StringVarP(&options.Profile, "profile", "", "default", "prod")
 	cmd.PersistentFlags().StringSliceVarP(&options.Regions, "regions", "", []string{}, "eu-west-1,eu-west-2,us-east-1")
-	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "aws_elb=id1:id2:id4")
 	return cmd
 }
 

--- a/cmd/provider_cmd_azure.go
+++ b/cmd/provider_cmd_azure.go
@@ -36,13 +36,7 @@ func newCmdAzureImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newAzureProvider()))
-	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
-	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "resource_group")
-	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
-	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
-	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
-	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
-	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "resource_group=name1:name2:name3")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "resource_group", "resource_group=name1:name2:name3")
 	return cmd
 }
 

--- a/cmd/provider_cmd_cloudflare.go
+++ b/cmd/provider_cmd_cloudflare.go
@@ -36,12 +36,7 @@ func newCmdCloudflareImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newCloudflareProvider()))
-	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
-	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "zone")
-	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
-	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
-	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
-	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "zone", "cloudflare_access_application=id1:id2:id4")
 	return cmd
 }
 

--- a/cmd/provider_cmd_datadog.go
+++ b/cmd/provider_cmd_datadog.go
@@ -35,15 +35,9 @@ func newCmdDatadogImporter(options ImportOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(listCmd(newDataDogProvider()))
-	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
-	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "monitors,users")
-	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
-	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
-	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
-	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "monitors,users", "datadog_monitor=id1:id2:id4")
 	cmd.PersistentFlags().StringVarP(&apiKey, "api-key", "", "", "YOUR_DATADOG_API_KEY or env param DATADOG_API_KEY")
 	cmd.PersistentFlags().StringVarP(&appKey, "app-key", "", "", "YOUR_DATADOG_APP_KEY or env param DATADOG_APP_KEY")
-	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "datadog_monitor=id1:id2:id4")
 	return cmd
 }
 

--- a/cmd/provider_cmd_digitalocean.go
+++ b/cmd/provider_cmd_digitalocean.go
@@ -36,13 +36,7 @@ func newCmdDigitalOceanImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newDigitalOceanProvider()))
-	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
-	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "project,droplet")
-	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
-	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
-	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
-	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
-	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "digitalocean_project=name1:name2:name3")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "project,droplet", "digitalocean_project=name1:name2:name3")
 
 	return cmd
 }

--- a/cmd/provider_cmd_github.go
+++ b/cmd/provider_cmd_github.go
@@ -45,14 +45,8 @@ func newCmdGithubImporter(options ImportOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(listCmd(newGitHubProvider()))
-	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
-	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "repository")
-	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
-	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
-	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
-	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "repository", "github_repository=id1:id2:id4")
 	cmd.PersistentFlags().StringVarP(&token, "token", "t", "", "YOUR_GITHUB_TOKEN or env param GITHUB_TOKEN")
-	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "github_repository=id1:id2:id4")
 	cmd.PersistentFlags().StringSliceVarP(&organizations, "organizations", "", []string{}, "")
 	return cmd
 }

--- a/cmd/provider_cmd_google.go
+++ b/cmd/provider_cmd_google.go
@@ -45,14 +45,8 @@ func newCmdGoogleImporter(options ImportOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(listCmd(newGoogleProvider()))
-	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
-	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "firewalls,networks")
-	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
-	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
-	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
-	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "firewalls,networks", "google_compute_firewall=id1:id2:id4")
 	cmd.PersistentFlags().StringSliceVarP(&options.Regions, "regions", "z", []string{"global"}, "europe-west1,")
-	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "google_compute_firewall=id1:id2:id4")
 	cmd.PersistentFlags().StringSliceVarP(&options.Projects, "projects", "", []string{}, "")
 	_ = cmd.MarkPersistentFlagRequired("projects")
 	return cmd

--- a/cmd/provider_cmd_heroku.go
+++ b/cmd/provider_cmd_heroku.go
@@ -36,14 +36,7 @@ func newCmdHerokuImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newHerokuProvider()))
-	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
-	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "app,addon")
-	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
-	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
-	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
-	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
-	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "heroku_app=name1:name2:name3")
-
+	baseProviderFlags(cmd.PersistentFlags(), &options, "app,addon", "heroku_app=name1:name2:name3")
 	return cmd
 }
 

--- a/cmd/provider_cmd_kubernetes.go
+++ b/cmd/provider_cmd_kubernetes.go
@@ -35,13 +35,7 @@ func newCmdKubernetesImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newKubernetesProvider()))
-	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
-	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "configmaps,deployments,services")
-	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
-	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
-	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
-	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
-	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "kubernetes_deployment=name1:name2:name3")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "configmaps,deployments,services", "kubernetes_deployment=name1:name2:name3")
 	return cmd
 }
 

--- a/cmd/provider_cmd_linode.go
+++ b/cmd/provider_cmd_linode.go
@@ -36,14 +36,7 @@ func newCmdLinodeImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newLinodeProvider()))
-	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
-	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "instance")
-	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
-	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
-	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
-	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
-	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "linode_instance=name1:name2:name3")
-
+	baseProviderFlags(cmd.PersistentFlags(), &options, "instance", "linode_instance=name1:name2:name3")
 	return cmd
 }
 

--- a/cmd/provider_cmd_logzio.go
+++ b/cmd/provider_cmd_logzio.go
@@ -50,13 +50,7 @@ func newCmdLogzioImporter(options ImportOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(listCmd(newLogzioProvider()))
-	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
-	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "repository")
-	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
-	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
-	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
-	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
-	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "logzio_alert=id1:id2:id4")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "repository", "logzio_alert=id1:id2:id4")
 	return cmd
 }
 

--- a/cmd/provider_cmd_newrelic.go
+++ b/cmd/provider_cmd_newrelic.go
@@ -36,12 +36,7 @@ func newCmdNewRelicImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newNewRelicProvider()))
-	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", false, "")
-	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "alert")
-	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
-	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
-	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
-	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "alert", "newrelic_dashboard=id1:id2:id4")
 	return cmd
 }
 

--- a/cmd/provider_cmd_openstack.go
+++ b/cmd/provider_cmd_openstack.go
@@ -42,14 +42,8 @@ func newCmdOpenStackImporter(options ImportOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(listCmd(newOpenStackProvider()))
-	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
-	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "compute,networking")
-	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
-	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
-	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
-	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "compute,networking", "openstack_compute_instance_v2=id1:id2:id4")
 	cmd.PersistentFlags().StringSliceVarP(&options.Regions, "regions", "", []string{}, "RegionOne")
-	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "openstack_compute_instance_v2=id1:id2:id4")
 	return cmd
 }
 

--- a/terraform_utils/connect.go
+++ b/terraform_utils/connect.go
@@ -14,7 +14,7 @@
 
 package terraform_utils
 
-func ConnectServices(importResources map[string][]Resource, resourceConnections map[string]map[string][]string) map[string][]Resource {
+func ConnectServices(importResources map[string][]Resource, isServicePath bool, resourceConnections map[string]map[string][]string) map[string][]Resource {
 	for resource, connection := range resourceConnections {
 		if _, exist := importResources[resource]; exist {
 			for k, connectionPairs := range connection {
@@ -25,7 +25,11 @@ func ConnectServices(importResources map[string][]Resource, resourceConnections 
 					for i := 0; i < len(connectionPairs)/2; i++ {
 						connectionPair := []string{connectionPairs[i*2], connectionPairs[i*2+1]}
 						for _, ccc := range cc {
-							mapResource(importResources, resource, connectionPair, ccc, k)
+							if !isServicePath {
+								mapResource(importResources, resource, connectionPair, ccc, "local")
+							} else {
+								mapResource(importResources, resource, connectionPair, ccc, k)
+							}
 						}
 					}
 				}

--- a/terraform_utils/connect_test.go
+++ b/terraform_utils/connect_test.go
@@ -36,7 +36,7 @@ func TestSimpleReference(t *testing.T) {
 			"type2": {"type2_ref", "id"},
 		},
 	}
-	resources := ConnectServices(importResources, resourceConnections)
+	resources := ConnectServices(importResources, true, resourceConnections)
 
 	if !reflect.DeepEqual(resources["type1"][0].Item, map[string]interface{}{
 		"type2_ref": "${data.terraform_remote_state.type2.outputs.type2_tfer--name-type2_id}",
@@ -65,7 +65,7 @@ func TestManyReferences(t *testing.T) {
 			},
 		},
 	}
-	resources := ConnectServices(importResources, resourceConnections)
+	resources := ConnectServices(importResources, true, resourceConnections)
 
 	if !reflect.DeepEqual(resources["type1"][0].Item, map[string]interface{}{
 		"type2_ref1": "${data.terraform_remote_state.type2.outputs.type2_tfer--name-type2_id}",
@@ -102,7 +102,7 @@ func TestResourceGroups(t *testing.T) {
 			},
 		},
 	}
-	resources := ConnectServices(importResources, resourceConnections)
+	resources := ConnectServices(importResources, true, resourceConnections)
 
 	if !reflect.DeepEqual(resources["group1"][0].Item, map[string]interface{}{
 		"type2_ref1": "${data.terraform_remote_state.group2.outputs.type2_tfer--name-type2_uid}",
@@ -125,7 +125,7 @@ func TestNestedReference(t *testing.T) {
 			"type2": {"nested.type2_ref", "id"},
 		},
 	}
-	resources := ConnectServices(importResources, resourceConnections)
+	resources := ConnectServices(importResources, true, resourceConnections)
 
 	if !reflect.DeepEqual(resources["type1"][0].Item, mapI("nested", mapI("type2_ref", "${data.terraform_remote_state.type2.outputs.type2_tfer--name-type2_id}"))) {
 		t.Errorf("failed to connect %v", resources)

--- a/terraform_utils/service_test.go
+++ b/terraform_utils/service_test.go
@@ -88,10 +88,16 @@ func TestServiceAttributeCleanupWithFilter(t *testing.T) {
 				InstanceInfo: &terraform.InstanceInfo{
 					Type: "aws_vpc",
 				},
+				InstanceState: &terraform.InstanceState{
+					ID: "vpc1",
+				},
 				Item: mapI("tags", mapI("Name", "some"))},
 			{
 				InstanceInfo: &terraform.InstanceInfo{
 					Type: "aws_vpc",
+				},
+				InstanceState: &terraform.InstanceState{
+					ID: "vpc2",
 				},
 				Item: mapI("tags", mapI("Name", "default"))}},
 	}

--- a/tests/aws/main.go
+++ b/tests/aws/main.go
@@ -52,30 +52,29 @@ func main() {
 	}
 	err := cmd.Import(provider, cmd.ImportOptions{
 		Resources:   services,
-		PathPattern: cmd.DefaultPathPattern,
+		PathPattern: "{output}/{provider}/",
 		PathOutput:  cmd.DefaultPathOutput,
 		State:       "local",
 		Connect:     true,
+		Compact:     true,
 	}, []string{region, profile})
 	if err != nil {
 		log.Println(err)
 		os.Exit(1)
 	}
 	rootPath, _ := os.Getwd()
-	for _, serviceName := range services {
-		currentPath := cmd.Path(cmd.DefaultPathPattern, provider.GetName(), serviceName, cmd.DefaultPathOutput)
-		if err := os.Chdir(currentPath); err != nil {
-			log.Println(err)
-			os.Exit(1)
-		}
-		cmd := exec.Command("sh", "-c", command)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		err = cmd.Run()
-		if err != nil {
-			log.Println(err)
-			os.Exit(1)
-		}
-		os.Chdir(rootPath)
+	currentPath := cmd.Path(cmd.DefaultPathPattern, provider.GetName(), "", cmd.DefaultPathOutput)
+	if err := os.Chdir(currentPath); err != nil {
+		log.Println(err)
+		os.Exit(1)
 	}
+	cmd := exec.Command("sh", "-c", command)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
+	os.Chdir(rootPath)
 }


### PR DESCRIPTION
This PR simplifies the output resource structure. It's possible to:

1. Provide output path without `{service}` part, so that all resources will be saved in one directory
2. Provide `--compact` option which allows for saving all of providers resources under `resources.tf` file

If a user invokes terraformer with parameters `--path-pattern={output}/{provider}/ --compact=true`, all generated resources will be saved in `resources.tf` file in a provider's output directory.

This PR partially solves #242  - at least just one backend configuration to add.
It also organizes arguments across providers.