### PR TITLE
Add Azure Analysis & Databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,31 @@ List of supported Azure resources:
     * `azurerm_virtual_machine`
 *   `virtual_network`
     * `azurerm_virtual_network`
+*   `analysis`
+    * `azurerm_analysis_services_server`
+*   `database`
+	* `azurerm_mariadb_configuration`
+	* `azurerm_mariadb_database`
+	* `azurerm_mariadb_firewall_rule`
+	* `azurerm_mariadb_server`
+	* `azurerm_mariadb_virtual_network_rule`
+	* `azurerm_mysql_configuration`
+	* `azurerm_mysql_database`
+	* `azurerm_mysql_firewall_rule`
+	* `azurerm_mysql_server`
+	* `azurerm_mysql_virtual_network_rule`
+	* `azurerm_postgresql_configuration`
+	* `azurerm_postgresql_database`
+	* `azurerm_postgresql_firewall_rule`
+	* `azurerm_postgresql_server`
+	* `azurerm_postgresql_virtual_network_rule`
+	* `azurerm_sql_database`
+	* `azurerm_sql_active_directory_administrator`
+	* `azurerm_sql_elasticpool`
+	* `azurerm_sql_failover_group`
+	* `azurerm_sql_firewall_rule`
+	* `azurerm_sql_server`
+	* `azurerm_sql_virtual_network_rule`
 
 ### Use with AliCloud
 

--- a/go.sum
+++ b/go.sum
@@ -939,6 +939,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/providers/azure/analysis.go
+++ b/providers/azure/analysis.go
@@ -1,0 +1,67 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"context"
+	"github.com/Azure/azure-sdk-for-go/services/analysisservices/mgmt/2017-08-01/analysisservices"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/hashicorp/go-azure-helpers/authentication"
+	"log"
+)
+
+type AnalysisGenerator struct {
+	AzureService
+}
+
+func (g *AnalysisGenerator) listServiceServers() ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting Service Servers")
+	var resources []terraform_utils.Resource
+	ctx := context.Background()
+	AnalysisClient := analysisservices.NewServersClient(g.Args["config"].(authentication.Config).SubscriptionID)
+	AnalysisClient.Authorizer = g.Args["authorizer"].(autorest.Authorizer)
+
+	servers, err := AnalysisClient.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, svr := range *servers.Value {
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			*svr.ID,
+			*svr.Name,
+			"azurerm_analysis_services_server",
+			g.ProviderName,
+			[]string{}))
+	}
+
+	return resources, nil
+}
+
+func (g *AnalysisGenerator) InitResources() error {
+	functions := []func() ([]terraform_utils.Resource, error){
+		g.listServiceServers,
+	}
+
+	for _, f := range functions {
+		resources, err := f()
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, resources...)
+	}
+
+	return nil
+}

--- a/providers/azure/azure_provider.go
+++ b/providers/azure/azure_provider.go
@@ -136,6 +136,8 @@ func (p *AzureProvider) GetSupportedService() map[string]terraform_utils.Service
 		"storage_account":        &StorageAccountGenerator{},
 		"virtual_machine":        &VirtualMachineGenerator{},
 		"virtual_network":        &VirtualNetworkGenerator{},
+		"analysis":               &AnalysisGenerator{},
+		"database":               &DatabasesGenerator{},
 	}
 }
 

