### PR TITLE
Add support for Cloudflare API Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -928,10 +928,17 @@ All RabbitMQ resources that are currently supported by the RabbitMQ provider, ar
 
 ### Use with Cloudflare
 
-Example:
+Example using a Cloudflare API Key and corresponding email:
 ```
-CLOUDFLARE_TOKEN=[CLOUDFLARE_API_TOKEN]
-CLOUDFLARE_EMAIL=[CLOUDFLARE_EMAIL]
+export CLOUDFLARE_API_KEY=[CLOUDFLARE_API_KEY]
+export CLOUDFLARE_EMAIL=[CLOUDFLARE_EMAIL]
+ ./terraformer import cloudflare --resources=firewall,dns
+```
+
+or using a Cloudflare API Token:
+
+```
+export CLOUDFLARE_API_TOKEN=[CLOUDFLARE_API_TOKEN]
  ./terraformer import cloudflare --resources=firewall,dns
 ```
 

--- a/providers/cloudflare/cloudflare_service.go
+++ b/providers/cloudflare/cloudflare_service.go
@@ -28,14 +28,18 @@ type CloudflareService struct {
 }
 
 func (s *CloudflareService) initializeAPI() (*cf.API, error) {
-	apiKey := os.Getenv("CLOUDFLARE_TOKEN")
+	apiKey := os.Getenv("CLOUDFLARE_API_KEY")
 	apiEmail := os.Getenv("CLOUDFLARE_EMAIL")
+	apiToken := os.Getenv("CLOUDFLARE_API_TOKEN")
 
-	if apiEmail == "" || apiKey == "" {
-		err := errors.New("No CLOUDFLARE_TOKEN/CLOUDFLARE_EMAIL environment set")
+	if apiToken == "" && (apiEmail == "" || apiKey == "") {
+		err := errors.New("Either CLOUDFLARE_API_TOKEN or CLOUDFLARE_API_KEY/CLOUDFLARE_EMAIL environment variables must be set")
 		fmt.Fprintln(os.Stderr, err)
 		return nil, err
 	}
 
+	if apiToken != "" {
+		return cf.NewWithAPIToken(apiToken)
+	}
 	return cf.New(apiKey, apiEmail)
 }


### PR DESCRIPTION
In addition to email/API key, Cloudflare supports using actual API tokens with fine grained permissions: https://blog.cloudflare.com/api-tokens-general-availability/

This PR adds support for those.