### PR TITLE
handle errs in azure databases init resources

### DIFF
--- a/providers/azure/database.go
+++ b/providers/azure/database.go
@@ -766,10 +766,21 @@ func (g *DatabasesGenerator) createSQLADAdministratorResources(Servers []sql.Ser
 
 func (g *DatabasesGenerator) InitResources() error {
 	mariadbServers, err := g.getMariaDBServers()
-	mysqlServers, err := g.getMySQLServers()
-	postgresqlServers, err := g.getPostgreSQLServers()
-	sqlServers, err := g.getSQLServers()
+	if err != nil {
+		return err
+	}
 
+	mysqlServers, err := g.getMySQLServers()
+	if err != nil {
+		return err
+	}
+
+	postgresqlServers, err := g.getPostgreSQLServers()
+	if err != nil {
+		return err
+	}
+
+	sqlServers, err := g.getSQLServers()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Makes sure each individual `err` returned from function calls within the `InitResouces()` function for Azure databases is checked.