### PR TITLE
Escape Terraform Unsafe Characters instead of Replacing with `--`

### DIFF
--- a/terraform_utils/hcl.go
+++ b/terraform_utils/hcl.go
@@ -33,7 +33,7 @@ import (
 
 const safeChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_"
 
-var unsafeChars = regexp.MustCompile(`[^-0-9A-Za-z_]`)
+var unsafeChars = regexp.MustCompile(`[^0-9A-Za-z_]`)
 
 // sanitizer fixes up an invalid HCL AST, as produced by the HCL parser for JSON
 type astSanitizer struct{}
@@ -188,9 +188,13 @@ func terraform12Adjustments(formatted []byte, mapsObjects map[string]struct{}) [
 	return []byte(s)
 }
 
+func escapeRune(s string) string {
+	return fmt.Sprintf("-%04X-", s)
+}
+
 // Sanitize name for terraform style
 func TfSanitize(name string) string {
-	name = unsafeChars.ReplaceAllString(name, "--")
+	name = unsafeChars.ReplaceAllStringFunc(name, escapeRune)
 	name = "tfer--" + name
 	return name
 }


### PR DESCRIPTION
Previously, characters that could not be used in Terraform identifiers were replaced by `--`. This behavior cloud lead to a resource name collision, for example `(example)` and `[example]` would generate `--example--`.

Instead of replacing those characters with a fixed string, we can escape those characters making any two different string generate a unique Terraform identifier.

As specified in Terraform's documentation, `-` character is a valid identifier character, although it is not recommended to be used and `_` should be used instead. So I used `-` as a scape character.

Everything that is not `_` and is not between `0` and `9`, `A` and `Z`, and `a` and `z` should be escaped, `-` included. To escape characters we could simply use the character's Unicode value, so even emojis could be used on resources' identifier and generate a safe Terraform identifier.

- `~` would become `-007E-`
- ` !` would become `-0021-`
- `@` would become `-0040-`
- `-` would become `-002D-`

If a resource was named as `3x 4mp	!3` it now would be identified as `tfer--3x-0020-4mp-0009--0021-3` on Terraform.