### PR TITLE
Add support for Vultr DNS record

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,6 +753,7 @@ List of supported Vultr resources:
     * `vultr_block_storage`
 *   `dns_domain`
     * `vultr_dns_domain`
+    * `vultr_dns_record`
 *   `firewall_group`
     * `vultr_firewall_group`
 *   `network`


### PR DESCRIPTION
Adds support for the [`vultr_dns_record`](https://www.terraform.io/docs/providers/vultr/r/dns_record.html) resource.