### PR TITLE
Add support for Heroku Cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,6 +666,8 @@ List of supported Heroku resources:
     * `heroku_app_webhook`
 *   `build`
     * `heroku_build`
+*   `cert`
+    * `heroku_cert`
 *   `domain`
     * `heroku_domain`
 *   `drain`

--- a/providers/heroku/cert.go
+++ b/providers/heroku/cert.go
@@ -1,0 +1,58 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package heroku
+
+import (
+	"context"
+	"log"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	heroku "github.com/heroku/heroku-go/v5"
+)
+
+type CertGenerator struct {
+	HerokuService
+}
+
+func (g CertGenerator) createResources(svc *heroku.Service, appList []heroku.App) []terraform_utils.Resource {
+	var resources []terraform_utils.Resource
+	for _, app := range appList {
+		output, err := svc.SSLEndpointList(context.TODO(), app.ID, &heroku.ListRange{Field: "id"})
+		if err != nil {
+			log.Println(err)
+		}
+		for _, sslEndpoint := range output {
+			resources = append(resources, terraform_utils.NewResource(
+				sslEndpoint.ID,
+				sslEndpoint.Name,
+				"heroku_cert",
+				"heroku",
+				map[string]string{"app": app.Name},
+				[]string{},
+				map[string]interface{}{}))
+		}
+	}
+	return resources
+}
+
+func (g *CertGenerator) InitResources() error {
+	svc := g.generateService()
+	output, err := svc.AppList(context.TODO(), &heroku.ListRange{Field: "id"})
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(svc, output)
+	return nil
+}

--- a/providers/heroku/heroku_provider.go
+++ b/providers/heroku/heroku_provider.go
@@ -72,6 +72,7 @@ func (p *HerokuProvider) GetSupportedService() map[string]terraform_utils.Servic
 		"app_feature":            &AppFeatureGenerator{},
 		"app_webhook":            &AppWebhookGenerator{},
 		"build":                  &BuildGenerator{},
+		"cert":                   &CertGenerator{},
 		"domain":                 &DomainGenerator{},
 		"drain":                  &DrainGenerator{},
 		"formation":              &FormationGenerator{},


### PR DESCRIPTION
Adds support for the [`heroku_cert`](https://www.terraform.io/docs/providers/heroku/r/cert.html) resource.