### PR TITLE
Add support for DigitalOcean record

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,7 @@ List of supported DigitalOcean resources:
     * `digitalocean_database_cluster`
 *   `domain`
     * `digitalocean_domain`
+    * `digitalocean_record`
 *   `droplet`
     * `digitalocean_droplet`
 *   `droplet_snapshot`


### PR DESCRIPTION
Adds support for the [`digitalocean_record`](https://www.terraform.io/docs/providers/do/r/record.html) resource.