### PR TITLE
Add support for AWS Cloud9

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Flags:
   -h, --help                  help for google
   -o, --path-output string     (default "generated")
   -p, --path-pattern string   {output}/{provider}/custom/{service}/ (default "{output}/{provider}/{service}/")
-      --projects strings      
+      --projects strings
   -z, --regions strings       europe-west1, (default [global])
   -r, --resources strings     firewalls,networks
   -s, --state string          local or bucket (default "local")
@@ -360,6 +360,8 @@ In that case terraformer will not know with which region resources are associate
     * `aws_launch_template`
 *   `budgets`
     * `aws_budgets_budget`
+*   `cloud9`
+    * `aws_cloud9_environment_ec2`
 *   `cloudfront`
     * `aws_cloudfront_distribution`
 *   `cloudformation`

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -198,6 +198,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraform_utils.ServiceGe
 		"alb":            &AlbGenerator{},
 		"auto_scaling":   &AutoScalingGenerator{},
 		"budgets":        &BudgetsGenerator{},
+		"cloud9":         &Cloud9Generator{},
 		"cloudformation": &CloudFormationGenerator{},
 		"cloudfront":     &CloudFrontGenerator{},
 		"cloudtrail":     &CloudTrailGenerator{},

--- a/providers/aws/cloud9.go
+++ b/providers/aws/cloud9.go
@@ -1,0 +1,52 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloud9"
+)
+
+var cloud9AllowEmptyValues = []string{"tags."}
+
+type Cloud9Generator struct {
+	AWSService
+}
+
+func (g Cloud9Generator) createResources(environmentIds []*string) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, environmentId := range environmentIds {
+		resourceName := aws.StringValue(environmentId)
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			resourceName,
+			resourceName,
+			"aws_cloud9_environment_ec2",
+			"aws",
+			cloud9AllowEmptyValues))
+	}
+	return resources
+}
+
+func (g *Cloud9Generator) InitResources() error {
+	sess := g.generateSession()
+	svc := cloud9.New(sess)
+	output, err := svc.ListEnvironments(&cloud9.ListEnvironmentsInput{})
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output.EnvironmentIds)
+	return nil
+}


### PR DESCRIPTION
Adds support for the [`aws_cloud9_environment_ec2`](https://www.terraform.io/docs/providers/aws/r/cloud9_environment_ec2.html) resource.