### PR TITLE
Add aws_route_table_association importing support

### DIFF
--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -101,7 +101,9 @@ func (p AWSProvider) GetResourceConnections() map[string]map[string][]string {
 			"sg":     []string{"vpc_security_group_ids", "id"},
 		},
 		"route_table": {
-			"vpc": []string{"vpc_id", "id"},
+			"route_table": []string{"route_table_id", "id"},
+			"subnet":      []string{"subnet_id", "id"},
+			"vpc":         []string{"vpc_id", "id"},
 		},
 		"sns": {
 			"sns": []string{"topic_arn", "id"},

--- a/terraform_utils/hcl.go
+++ b/terraform_utils/hcl.go
@@ -164,7 +164,7 @@ func HclPrint(data interface{}, mapsObjects map[string]struct{}) ([]byte, error)
 	if err != nil {
 		log.Println("Invalid HCL follows:")
 		for i, line := range strings.Split(s, "\n") {
-			fmt.Printf("%d\t%s", i+1, line)
+			fmt.Printf("%4d|\t%s\n", i+1, line)
 		}
 		return nil, fmt.Errorf("error formatting HCL: %v", err)
 	}


### PR DESCRIPTION
This PR adds `aws_route_table_association` and `aws_main_route_table_association` importing support along with `aws_route_table`.