### PR TITLE
Fix typo in rabbitmq_provider

### DIFF
--- a/providers/rabbitmq/rabbitmq_provider.go
+++ b/providers/rabbitmq/rabbitmq_provider.go
@@ -52,9 +52,9 @@ func (p *RBTProvider) GetProviderData(arg ...string) map[string]interface{} {
 
 func (p *RBTProvider) GetConfig() cty.Value {
 	return cty.ObjectVal(map[string]cty.Value{
-		"endpoint":      cty.StringVal(p.endpoint),
-		"userself_link": cty.StringVal(p.username),
-		"password":      cty.StringVal(p.password),
+		"endpoint": cty.StringVal(p.endpoint),
+		"username": cty.StringVal(p.username),
+		"password": cty.StringVal(p.password),
 	})
 }
 


### PR DESCRIPTION
This PR will fix a typo (copy/paste ?) in providers/rabbitmq/rabbitmq_provider.go. Sorry !