### PR TITLE
Improve travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
+dist: bionic
 language: go
 
 go:
-  - 1.13
-
-env:
-  - GO111MODULE=on
-
-go_import_path: github.com/GoogleCloudPlatform/terraformer
+  - 1.13.x
 
 before_script: go mod vendor
 


### PR DESCRIPTION
Some improvements on the Travis config:
- Use the latest go 1.13.x (right now it is 1.13.6)
- Remove `GO111MODULE` (not quite needed)
- Upgrade dist to bionic