### PR TITLE
Support Vultr provider 🐦 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A CLI tool that generates `tf` and `tfstate` files based on existing infrastruct
         * [Heroku](#use-with-heroku)
         * [Linode](#use-with-linode)
         * [OpenStack](#use-with-openstack)
+        * [Vultr](#use-with-vultr)
     * Infrastructure Software
         * [Kubernetes](#use-with-kubernetes)
         * [RabbitMQ](#use-with-rabbitmq)
@@ -168,6 +169,7 @@ Links to download Terraform Providers:
     * Heroku provider >2.2.1 - [here](https://releases.hashicorp.com/terraform-provider-heroku/)
     * Linode provider >1.8.0 - [here](https://releases.hashicorp.com/terraform-provider-linode/)
     * OpenStack provider >1.21.1 - [here](https://releases.hashicorp.com/terraform-provider-openstack/)
+    * Vultr provider >1.0.5 - [here](https://releases.hashicorp.com/terraform-provider-vultr/)
 * Infrastructure Software
     * Kubernetes provider >=1.9.0 - [here](https://releases.hashicorp.com/terraform-provider-kubernetes/)
 * Network
@@ -696,6 +698,40 @@ List of supported OpenStack services:
 *   `networking`
     * `openstack_networking_secgroup_v2`
     * `openstack_networking_secgroup_rule_v2`
+
+### Use with Vultr
+
+Example:
+
+```
+export VULTR_API_KEY=[VULTR_API_KEY]
+./terraformer import vultr -r server
+```
+
+List of supported Vultr resources:
+
+*   `bare_metal_server`
+    * `vultr_bare_metal_server`
+*   `block_storage`
+    * `vultr_block_storage`
+*   `dns_domain`
+    * `vultr_dns_domain`
+*   `firewall_group`
+    * `vultr_firewall_group`
+*   `network`
+    * `vultr_network`
+*   `reserved_ip`
+    * `vultr_reserved_ip`
+*   `server`
+    * `vultr_server`
+*   `snapshot`
+    * `vultr_snapshot`
+*   `ssh_key`
+    * `vultr_ssh_key`
+*   `startup_script`
+    * `vultr_startup_script`
+*   `user`
+    * `vultr_user`
 
 ### Use with Kubernetes
 

--- a/cmd/provider_cmd_vultr.go
+++ b/cmd/provider_cmd_vultr.go
@@ -1,0 +1,52 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cmd
+
+import (
+	vultr_terraforming "github.com/GoogleCloudPlatform/terraformer/providers/vultr"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/spf13/cobra"
+)
+
+func newCmdVultrImporter(options ImportOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vultr",
+		Short: "Import current state to Terraform configuration from Vultr",
+		Long:  "Import current state to Terraform configuration from Vultr",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			provider := newVultrProvider()
+			err := Import(provider, options, []string{})
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.AddCommand(listCmd(newVultrProvider()))
+	cmd.PersistentFlags().BoolVarP(&options.Connect, "connect", "c", true, "")
+	cmd.PersistentFlags().StringSliceVarP(&options.Resources, "resources", "r", []string{}, "server")
+	cmd.PersistentFlags().StringVarP(&options.PathPattern, "path-pattern", "p", DefaultPathPattern, "{output}/{provider}/custom/{service}/")
+	cmd.PersistentFlags().StringVarP(&options.PathOutput, "path-output", "o", DefaultPathOutput, "")
+	cmd.PersistentFlags().StringVarP(&options.State, "state", "s", DefaultState, "local or bucket")
+	cmd.PersistentFlags().StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
+	cmd.PersistentFlags().StringSliceVarP(&options.Filter, "filter", "f", []string{}, "vultr_server=name1:name2:name3")
+
+	return cmd
+}
+
+func newVultrProvider() terraform_utils.ProviderGenerator {
+	return &vultr_terraforming.VultrProvider{}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,7 @@ func providerImporterSubcommands() []func(options ImportOptions) *cobra.Command 
 		newCmdHerokuImporter,
 		newCmdLinodeImporter,
 		newCmdOpenStackImporter,
+		newCmdVultrImporter,
 		// Infrastructure Software
 		newCmdKubernetesImporter,
 		newCmdRabbitMQImporter,
@@ -76,6 +77,7 @@ func providerGenerators() map[string]func() terraform_utils.ProviderGenerator {
 		newHerokuProvider,
 		newLinodeProvider,
 		newOpenStackProvider,
+		newVultrProvider,
 		// Infrastructure Software
 		newKubernetesProvider,
 		newRabbitMQProvider,

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/google/go-github/v25 v25.1.3
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/gophercloud/gophercloud v0.4.1-0.20190920074709-6e93a6ba3b09
-	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/hashicorp/go-hclog v0.9.2
 	github.com/hashicorp/go-plugin v1.0.1
 	github.com/hashicorp/go-version v1.2.0 // indirect
@@ -51,6 +50,7 @@ require (
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect
 	github.com/ulikunitz/xz v0.5.6 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
+	github.com/vultr/govultr v0.1.6
 	github.com/zclconf/go-cty v1.1.0
 	github.com/zorkian/go-datadog-api v2.24.0+incompatible
 	go.opencensus.io v0.22.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -260,6 +260,8 @@ github.com/hashicorp/go-plugin v1.0.1-0.20190610192547-a1bc61569a26/go.mod h1:++
 github.com/hashicorp/go-plugin v1.0.1 h1:4OtAfUGbnKC6yS48p0CtMX2oFYtzFZVv6rok3cRWgnE=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-retryablehttp v0.5.2/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
+github.com/hashicorp/go-retryablehttp v0.6.3 h1:tuulM+WnToeqa05z83YLmKabZxrySOmJAd4mJ+s2Nfg=
+github.com/hashicorp/go-retryablehttp v0.6.3/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
@@ -497,6 +499,8 @@ github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6Ac
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/vultr/govultr v0.1.6 h1:FZqwbph8iir4IwUjC/bZfnulM3OejhNoI2ebYUlvNCs=
+github.com/vultr/govultr v0.1.6/go.mod h1:glSLa57Jdj5s860EEc6+DEBbb/t3aUOKnB4gVPmDVlQ=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=

--- a/providers/vultr/bare_metal_server.go
+++ b/providers/vultr/bare_metal_server.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vultr
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/vultr/govultr"
+)
+
+type BareMetalServerGenerator struct {
+	VultrService
+}
+
+func (g BareMetalServerGenerator) createResources(serverList []govultr.BareMetalServer) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, server := range serverList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			server.BareMetalServerID,
+			server.BareMetalServerID,
+			"vultr_bare_metal_server",
+			"vultr",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *BareMetalServerGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := client.BareMetalServer.List(context.Background())
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/vultr/block_storage.go
+++ b/providers/vultr/block_storage.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vultr
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/vultr/govultr"
+)
+
+type BlockStorageGenerator struct {
+	VultrService
+}
+
+func (g BlockStorageGenerator) createResources(blockStorageList []govultr.BlockStorage) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, blockStorage := range blockStorageList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			blockStorage.BlockStorageID,
+			blockStorage.BlockStorageID,
+			"vultr_block_storage",
+			"vultr",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *BlockStorageGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := client.BlockStorage.List(context.Background())
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/vultr/dns_domain.go
+++ b/providers/vultr/dns_domain.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vultr
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/vultr/govultr"
+)
+
+type DNSDomainGenerator struct {
+	VultrService
+}
+
+func (g DNSDomainGenerator) createResources(domainList []govultr.DNSDomain) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, domain := range domainList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			domain.Domain,
+			domain.Domain,
+			"vultr_dns_domain",
+			"vultr",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *DNSDomainGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := client.DNSDomain.List(context.Background())
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/vultr/firewall_group.go
+++ b/providers/vultr/firewall_group.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vultr
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/vultr/govultr"
+)
+
+type FirewallGroupGenerator struct {
+	VultrService
+}
+
+func (g FirewallGroupGenerator) createResources(firewallGroup []govultr.FirewallGroup) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, firewallGroup := range firewallGroup {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			firewallGroup.FirewallGroupID,
+			firewallGroup.FirewallGroupID,
+			"vultr_firewall_group",
+			"vultr",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *FirewallGroupGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := client.FirewallGroup.List(context.Background())
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/vultr/network.go
+++ b/providers/vultr/network.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vultr
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/vultr/govultr"
+)
+
+type NetworkGenerator struct {
+	VultrService
+}
+
+func (g NetworkGenerator) createResources(networkList []govultr.Network) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, network := range networkList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			network.NetworkID,
+			network.NetworkID,
+			"vultr_network",
+			"vultr",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *NetworkGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := client.Network.List(context.Background())
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/vultr/reserved_ip.go
+++ b/providers/vultr/reserved_ip.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vultr
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/vultr/govultr"
+)
+
+type ReservedIPGenerator struct {
+	VultrService
+}
+
+func (g ReservedIPGenerator) createResources(ipList []govultr.ReservedIP) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, ip := range ipList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			ip.ReservedIPID,
+			ip.ReservedIPID,
+			"vultr_reserved_ip",
+			"vultr",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *ReservedIPGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := client.ReservedIP.List(context.Background())
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/vultr/server.go
+++ b/providers/vultr/server.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vultr
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/vultr/govultr"
+)
+
+type ServerGenerator struct {
+	VultrService
+}
+
+func (g ServerGenerator) createResources(serverList []govultr.Server) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, server := range serverList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			server.InstanceID,
+			server.InstanceID,
+			"vultr_server",
+			"vultr",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *ServerGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := client.Server.List(context.Background())
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/vultr/snapshot.go
+++ b/providers/vultr/snapshot.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vultr
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/vultr/govultr"
+)
+
+type SnapshotGenerator struct {
+	VultrService
+}
+
+func (g SnapshotGenerator) createResources(snapshotList []govultr.Snapshot) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, snapshot := range snapshotList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			snapshot.SnapshotID,
+			snapshot.SnapshotID,
+			"vultr_snapshot",
+			"vultr",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *SnapshotGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := client.Snapshot.List(context.Background())
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/vultr/ssh_key.go
+++ b/providers/vultr/ssh_key.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vultr
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/vultr/govultr"
+)
+
+type SSHKeyGenerator struct {
+	VultrService
+}
+
+func (g SSHKeyGenerator) createResources(keyList []govultr.SSHKey) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, key := range keyList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			key.SSHKeyID,
+			key.SSHKeyID,
+			"vultr_ssh_key",
+			"vultr",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *SSHKeyGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := client.SSHKey.List(context.Background())
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/vultr/startup_script.go
+++ b/providers/vultr/startup_script.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vultr
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/vultr/govultr"
+)
+
+type StartupScriptGenerator struct {
+	VultrService
+}
+
+func (g StartupScriptGenerator) createResources(scriptList []govultr.StartupScript) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, script := range scriptList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			script.ScriptID,
+			script.ScriptID,
+			"vultr_startup_script",
+			"vultr",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *StartupScriptGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := client.StartupScript.List(context.Background())
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/vultr/user.go
+++ b/providers/vultr/user.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vultr
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/vultr/govultr"
+)
+
+type UserGenerator struct {
+	VultrService
+}
+
+func (g UserGenerator) createResources(userList []govultr.User) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, user := range userList {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			user.UserID,
+			user.UserID,
+			"vultr_user",
+			"vultr",
+			[]string{}))
+	}
+	return resources
+}
+
+func (g *UserGenerator) InitResources() error {
+	client := g.generateClient()
+	output, err := client.User.List(context.Background())
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(output)
+	return nil
+}

--- a/providers/vultr/vultr_provider.go
+++ b/providers/vultr/vultr_provider.go
@@ -1,0 +1,86 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vultr
+
+import (
+	"errors"
+	"os"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils/provider_wrapper"
+)
+
+type VultrProvider struct {
+	terraform_utils.Provider
+	apiKey string
+}
+
+func (p *VultrProvider) Init(args []string) error {
+	if os.Getenv("VULTR_API_KEY") == "" {
+		return errors.New("set VULTR_API_KEY env var")
+	}
+	p.apiKey = os.Getenv("VULTR_API_KEY")
+
+	return nil
+}
+
+func (p *VultrProvider) GetName() string {
+	return "vultr"
+}
+
+func (p *VultrProvider) GetProviderData(arg ...string) map[string]interface{} {
+	return map[string]interface{}{
+		"provider": map[string]interface{}{
+			"vultr": map[string]interface{}{
+				"version": provider_wrapper.GetProviderVersion(p.GetName()),
+				"api_key": p.apiKey,
+			},
+		},
+	}
+}
+
+func (VultrProvider) GetResourceConnections() map[string]map[string][]string {
+	return map[string]map[string][]string{}
+}
+
+func (p *VultrProvider) GetSupportedService() map[string]terraform_utils.ServiceGenerator {
+	return map[string]terraform_utils.ServiceGenerator{
+		"bare_metal_server": &BareMetalServerGenerator{},
+		"block_storage":     &BlockStorageGenerator{},
+		"dns_domain":        &DNSDomainGenerator{},
+		"firewall_group":    &FirewallGroupGenerator{},
+		"network":           &NetworkGenerator{},
+		"reserved_ip":       &ReservedIPGenerator{},
+		"server":            &ServerGenerator{},
+		"snapshot":          &SnapshotGenerator{},
+		"ssh_key":           &SSHKeyGenerator{},
+		"startup_script":    &StartupScriptGenerator{},
+		"user":              &UserGenerator{},
+	}
+}
+
+func (p *VultrProvider) InitService(serviceName string) error {
+	var isSupported bool
+	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+		return errors.New("vultr: " + serviceName + " not supported service")
+	}
+	p.Service = p.GetSupportedService()[serviceName]
+	p.Service.SetName(serviceName)
+	p.Service.SetProviderName(p.GetName())
+	p.Service.SetArgs(map[string]interface{}{
+		"api_key": p.apiKey,
+	})
+	return nil
+}

--- a/providers/vultr/vultr_service.go
+++ b/providers/vultr/vultr_service.go
@@ -1,0 +1,28 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vultr
+
+import (
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/vultr/govultr"
+)
+
+type VultrService struct {
+	terraform_utils.Service
+}
+
+func (s *VultrService) generateClient() *govultr.Client {
+	return govultr.NewClient(nil, s.Args["api_key"].(string))
+}


### PR DESCRIPTION
Adds support for the [Vultr provider](https://www.terraform.io/docs/providers/vultr/index.html). Also adds the following resources:

 * `vultr_bare_metal_server`
* `vultr_block_storage`
* `vultr_dns_domain`
* `vultr_firewall_group`
* `vultr_network`
* `vultr_reserved_ip`
* `vultr_server`
* `vultr_snapshot`
* `vultr_ssh_key`
* `vultr_startup_script`
* `vultr_user`