--- a/providers/azure/database.go
+++ b/providers/azure/database.go
@@ -1,0 +1,895 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"context"
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/services/mariadb/mgmt/2018-06-01/mariadb"
+	"github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-12-01/mysql"
+	"github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2017-12-01/postgresql"
+	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/2017-03-01-preview/sql"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/hashicorp/go-azure-helpers/authentication"
+	"log"
+	"strings"
+)
+
+type DatabasesGenerator struct {
+	AzureService
+}
+
+func (g *DatabasesGenerator) getMariaDBServers() ([]mariadb.Server, error) {
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := mariadb.NewServersClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	Servers, err := Client.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return *Servers.Value, nil
+}
+
+func (g *DatabasesGenerator) createMariaDBServerResources(Servers []mariadb.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting MariaDB Servers")
+	var resources []terraform_utils.Resource
+
+	for _, server := range Servers {
+		resources = append(resources, terraform_utils.NewResource(
+			*server.ID,
+			*server.Name,
+			"azurerm_mariadb_server",
+			g.ProviderName,
+			map[string]string{},
+			[]string{},
+			map[string]interface{}{
+				"administrator_login_password": "",
+			}))
+	}
+
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) createMariaDBConfigurationResources(Servers []mariadb.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting MariaDB Configurations")
+	var resources []terraform_utils.Resource
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := mariadb.NewConfigurationsClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	for _, server := range Servers {
+		id, err := ParseAzureResourceID(*server.ID)
+		if err != nil {
+			return nil, err
+		}
+		configs, err := Client.ListByServer(ctx, id.ResourceGroup, *server.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, config := range *configs.Value {
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				*config.ID,
+				*config.Name,
+				"azurerm_mariadb_configuration",
+				g.ProviderName,
+				[]string{"value"}))
+		}
+	}
+
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) createMariaDBDatabaseResources(Servers []mariadb.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting MariaDB Database")
+	var resources []terraform_utils.Resource
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := mariadb.NewDatabasesClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	for _, server := range Servers {
+		id, err := ParseAzureResourceID(*server.ID)
+		if err != nil {
+			return nil, err
+		}
+		databases, err := Client.ListByServer(ctx, id.ResourceGroup, *server.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, database := range *databases.Value {
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				*database.ID,
+				*database.Name,
+				"azurerm_mariadb_database",
+				g.ProviderName,
+				[]string{}))
+		}
+	}
+
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) createMariaDBFirewallRuleResources(Servers []mariadb.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting MariaDB Firewall Rules")
+	var resources []terraform_utils.Resource
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := mariadb.NewFirewallRulesClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+	for _, server := range Servers {
+		id, err := ParseAzureResourceID(*server.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		rules, err := Client.ListByServer(ctx, id.ResourceGroup, *server.Name)
+		if err != nil {
+			return nil, err
+		}
+		for _, rule := range *rules.Value {
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				*rule.ID,
+				*rule.Name,
+				"azurerm_mariadb_firewall_rule",
+				g.ProviderName,
+				[]string{}))
+		}
+	}
+
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) createMariaDBVirtualNetworkRuleResources(Servers []mariadb.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting MariaDB Virtual Network Rules")
+	var resources []terraform_utils.Resource
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := mariadb.NewVirtualNetworkRulesClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	for _, server := range Servers {
+		id, err := ParseAzureResourceID(*server.ID)
+		if err != nil {
+			return nil, err
+		}
+		iter, err := Client.ListByServerComplete(ctx, id.ResourceGroup, *server.Name)
+		if err != nil {
+			return nil, err
+		}
+		for iter.NotDone() {
+			rule := iter.Value()
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				*rule.ID,
+				*rule.Name,
+				"azurerm_mariadb_virtual_network_rule",
+				g.ProviderName,
+				[]string{}))
+
+			if err := iter.NextWithContext(ctx); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) getMySQLServers() ([]mysql.Server, error) {
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := mysql.NewServersClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	Servers, err := Client.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return *Servers.Value, nil
+}
+
+func (g *DatabasesGenerator) createMySQLServerResources(Servers []mysql.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting MySQL Servers")
+	var resources []terraform_utils.Resource
+
+	Servers, err := g.getMySQLServers()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, server := range Servers {
+		resources = append(resources, terraform_utils.NewResource(
+			*server.ID,
+			*server.Name,
+			"azurerm_mysql_server",
+			g.ProviderName,
+			map[string]string{},
+			[]string{},
+			map[string]interface{}{
+				"administrator_login_password": "",
+			}))
+	}
+
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) createMySQLConfigurationResources(Servers []mysql.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting MySQL Configurations")
+	var resources []terraform_utils.Resource
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := mysql.NewConfigurationsClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	for _, server := range Servers {
+		id, err := ParseAzureResourceID(*server.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		configs, err := Client.ListByServer(ctx, id.ResourceGroup, *server.Name)
+		if err != nil {
+			return nil, err
+		}
+		for _, config := range *configs.Value {
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				*config.ID,
+				*config.Name,
+				"azurerm_mysql_configuration",
+				g.ProviderName,
+				[]string{"value"}))
+		}
+	}
+
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) createMySQLDatabaseResources(Servers []mysql.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting MySQL Databases")
+	var resources []terraform_utils.Resource
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := mysql.NewDatabasesClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	for _, server := range Servers {
+		id, err := ParseAzureResourceID(*server.ID)
+		if err != nil {
+			return nil, err
+		}
+		databases, err := Client.ListByServer(ctx, id.ResourceGroup, *server.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, database := range *databases.Value {
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				*database.ID,
+				*database.Name,
+				"azurerm_mysql_database",
+				g.ProviderName,
+				[]string{}))
+		}
+	}
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) createMySQLFirewallRuleResources(Servers []mysql.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting MySQL Firewall Rules")
+	var resources []terraform_utils.Resource
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := mysql.NewFirewallRulesClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	for _, server := range Servers {
+		id, err := ParseAzureResourceID(*server.ID)
+		if err != nil {
+			return nil, err
+		}
+		rules, err := Client.ListByServer(ctx, id.ResourceGroup, *server.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, rule := range *rules.Value {
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				*rule.ID,
+				*rule.Name,
+				"azurerm_mysql_firewall_rule",
+				g.ProviderName,
+				[]string{}))
+		}
+	}
+
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) createMySQLVirtualNetworkRuleResources(Servers []mysql.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting MySQL VirtualNetwork Rules")
+	var resources []terraform_utils.Resource
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := mysql.NewVirtualNetworkRulesClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	for _, server := range Servers {
+		id, err := ParseAzureResourceID(*server.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		iter, err := Client.ListByServerComplete(ctx, id.ResourceGroup, *server.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		for iter.NotDone() {
+			rule := iter.Value()
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				*rule.ID,
+				*rule.Name,
+				"azurerm_mysql_virtual_network_rule",
+				g.ProviderName,
+				[]string{}))
+
+			if err := iter.NextWithContext(ctx); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) getPostgreSQLServers() ([]postgresql.Server, error) {
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := postgresql.NewServersClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	Servers, err := Client.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return *Servers.Value, nil
+}
+
+func (g *DatabasesGenerator) createPostgreSQLServerResources(Servers []postgresql.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting Postgresql Servers")
+	var resources []terraform_utils.Resource
+
+	for _, server := range Servers {
+		resources = append(resources, terraform_utils.NewResource(
+			*server.ID,
+			*server.Name,
+			"azurerm_postgresql_server",
+			g.ProviderName,
+			map[string]string{},
+			[]string{},
+			map[string]interface{}{
+				"administrator_login_password": "",
+			}))
+	}
+
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) createPostgreSQLDatabaseResources(Servers []postgresql.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting PostgreSQL Databases")
+	var resources []terraform_utils.Resource
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := postgresql.NewDatabasesClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	for _, server := range Servers {
+		id, err := ParseAzureResourceID(*server.ID)
+		if err != nil {
+			return nil, err
+		}
+		databases, err := Client.ListByServer(ctx, id.ResourceGroup, *server.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, database := range *databases.Value {
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				*database.ID,
+				*database.Name,
+				"azurerm_postgresql_database",
+				g.ProviderName,
+				[]string{}))
+		}
+	}
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) createPostgreSQLConfigurationResources(Servers []postgresql.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting PostgreSQL Configurations")
+	var resources []terraform_utils.Resource
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+	//terraform_utils.NewSim
+	Client := postgresql.NewConfigurationsClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	for _, server := range Servers {
+		id, err := ParseAzureResourceID(*server.ID)
+		if err != nil {
+			return nil, err
+		}
+		configs, err := Client.ListByServer(ctx, id.ResourceGroup, *server.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, config := range *configs.Value {
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				*config.ID,
+				*config.Name,
+				"azurerm_postgresql_configuration",
+				g.ProviderName,
+				[]string{"value"}))
+		}
+	}
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) createPostgreSQLFirewallRuleResources(Servers []postgresql.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting PostgreSQL Firewall Rules")
+	var resources []terraform_utils.Resource
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := postgresql.NewFirewallRulesClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	for _, server := range Servers {
+		id, err := ParseAzureResourceID(*server.ID)
+		if err != nil {
+			return nil, err
+		}
+		rules, err := Client.ListByServer(ctx, id.ResourceGroup, *server.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, rule := range *rules.Value {
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				*rule.ID,
+				*rule.Name,
+				"azurerm_postgresql_firewall_rule",
+				g.ProviderName,
+				[]string{}))
+		}
+	}
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) createPostgreSQLVirtualNetworkRuleResources(Servers []postgresql.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting PostgreSQL VirtualNetwork Rules")
+	var resources []terraform_utils.Resource
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := postgresql.NewVirtualNetworkRulesClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	for _, server := range Servers {
+		id, err := ParseAzureResourceID(*server.ID)
+		if err != nil {
+			return nil, err
+		}
+		rulePages, err := Client.ListByServerComplete(ctx, id.ResourceGroup, *server.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		for rulePages.NotDone() {
+			rule := rulePages.Value()
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				*rule.ID,
+				*rule.Name,
+				"azurerm_postgresql_virtual_network_rule",
+				g.ProviderName,
+				[]string{}))
+		}
+	}
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) getSQLServers() ([]sql.Server, error) {
+	var servers []sql.Server
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := sql.NewServersClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	ServerPages, err := Client.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for ServerPages.NotDone() {
+		servers = append(servers, ServerPages.Values()...)
+		if err := ServerPages.NextWithContext(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	return servers, nil
+}
+
+func (g *DatabasesGenerator) createSQLServerResources(Servers []sql.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting SQL Servers")
+	var resources []terraform_utils.Resource
+
+	for _, server := range Servers {
+		resources = append(resources, terraform_utils.NewResource(
+			*server.ID,
+			*server.Name,
+			"azurerm_sql_server",
+			g.ProviderName,
+			map[string]string{},
+			[]string{},
+			map[string]interface{}{
+				"administrator_login_password": "",
+			}))
+	}
+
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) createSQLDatabaseResources(Servers []sql.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting SQL Databases")
+	var resources []terraform_utils.Resource
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := sql.NewDatabasesClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	for _, server := range Servers {
+		id, err := ParseAzureResourceID(*server.ID)
+		if err != nil {
+			return nil, err
+		}
+		databases, err := Client.ListByServer(ctx, id.ResourceGroup, *server.Name, "", "")
+		if err != nil {
+			return nil, err
+		}
+
+		for _, database := range *databases.Value {
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				*database.ID,
+				*database.Name,
+				"azurerm_sql_database",
+				g.ProviderName,
+				[]string{}))
+		}
+	}
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) createSQLFirewallRuleResources(Servers []sql.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting SQL Firewall Rules")
+	var resources []terraform_utils.Resource
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := sql.NewFirewallRulesClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	for _, server := range Servers {
+		id, err := ParseAzureResourceID(*server.ID)
+		if err != nil {
+			return nil, err
+		}
+		rules, err := Client.ListByServer(ctx, id.ResourceGroup, *server.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, rule := range *rules.Value {
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				*rule.ID,
+				*rule.Name,
+				"azurerm_sql_firewall_rule",
+				g.ProviderName,
+				[]string{}))
+		}
+	}
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) createSQLVirtualNetworkRuleResources(Servers []sql.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting SQL VirtualNetwork Rules")
+	var resources []terraform_utils.Resource
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := sql.NewVirtualNetworkRulesClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	for _, server := range Servers {
+		id, err := ParseAzureResourceID(*server.ID)
+		if err != nil {
+			return nil, err
+		}
+		ruleIter, err := Client.ListByServerComplete(ctx, id.ResourceGroup, *server.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		for ruleIter.NotDone() {
+			rule := ruleIter.Value()
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				*rule.ID,
+				*rule.Name,
+				"azurerm_sql_virtual_network_rule",
+				g.ProviderName,
+				[]string{}))
+		}
+		if err := ruleIter.NextWithContext(ctx); err != nil {
+			return nil, err
+		}
+	}
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) createSQLElasticPoolResources(Servers []sql.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting SQL Elastic Pools")
+	var resources []terraform_utils.Resource
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := sql.NewElasticPoolsClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	for _, server := range Servers {
+		id, err := ParseAzureResourceID(*server.ID)
+		if err != nil {
+			return nil, err
+		}
+		pools, err := Client.ListByServer(ctx, id.ResourceGroup, *server.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, pool := range *pools.Value {
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				*pool.ID,
+				*pool.Name,
+				"azurerm_sql_elasticpool",
+				g.ProviderName,
+				[]string{}))
+		}
+	}
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) createSQLFailoverResources(Servers []sql.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting SQL Failover Groups")
+	var resources []terraform_utils.Resource
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := sql.NewFailoverGroupsClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	for _, server := range Servers {
+		id, err := ParseAzureResourceID(*server.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		iter, err := Client.ListByServerComplete(ctx, id.ResourceGroup, *server.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		for iter.NotDone() {
+			failoverGroup := iter.Value()
+
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				*failoverGroup.ID,
+				*failoverGroup.Name,
+				"azurerm_sql_failover_group",
+				g.ProviderName,
+				[]string{}))
+		}
+	}
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) createSQLADAdministratorResources(Servers []sql.Server) ([]terraform_utils.Resource, error) {
+	log.Println("\tImporting SQL Active Directory Administrator")
+	var resources []terraform_utils.Resource
+	ctx := context.Background()
+	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
+
+	Client := sql.NewServerAzureADAdministratorsClient(SubscriptionID)
+	Client.Authorizer = Authorizer
+
+	for _, server := range Servers {
+		id, err := ParseAzureResourceID(*server.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		administrators, err := Client.ListByServer(ctx, id.ResourceGroup, *server.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, administrator := range *administrators.Value {
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				*administrator.ID,
+				*administrator.Name,
+				"azurerm_sql_active_directory_administrator",
+				g.ProviderName,
+				[]string{}))
+		}
+	}
+	return resources, nil
+}
+
+func (g *DatabasesGenerator) InitResources() error {
+	mariadbServers, err := g.getMariaDBServers()
+	mysqlServers, err := g.getMySQLServers()
+	postgresqlServers, err := g.getPostgreSQLServers()
+	sqlServers, err := g.getSQLServers()
+
+	if err != nil {
+		return err
+	}
+
+	mariadbFunctions := []func([]mariadb.Server) ([]terraform_utils.Resource, error){
+		g.createMariaDBServerResources,
+		g.createMariaDBDatabaseResources,
+		g.createMariaDBConfigurationResources,
+		g.createMariaDBFirewallRuleResources,
+		g.createMariaDBVirtualNetworkRuleResources,
+	}
+
+	mysqlFunctions := []func([]mysql.Server) ([]terraform_utils.Resource, error){
+		g.createMySQLServerResources,
+		g.createMySQLDatabaseResources,
+		g.createMySQLConfigurationResources,
+		g.createMySQLFirewallRuleResources,
+		g.createMySQLVirtualNetworkRuleResources,
+	}
+
+	postgresqlFunctions := []func([]postgresql.Server) ([]terraform_utils.Resource, error){
+		g.createPostgreSQLServerResources,
+		g.createPostgreSQLDatabaseResources,
+		g.createPostgreSQLConfigurationResources,
+		g.createPostgreSQLFirewallRuleResources,
+		g.createPostgreSQLVirtualNetworkRuleResources,
+	}
+
+	sqlFunctions := []func([]sql.Server) ([]terraform_utils.Resource, error){
+		g.createSQLServerResources,
+		g.createSQLDatabaseResources,
+		g.createSQLADAdministratorResources,
+		g.createSQLElasticPoolResources,
+		g.createSQLFailoverResources,
+		g.createSQLFirewallRuleResources,
+		g.createSQLVirtualNetworkRuleResources,
+	}
+
+	for _, f := range mariadbFunctions {
+		resources, err := f(mariadbServers)
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, resources...)
+	}
+
+	for _, f := range mysqlFunctions {
+		resources, err := f(mysqlServers)
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, resources...)
+	}
+
+	for _, f := range postgresqlFunctions {
+		resources, err := f(postgresqlServers)
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, resources...)
+	}
+
+	for _, f := range sqlFunctions {
+		resources, err := f(sqlServers)
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, resources...)
+	}
+
+	return nil
+}
+
+func (g *DatabasesGenerator) PostConvertHook() error {
+	dbEngines := []string{
+		"mariadb",
+		"mysql",
+		"postgresql",
+		"sql",
+	}
+
+	for _, engineName := range dbEngines {
+		for _, resource := range g.Resources {
+			dbServerResourceType := fmt.Sprintf("azurerm_%s_server", engineName)
+			if resource.InstanceInfo.Type == dbServerResourceType {
+				dbName := resource.Item["name"]
+				for rIdx, r := range g.Resources {
+					if r.InstanceInfo.Type != dbServerResourceType &&
+						strings.Contains(r.InstanceInfo.Type, engineName) &&
+						r.Item["server_name"] == dbName {
+						g.Resources[rIdx].Item["server_name"] = fmt.Sprintf("${%s.%s}", resource.InstanceInfo.Id, "name")
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/providers/azure/database.go
+++ b/providers/azure/database.go
@@ -24,7 +24,6 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 	"github.com/hashicorp/go-azure-helpers/authentication"
-	"log"
 	"strings"
 )
 
@@ -49,7 +48,6 @@ func (g *DatabasesGenerator) getMariaDBServers() ([]mariadb.Server, error) {
 }
 
 func (g *DatabasesGenerator) createMariaDBServerResources(Servers []mariadb.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting MariaDB Servers")
 	var resources []terraform_utils.Resource
 
 	for _, server := range Servers {
@@ -69,7 +67,6 @@ func (g *DatabasesGenerator) createMariaDBServerResources(Servers []mariadb.Serv
 }
 
 func (g *DatabasesGenerator) createMariaDBConfigurationResources(Servers []mariadb.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting MariaDB Configurations")
 	var resources []terraform_utils.Resource
 	ctx := context.Background()
 	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
@@ -102,7 +99,6 @@ func (g *DatabasesGenerator) createMariaDBConfigurationResources(Servers []maria
 }
 
 func (g *DatabasesGenerator) createMariaDBDatabaseResources(Servers []mariadb.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting MariaDB Database")
 	var resources []terraform_utils.Resource
 	ctx := context.Background()
 	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
@@ -135,7 +131,6 @@ func (g *DatabasesGenerator) createMariaDBDatabaseResources(Servers []mariadb.Se
 }
 
 func (g *DatabasesGenerator) createMariaDBFirewallRuleResources(Servers []mariadb.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting MariaDB Firewall Rules")
 	var resources []terraform_utils.Resource
 	ctx := context.Background()
 	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
@@ -167,7 +162,6 @@ func (g *DatabasesGenerator) createMariaDBFirewallRuleResources(Servers []mariad
 }
 
 func (g *DatabasesGenerator) createMariaDBVirtualNetworkRuleResources(Servers []mariadb.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting MariaDB Virtual Network Rules")
 	var resources []terraform_utils.Resource
 	ctx := context.Background()
 	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
@@ -219,7 +213,6 @@ func (g *DatabasesGenerator) getMySQLServers() ([]mysql.Server, error) {
 }
 
 func (g *DatabasesGenerator) createMySQLServerResources(Servers []mysql.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting MySQL Servers")
 	var resources []terraform_utils.Resource
 
 	Servers, err := g.getMySQLServers()
@@ -244,7 +237,6 @@ func (g *DatabasesGenerator) createMySQLServerResources(Servers []mysql.Server) 
 }
 
 func (g *DatabasesGenerator) createMySQLConfigurationResources(Servers []mysql.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting MySQL Configurations")
 	var resources []terraform_utils.Resource
 	ctx := context.Background()
 	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
@@ -277,7 +269,6 @@ func (g *DatabasesGenerator) createMySQLConfigurationResources(Servers []mysql.S
 }
 
 func (g *DatabasesGenerator) createMySQLDatabaseResources(Servers []mysql.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting MySQL Databases")
 	var resources []terraform_utils.Resource
 	ctx := context.Background()
 	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
@@ -309,7 +300,6 @@ func (g *DatabasesGenerator) createMySQLDatabaseResources(Servers []mysql.Server
 }
 
 func (g *DatabasesGenerator) createMySQLFirewallRuleResources(Servers []mysql.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting MySQL Firewall Rules")
 	var resources []terraform_utils.Resource
 	ctx := context.Background()
 	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
@@ -342,7 +332,6 @@ func (g *DatabasesGenerator) createMySQLFirewallRuleResources(Servers []mysql.Se
 }
 
 func (g *DatabasesGenerator) createMySQLVirtualNetworkRuleResources(Servers []mysql.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting MySQL VirtualNetwork Rules")
 	var resources []terraform_utils.Resource
 	ctx := context.Background()
 	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
@@ -397,7 +386,6 @@ func (g *DatabasesGenerator) getPostgreSQLServers() ([]postgresql.Server, error)
 }
 
 func (g *DatabasesGenerator) createPostgreSQLServerResources(Servers []postgresql.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting Postgresql Servers")
 	var resources []terraform_utils.Resource
 
 	for _, server := range Servers {
@@ -417,7 +405,6 @@ func (g *DatabasesGenerator) createPostgreSQLServerResources(Servers []postgresq
 }
 
 func (g *DatabasesGenerator) createPostgreSQLDatabaseResources(Servers []postgresql.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting PostgreSQL Databases")
 	var resources []terraform_utils.Resource
 	ctx := context.Background()
 	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
@@ -449,12 +436,10 @@ func (g *DatabasesGenerator) createPostgreSQLDatabaseResources(Servers []postgre
 }
 
 func (g *DatabasesGenerator) createPostgreSQLConfigurationResources(Servers []postgresql.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting PostgreSQL Configurations")
 	var resources []terraform_utils.Resource
 	ctx := context.Background()
 	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
 	Authorizer := g.Args["authorizer"].(autorest.Authorizer)
-	//terraform_utils.NewSim
 	Client := postgresql.NewConfigurationsClient(SubscriptionID)
 	Client.Authorizer = Authorizer
 
@@ -481,7 +466,6 @@ func (g *DatabasesGenerator) createPostgreSQLConfigurationResources(Servers []po
 }
 
 func (g *DatabasesGenerator) createPostgreSQLFirewallRuleResources(Servers []postgresql.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting PostgreSQL Firewall Rules")
 	var resources []terraform_utils.Resource
 	ctx := context.Background()
 	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
@@ -513,7 +497,6 @@ func (g *DatabasesGenerator) createPostgreSQLFirewallRuleResources(Servers []pos
 }
 
 func (g *DatabasesGenerator) createPostgreSQLVirtualNetworkRuleResources(Servers []postgresql.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting PostgreSQL VirtualNetwork Rules")
 	var resources []terraform_utils.Resource
 	ctx := context.Background()
 	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
@@ -569,7 +552,6 @@ func (g *DatabasesGenerator) getSQLServers() ([]sql.Server, error) {
 }
 
 func (g *DatabasesGenerator) createSQLServerResources(Servers []sql.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting SQL Servers")
 	var resources []terraform_utils.Resource
 
 	for _, server := range Servers {
@@ -589,7 +571,6 @@ func (g *DatabasesGenerator) createSQLServerResources(Servers []sql.Server) ([]t
 }
 
 func (g *DatabasesGenerator) createSQLDatabaseResources(Servers []sql.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting SQL Databases")
 	var resources []terraform_utils.Resource
 	ctx := context.Background()
 	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
@@ -621,7 +602,6 @@ func (g *DatabasesGenerator) createSQLDatabaseResources(Servers []sql.Server) ([
 }
 
 func (g *DatabasesGenerator) createSQLFirewallRuleResources(Servers []sql.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting SQL Firewall Rules")
 	var resources []terraform_utils.Resource
 	ctx := context.Background()
 	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
@@ -653,7 +633,6 @@ func (g *DatabasesGenerator) createSQLFirewallRuleResources(Servers []sql.Server
 }
 
 func (g *DatabasesGenerator) createSQLVirtualNetworkRuleResources(Servers []sql.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting SQL VirtualNetwork Rules")
 	var resources []terraform_utils.Resource
 	ctx := context.Background()
 	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
@@ -689,7 +668,6 @@ func (g *DatabasesGenerator) createSQLVirtualNetworkRuleResources(Servers []sql.
 }
 
 func (g *DatabasesGenerator) createSQLElasticPoolResources(Servers []sql.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting SQL Elastic Pools")
 	var resources []terraform_utils.Resource
 	ctx := context.Background()
 	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
@@ -721,7 +699,6 @@ func (g *DatabasesGenerator) createSQLElasticPoolResources(Servers []sql.Server)
 }
 
 func (g *DatabasesGenerator) createSQLFailoverResources(Servers []sql.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting SQL Failover Groups")
 	var resources []terraform_utils.Resource
 	ctx := context.Background()
 	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
@@ -756,7 +733,6 @@ func (g *DatabasesGenerator) createSQLFailoverResources(Servers []sql.Server) ([
 }
 
 func (g *DatabasesGenerator) createSQLADAdministratorResources(Servers []sql.Server) ([]terraform_utils.Resource, error) {
-	log.Println("\tImporting SQL Active Directory Administrator")
 	var resources []terraform_utils.Resource
 	ctx := context.Background()
 	SubscriptionID := g.Args["config"].(authentication.Config).SubscriptionID

--- a/providers/azure/helper.go
+++ b/providers/azure/helper.go
@@ -1,0 +1,158 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"context"
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
+	"github.com/Azure/go-autorest/autorest"
+	"net/url"
+	"strings"
+)
+
+// FROM https://github.com/terraform-providers/terraform-provider-azurerm/blob/6e006ff4e5d1fb200a6b37eb2743ff0ec8b11e0d/azurerm/helpers/azure/resourceid.go#L24
+
+// ResourceID represents a parsed long-form Azure Resource Manager ID
+// with the Subscription ID, Resource Group and the Provider as top-
+// level fields, and other key-value pairs available via a map in the
+// Path field.
+type ResourceID struct {
+	SubscriptionID string
+	ResourceGroup  string
+	Provider       string
+	Path           map[string]string
+}
+
+// ParseAzureResourceID converts a long-form Azure Resource Manager ID
+// into a ResourceID. We make assumptions about the structure of URLs,
+// which is obviously not good, but the best thing available given the
+// SDK.
+func ParseAzureResourceID(id string) (*ResourceID, error) {
+	idURL, err := url.ParseRequestURI(id)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot parse Azure ID: %s", err)
+	}
+
+	path := idURL.Path
+
+	path = strings.TrimPrefix(path, "/")
+	path = strings.TrimSuffix(path, "/")
+
+	components := strings.Split(path, "/")
+
+	// We should have an even number of key-value pairs.
+	if len(components)%2 != 0 {
+		return nil, fmt.Errorf("The number of path segments is not divisible by 2 in %q", path)
+	}
+
+	var subscriptionID string
+
+	// Put the constituent key-value pairs into a map
+	componentMap := make(map[string]string, len(components)/2)
+	for current := 0; current < len(components); current += 2 {
+		key := components[current]
+		value := components[current+1]
+
+		// Check key/value for empty strings.
+		if key == "" || value == "" {
+			return nil, fmt.Errorf("Key/Value cannot be empty strings. Key: '%s', Value: '%s'", key, value)
+		}
+
+		// Catch the subscriptionID before it can be overwritten by another "subscriptions"
+		// value in the ID which is the case for the Service Bus subscription resource
+		if key == "subscriptions" && subscriptionID == "" {
+			subscriptionID = value
+		} else {
+			componentMap[key] = value
+		}
+	}
+
+	// Build up a TargetResourceID from the map
+	idObj := &ResourceID{}
+	idObj.Path = componentMap
+
+	if subscriptionID != "" {
+		idObj.SubscriptionID = subscriptionID
+	} else {
+		return nil, fmt.Errorf("No subscription ID found in: %q", path)
+	}
+
+	if resourceGroup, ok := componentMap["resourceGroups"]; ok {
+		idObj.ResourceGroup = resourceGroup
+		delete(componentMap, "resourceGroups")
+	} else {
+		// Some Azure APIs are weird and provide things in lower case...
+		// However it's not clear whether the casing of other elements in the URI
+		// matter, so we explicitly look for that case here.
+		if resourceGroup, ok := componentMap["resourcegroups"]; ok {
+			idObj.ResourceGroup = resourceGroup
+			delete(componentMap, "resourcegroups")
+		}
+	}
+
+	// It is OK not to have a provider in the case of a resource group
+	if provider, ok := componentMap["providers"]; ok {
+		idObj.Provider = provider
+		delete(componentMap, "providers")
+	}
+
+	return idObj, nil
+}
+
+// END
+
+func listResourceGroups(SubscriptionID string, authorizer autorest.Authorizer) ([]resources.Group, error) {
+	ctx := context.Background()
+	var ResourceGroups []resources.Group
+	GroupClient := resources.NewGroupsClient(SubscriptionID)
+	GroupClient.Authorizer = authorizer
+
+	output, err := GroupClient.ListComplete(ctx, "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for output.NotDone() {
+		ResourceGroups = append(ResourceGroups, output.Value())
+		if err := output.NextWithContext(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	return ResourceGroups, err
+}
+
+func listVMs(SubscriptionID string, authorizer autorest.Authorizer) ([]compute.VirtualMachine, error) {
+	var virtualMachines []compute.VirtualMachine
+	ctx := context.Background()
+	VMsClient := compute.NewVirtualMachinesClient(SubscriptionID)
+	VMsClient.Authorizer = authorizer
+	VMIterator, err := VMsClient.ListAllComplete(ctx, "false")
+	if err != nil {
+		return nil, err
+	}
+
+	for VMIterator.NotDone() {
+		virtualMachines = append(virtualMachines, VMIterator.Value())
+
+		if err := VMIterator.NextWithContext(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	return virtualMachines, err
+}


### PR DESCRIPTION
This PR add more resources into Azure provider
Fix #333 
*   `analysis`
    * `azurerm_analysis_services_server`
*   `database`
	* `azurerm_mariadb_configuration`
	* `azurerm_mariadb_database`
	* `azurerm_mariadb_firewall_rule`
	* `azurerm_mariadb_server`
	* `azurerm_mariadb_virtual_network_rule`
	* `azurerm_mysql_configuration`
	* `azurerm_mysql_database`
	* `azurerm_mysql_firewall_rule`
	* `azurerm_mysql_server`
	* `azurerm_mysql_virtual_network_rule`
	* `azurerm_postgresql_configuration`
	* `azurerm_postgresql_database`
	* `azurerm_postgresql_firewall_rule`
	* `azurerm_postgresql_server`
	* `azurerm_postgresql_virtual_network_rule`
	* `azurerm_sql_database`
	* `azurerm_sql_active_directory_administrator`
	* `azurerm_sql_elasticpool`
	* `azurerm_sql_failover_group`
	* `azurerm_sql_firewall_rule`
	* `azurerm_sql_server`
	* `azurerm_sql_virtual_network_rule`
