### PR TITLE
Add support for DigitalOcean database resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,7 @@ List of supported DigitalOcean resources:
     * `digitalocean_database_cluster`
     * `digitalocean_database_connection_pool`
     * `digitalocean_database_db`
+    * `digitalocean_database_replica`
 *   `domain`
     * `digitalocean_domain`
     * `digitalocean_record`

--- a/README.md
+++ b/README.md
@@ -618,6 +618,7 @@ List of supported DigitalOcean resources:
     * `digitalocean_database_connection_pool`
     * `digitalocean_database_db`
     * `digitalocean_database_replica`
+    * `digitalocean_database_user`
 *   `domain`
     * `digitalocean_domain`
     * `digitalocean_record`

--- a/README.md
+++ b/README.md
@@ -616,6 +616,7 @@ List of supported DigitalOcean resources:
 *   `database_cluster`
     * `digitalocean_database_cluster`
     * `digitalocean_database_connection_pool`
+    * `digitalocean_database_db`
 *   `domain`
     * `digitalocean_domain`
     * `digitalocean_record`

--- a/providers/digitalocean/database_cluster.go
+++ b/providers/digitalocean/database_cluster.go
@@ -182,6 +182,49 @@ func (g *DatabaseClusterGenerator) loadDatabaseReplicas(ctx context.Context, cli
 	return nil
 }
 
+func (g *DatabaseClusterGenerator) loadDatabaseUsers(ctx context.Context, client *godo.Client, clusterID string) error {
+	// create options. initially, these will be blank
+	opt := &godo.ListOptions{}
+	for {
+		users, resp, err := client.Databases.ListUsers(ctx, clusterID, opt)
+		if err != nil {
+			return err
+		}
+
+		for _, user := range users {
+			// skip default user created by the digitalocean database cluster
+			if user.Name != "doadmin" {
+				g.Resources = append(g.Resources, terraform_utils.NewResource(
+					user.Name,
+					user.Name,
+					"digitalocean_database_user",
+					"digitalocean",
+					map[string]string{
+						"cluster_id": clusterID,
+						"name":       user.Name,
+					},
+					[]string{},
+					map[string]interface{}{}))
+			}
+		}
+
+		// if we are at the last page, break out the for loop
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return err
+		}
+
+		// set the page we want for the next request
+		opt.Page = page + 1
+	}
+
+	return nil
+}
+
 func (g *DatabaseClusterGenerator) InitResources() error {
 	client := g.generateClient()
 	clusters, err := g.loadDatabaseClusters(context.TODO(), client)
@@ -198,6 +241,10 @@ func (g *DatabaseClusterGenerator) InitResources() error {
 			return err
 		}
 		err = g.loadDatabaseReplicas(context.TODO(), client, cluster.ID)
+		if err != nil {
+			return err
+		}
+		err = g.loadDatabaseUsers(context.TODO(), client, cluster.ID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Adds support for the following resources: 

* [`digitalocean_database_db`](https://www.terraform.io/docs/providers/do/r/database_db.html)
* [`digitalocean_database_replica`](https://www.terraform.io/docs/providers/do/r/database_replica.html)
* [`digitalocean_database_user`](https://www.terraform.io/docs/providers/do/r/database_user.html)