### PR TITLE
Handle Alicloud initSecurityGroupRules err

### DIFF
--- a/providers/alicloud/sg.go
+++ b/providers/alicloud/sg.go
@@ -138,6 +138,9 @@ func (g *SgGenerator) InitResources() error {
 	}
 
 	allSecurityGroupRules, alignedSecurityGroups, err := initSecurityGroupRules(client, allSecurityGroups)
+	if err != nil {
+		return err
+	}
 
 	for _, securitygroup := range allSecurityGroups {
 		resource := resourceFromSecurityGroup(securitygroup)


### PR DESCRIPTION
Adds small check for the case of an error returned by the `initSecurityGroupRules` call in the Alicloud provider.