### PR TITLE
Add support for DigitalOcean Kubernetes node pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,6 +628,7 @@ List of supported DigitalOcean resources:
     * `digitalocean_floating_ip`
 *   `kubernetes_cluster`
     * `digitalocean_kubernetes_cluster`
+    * `digitalocean_kubernetes_node_pool`
 *   `loadbalancer`
     * `digitalocean_loadbalancer`
 *   `project`


### PR DESCRIPTION
Adds support for the [`digitalocean_kubernetes_node_pool`](https://www.terraform.io/docs/providers/do/r/kubernetes_node_pool.html) resource.