### PR TITLE
Match the config arguments to those in the provider.

### DIFF
--- a/providers/logzio/alert_notification_endpoints.go
+++ b/providers/logzio/alert_notification_endpoints.go
@@ -29,7 +29,7 @@ type AlertNotificationEndpointsGenerator struct {
 // Generate Terraform Resources from Logzio API,
 func (g *AlertNotificationEndpointsGenerator) InitResources() error {
 	var client *endpoints.EndpointsClient
-	client, _ = endpoints.New(g.Args["token"].(string), g.Args["baseURL"].(string))
+	client, _ = endpoints.New(g.Args["api_token"].(string), g.Args["base_url"].(string))
 
 	endpoints, err := client.ListEndpoints()
 	if err != nil {

--- a/providers/logzio/alerts.go
+++ b/providers/logzio/alerts.go
@@ -29,7 +29,7 @@ type AlertsGenerator struct {
 // Generate Terraform Resources from Logzio API,
 func (g *AlertsGenerator) InitResources() error {
 	var client *alerts.AlertsClient
-	client, _ = alerts.New(g.Args["token"].(string), g.Args["baseURL"].(string))
+	client, _ = alerts.New(g.Args["api_token"].(string), g.Args["base_url"].(string))
 
 	alerts, err := client.ListAlerts()
 	if err != nil {

--- a/providers/logzio/logzio_provider.go
+++ b/providers/logzio/logzio_provider.go
@@ -26,8 +26,8 @@ import (
 
 type LogzioProvider struct {
 	terraform_utils.Provider
-	token   string
-	baseURL string
+	api_token string // this must match the Config in the provider
+	base_url  string // this must match the Config in the provider
 }
 
 var (
@@ -52,15 +52,15 @@ func (p LogzioProvider) GetProviderData(arg ...string) map[string]interface{} {
 
 func (p *LogzioProvider) GetConfig() cty.Value {
 	return cty.ObjectVal(map[string]cty.Value{
-		"token":   cty.StringVal(p.token),
-		"baseURL": cty.StringVal(p.baseURL),
+		"api_token": cty.StringVal(p.api_token),
+		"base_url":  cty.StringVal(p.base_url),
 	})
 }
 
-// Init LogzioProvider with API token
+// Init LogzioProvider with API api_token
 func (p *LogzioProvider) Init(args []string) error {
-	p.token = args[0]
-	p.baseURL = args[1]
+	p.api_token = args[0]
+	p.base_url = args[1]
 	return nil
 }
 
@@ -77,8 +77,8 @@ func (p *LogzioProvider) InitService(serviceName string) error {
 	p.Service.SetName(serviceName)
 	p.Service.SetProviderName(p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
-		"token":   p.token,
-		"baseURL": p.baseURL,
+		"api_token": p.api_token,
+		"base_url":  p.base_url,
 	})
 	return nil
 }

--- a/providers/logzio/logzio_provider.go
+++ b/providers/logzio/logzio_provider.go
@@ -26,8 +26,8 @@ import (
 
 type LogzioProvider struct {
 	terraform_utils.Provider
-	api_token string // this must match the Config in the provider
-	base_url  string // this must match the Config in the provider
+	apiToken string
+	baseURL  string
 }
 
 var (
@@ -52,15 +52,15 @@ func (p LogzioProvider) GetProviderData(arg ...string) map[string]interface{} {
 
 func (p *LogzioProvider) GetConfig() cty.Value {
 	return cty.ObjectVal(map[string]cty.Value{
-		"api_token": cty.StringVal(p.api_token),
-		"base_url":  cty.StringVal(p.base_url),
+		"api_token": cty.StringVal(p.apiToken),
+		"base_url":  cty.StringVal(p.baseURL),
 	})
 }
 
-// Init LogzioProvider with API api_token
+// Init LogzioProvider with API apiToken
 func (p *LogzioProvider) Init(args []string) error {
-	p.api_token = args[0]
-	p.base_url = args[1]
+	p.apiToken = args[0]
+	p.baseURL = args[1]
 	return nil
 }
 
@@ -77,8 +77,8 @@ func (p *LogzioProvider) InitService(serviceName string) error {
 	p.Service.SetName(serviceName)
 	p.Service.SetProviderName(p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
-		"api_token": p.api_token,
-		"base_url":  p.base_url,
+		"api_token": p.apiToken,
+		"base_url":  p.baseURL,
 	})
 	return nil
 }


### PR DESCRIPTION
Terraform 0.12 is grabbing the values coming back for the provider logzio_terraform_provider but these aren't being matched in the terraformer provider for logzio.

Changing the looked up values in terraformer rather than the provide to avoid downstream breaking.

token -> api_token
baseURL -> base_url