### PR TITLE
Support Fastly provider ⏰

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A CLI tool that generates `tf` and `tfstate` files based on existing infrastruct
         * [AliCloud](#use-with-alicloud)
     * Cloud
         * [DigitalOcean](#use-with-digitalocean)
+        * [Fastly](#use-with-fastly)
         * [Heroku](#use-with-heroku)
         * [Linode](#use-with-linode)
         * [OpenStack](#use-with-openstack)
@@ -181,6 +182,7 @@ Links to download Terraform Providers:
     * Alicloud provider >1.57.1 - [here](https://releases.hashicorp.com/terraform-provider-alicloud/)
 * Cloud
     * DigitalOcean provider >1.9.1 - [here](https://releases.hashicorp.com/terraform-provider-digitalocean/)
+    * Fastly provider >0.11.0 - [here](https://releases.hashicorp.com/terraform-provider-fastly/)
     * Heroku provider >2.2.1 - [here](https://releases.hashicorp.com/terraform-provider-heroku/)
     * Linode provider >1.8.0 - [here](https://releases.hashicorp.com/terraform-provider-linode/)
     * OpenStack provider >1.21.1 - [here](https://releases.hashicorp.com/terraform-provider-openstack/)
@@ -637,6 +639,23 @@ List of supported DigitalOcean resources:
     * `digitalocean_volume`
 *   `volume_snapshot`
     * `digitalocean_volume_snapshot`
+
+### Use with Fastly
+
+Example:
+
+```
+export FASTLY_API_KEY=[FASTLY_API_KEY]
+./terraformer import fastly -r service_v1
+```
+
+List of supported Fastly resources:
+
+*   `service_v1`
+    * `fastly_service_acl_entries_v1`
+    * `fastly_service_dictionary_items_v1`
+    * `fastly_service_dynamic_snippet_content_v1`
+    * `fastly_service_v1`
 
 ### Use with Heroku
 

--- a/cmd/provider_cmd_fastly.go
+++ b/cmd/provider_cmd_fastly.go
@@ -1,0 +1,45 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cmd
+
+import (
+	fastly_terraforming "github.com/GoogleCloudPlatform/terraformer/providers/fastly"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/spf13/cobra"
+)
+
+func newCmdFastlyImporter(options ImportOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fastly",
+		Short: "Import current state to Terraform configuration from Fastly",
+		Long:  "Import current state to Terraform configuration from Fastly",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			provider := newFastlyProvider()
+			err := Import(provider, options, []string{})
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.AddCommand(listCmd(newFastlyProvider()))
+	baseProviderFlags(cmd.PersistentFlags(), &options, "service_v1", "fastly_service_v1=id1:id2:id3")
+	return cmd
+}
+
+func newFastlyProvider() terraform_utils.ProviderGenerator {
+	return &fastly_terraforming.FastlyProvider{}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,7 @@ func providerImporterSubcommands() []func(options ImportOptions) *cobra.Command 
 		newCmdAliCloudImporter,
 		// Cloud
 		newCmdDigitalOceanImporter,
+		newCmdFastlyImporter,
 		newCmdHerokuImporter,
 		newCmdLinodeImporter,
 		newCmdOpenStackImporter,
@@ -75,6 +76,7 @@ func providerGenerators() map[string]func() terraform_utils.ProviderGenerator {
 		newAliCloudProvider,
 		// Cloud
 		newDigitalOceanProvider,
+		newFastlyProvider,
 		newHerokuProvider,
 		newLinodeProvider,
 		newOpenStackProvider,

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/denverdino/aliyungo v0.0.0-20190924033012-e8e08fe22cb2
 	github.com/digitalocean/godo v1.24.1
 	github.com/dollarshaveclub/new-relic-synthetics-go v0.0.0-20170605224734-4dc3dd6ae884
+	github.com/fastly/go-fastly v1.3.0
 	github.com/go-resty/resty v0.0.0-00010101000000-000000000000 // indirect
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/golang/groupcache v0.0.0-20191002201903-404acd9df4cc // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agl/ed25519 v0.0.0-20150830182803-278e1ec8e8a6/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
+github.com/ajg/form v0.0.0-20160802194845-cc2954064ec9 h1:fJ4XPqxuZfm11zauw9XX7c30P8xwDyucdWu8H6Htrxs=
+github.com/ajg/form v0.0.0-20160802194845-cc2954064ec9/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -153,6 +155,7 @@ github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQ
 github.com/dnaeon/go-vcr v0.0.0-20180814043457-aafff18a5cc2/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/dnaeon/go-vcr v0.0.0-20180920040454-5637cf3d8a31 h1:Dzuw9GtbmllUqEcoHfScT9YpKFUssSiZ5PgZkIGf/YQ=
 github.com/dnaeon/go-vcr v0.0.0-20180920040454-5637cf3d8a31/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
+github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dollarshaveclub/new-relic-synthetics-go v0.0.0-20170605224734-4dc3dd6ae884 h1:Od9CDqwkw5F3vjN8Lp8CQhkMOEjC70eTW+AJlTepE6g=
@@ -162,6 +165,8 @@ github.com/dylanmei/winrmtest v0.0.0-20190225150635-99b7fe2fddf1/go.mod h1:lcy9/
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/fastly/go-fastly v1.3.0 h1:halI6tkEmn5JIeW888P2bNGprGP7OYot+o1akPXvPyY=
+github.com/fastly/go-fastly v1.3.0/go.mod h1:cBtWXhszIFx9xpzgm9L/3PW3Ixszo153xJBEHJghGUk=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
@@ -219,6 +224,8 @@ github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonapi v0.0.0-20170708005851-46d3ced04344 h1:G5TmuUtIYeR0scfa8ZQ06cfHeAAfVeFlIG8TVOCfuAA=
+github.com/google/jsonapi v0.0.0-20170708005851-46d3ced04344/go.mod h1:XSx4m2SziAqk9DXY9nz659easTq4q6TyrpYd9tHSm0g=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -252,6 +259,7 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.0.0-20190129193224-166dfd221bb2/go.mod h1:lu62V//auUow6k0IykxLK2DCNW8qTmpm8KqhYVWattA=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
+github.com/hashicorp/go-cleanhttp v0.0.0-20170211013415-3573b8b52aa7/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -401,6 +409,7 @@ github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/hashstructure v1.0.0 h1:ZkRJX1CyOoTkar7p/mLS5TZU4nJ1Rn/F8u9dGS02Q3Y=
 github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
+github.com/mitchellh/mapstructure v0.0.0-20170523030023-d0303fe80992/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/panicwrap v0.0.0-20190213213626-17011010aaa4/go.mod h1:YYMf4xtQnR8LRC0vKi3afvQ5QwRPQ17zjcpkBCufb+I=

--- a/providers/fastly/fastly_provider.go
+++ b/providers/fastly/fastly_provider.go
@@ -1,0 +1,77 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fastly
+
+import (
+	"errors"
+	"os"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils/provider_wrapper"
+)
+
+type FastlyProvider struct {
+	terraform_utils.Provider
+	api_key string
+}
+
+func (p *FastlyProvider) Init(args []string) error {
+	if os.Getenv("FASTLY_API_KEY") == "" {
+		return errors.New("set FASTLY_API_KEY env var")
+	}
+	p.api_key = os.Getenv("FASTLY_API_KEY")
+
+	return nil
+}
+
+func (p *FastlyProvider) GetName() string {
+	return "fastly"
+}
+
+func (p *FastlyProvider) GetProviderData(arg ...string) map[string]interface{} {
+	return map[string]interface{}{
+		"provider": map[string]interface{}{
+			"fastly": map[string]interface{}{
+				"version": provider_wrapper.GetProviderVersion(p.GetName()),
+				"api_key": p.api_key,
+			},
+		},
+	}
+}
+
+func (FastlyProvider) GetResourceConnections() map[string]map[string][]string {
+	return map[string]map[string][]string{}
+}
+
+func (p *FastlyProvider) GetSupportedService() map[string]terraform_utils.ServiceGenerator {
+	return map[string]terraform_utils.ServiceGenerator{
+		"service_v1": &ServiceV1Generator{},
+	}
+}
+
+func (p *FastlyProvider) InitService(serviceName string, verbose bool) error {
+	var isSupported bool
+	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+		return errors.New("fastly: " + serviceName + " not supported service")
+	}
+	p.Service = p.GetSupportedService()[serviceName]
+	p.Service.SetName(serviceName)
+	p.Service.SetVerbose(verbose)
+	p.Service.SetProviderName(p.GetName())
+	p.Service.SetArgs(map[string]interface{}{
+		"api_key": p.api_key,
+	})
+	return nil
+}

--- a/providers/fastly/fastly_provider.go
+++ b/providers/fastly/fastly_provider.go
@@ -24,14 +24,14 @@ import (
 
 type FastlyProvider struct {
 	terraform_utils.Provider
-	api_key string
+	apiKey string
 }
 
 func (p *FastlyProvider) Init(args []string) error {
 	if os.Getenv("FASTLY_API_KEY") == "" {
 		return errors.New("set FASTLY_API_KEY env var")
 	}
-	p.api_key = os.Getenv("FASTLY_API_KEY")
+	p.apiKey = os.Getenv("FASTLY_API_KEY")
 
 	return nil
 }
@@ -45,7 +45,7 @@ func (p *FastlyProvider) GetProviderData(arg ...string) map[string]interface{} {
 		"provider": map[string]interface{}{
 			"fastly": map[string]interface{}{
 				"version": provider_wrapper.GetProviderVersion(p.GetName()),
-				"api_key": p.api_key,
+				"api_key": p.apiKey,
 			},
 		},
 	}
@@ -71,7 +71,7 @@ func (p *FastlyProvider) InitService(serviceName string, verbose bool) error {
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
-		"api_key": p.api_key,
+		"api_key": p.apiKey,
 	})
 	return nil
 }

--- a/providers/fastly/fastly_service.go
+++ b/providers/fastly/fastly_service.go
@@ -1,0 +1,23 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fastly
+
+import (
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+)
+
+type FastlyService struct {
+	terraform_utils.Service
+}

--- a/providers/fastly/service_v1.go
+++ b/providers/fastly/service_v1.go
@@ -1,0 +1,159 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fastly
+
+import (
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/fastly/go-fastly/fastly"
+)
+
+type ServiceV1Generator struct {
+	FastlyService
+}
+
+func (g *ServiceV1Generator) loadServices(client *fastly.Client) ([]*fastly.Service, error) {
+	services, err := client.ListServices(&fastly.ListServicesInput{})
+	if err != nil {
+		return nil, err
+	}
+	for _, service := range services {
+		g.Resources = append(g.Resources, terraform_utils.NewSimpleResource(
+			service.ID,
+			service.ID,
+			"fastly_service_v1",
+			"fastly",
+			[]string{}))
+	}
+	return services, nil
+}
+
+func (g *ServiceV1Generator) loadDictionaryItems(client *fastly.Client, serviceID string) error {
+	latest, err := client.LatestVersion(&fastly.LatestVersionInput{
+		Service: serviceID,
+	})
+	if err != nil {
+		return err
+	}
+	dictionaries, err := client.ListDictionaries(&fastly.ListDictionariesInput{
+		Service: serviceID,
+		Version: latest.Number,
+	})
+	if err != nil {
+		return err
+	}
+	for _, dictionary := range dictionaries {
+		g.Resources = append(g.Resources, terraform_utils.NewResource(
+			dictionary.ID,
+			dictionary.ID,
+			"fastly_service_dictionary_items_v1",
+			"fastly",
+			map[string]string{
+				"service_id":    serviceID,
+				"dictionary_id": dictionary.ID,
+			},
+			[]string{},
+			map[string]interface{}{}))
+	}
+	return nil
+}
+
+func (g *ServiceV1Generator) loadAclEntries(client *fastly.Client, serviceID string) error {
+	latest, err := client.LatestVersion(&fastly.LatestVersionInput{
+		Service: serviceID,
+	})
+	if err != nil {
+		return err
+	}
+	acls, err := client.ListACLs(&fastly.ListACLsInput{
+		Service: serviceID,
+		Version: latest.Number,
+	})
+	if err != nil {
+		return err
+	}
+	for _, acl := range acls {
+		g.Resources = append(g.Resources, terraform_utils.NewResource(
+			acl.ID,
+			acl.ID,
+			"fastly_service_acl_entries_v1",
+			"fastly",
+			map[string]string{
+				"service_id": serviceID,
+				"acl_id":     acl.ID,
+			},
+			[]string{},
+			map[string]interface{}{}))
+	}
+	return nil
+}
+
+func (g *ServiceV1Generator) loadDynamicSnippetContent(client *fastly.Client, serviceID string) error {
+	latest, err := client.LatestVersion(&fastly.LatestVersionInput{
+		Service: serviceID,
+	})
+	if err != nil {
+		return err
+	}
+	snippets, err := client.ListSnippets(&fastly.ListSnippetsInput{
+		Service: serviceID,
+		Version: latest.Number,
+	})
+	if err != nil {
+		return err
+	}
+	for _, snippet := range snippets {
+		// check if dynamic
+		if snippet.Dynamic == 1 {
+			g.Resources = append(g.Resources, terraform_utils.NewResource(
+				snippet.ID,
+				snippet.ID,
+				"fastly_service_dynamic_snippet_content_v1",
+				"fastly",
+				map[string]string{
+					"service_id": serviceID,
+					"snippet_id": snippet.ID,
+				},
+				[]string{},
+				map[string]interface{}{}))
+		}
+	}
+	return nil
+}
+
+func (g *ServiceV1Generator) InitResources() error {
+	client, err := fastly.NewClient(g.Args["api_key"].(string))
+	if err != nil {
+		return err
+	}
+	services, err := g.loadServices(client)
+	if err != nil {
+		return err
+	}
+	for _, service := range services {
+		err := g.loadDictionaryItems(client, service.ID)
+		if err != nil {
+			return err
+		}
+		err = g.loadAclEntries(client, service.ID)
+		if err != nil {
+			return err
+		}
+		err = g.loadDynamicSnippetContent(client, service.ID)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes: #309 

Adds support for the [Fastly provider](https://www.terraform.io/docs/providers/fastly/index.html). Also adds the following resources:

* `fastly_service_acl_entries_v1`
* `fastly_service_dictionary_items_v1`
* `fastly_service_dynamic_snippet_content_v1`
* `fastly_service_v1`