### PR TITLE
GCP: Project IAM Resources

### DIFF
--- a/providers/gcp/iam.go
+++ b/providers/gcp/iam.go
@@ -18,21 +18,23 @@ import (
 	"context"
 	"log"
 
-	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
-
+	"cloud.google.com/go/iam/admin/apiv1"
+	"google.golang.org/api/cloudresourcemanager/v1"
+	"google.golang.org/api/iterator"
 	adminpb "google.golang.org/genproto/googleapis/iam/admin/v1"
 
-	"cloud.google.com/go/iam/admin/apiv1"
-	"google.golang.org/api/iterator"
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 )
 
 var IamAllowEmptyValues = []string{"tags."}
+
+var IamAdditionalFields = map[string]interface{}{}
 
 type IamGenerator struct {
 	GCPService
 }
 
-func (IamGenerator) createResources(serviceAccountsIterator *admin.ServiceAccountIterator) []terraform_utils.Resource {
+func (IamGenerator) createServiceAccountResources(serviceAccountsIterator *admin.ServiceAccountIterator) []terraform_utils.Resource {
 	resources := []terraform_utils.Resource{}
 	for {
 		serviceAccount, err := serviceAccountsIterator.Next()
@@ -54,7 +56,48 @@ func (IamGenerator) createResources(serviceAccountsIterator *admin.ServiceAccoun
 	return resources
 }
 
-// TODO ALL
+func (g *IamGenerator) createIamCustomRoleResources(rolesResponse *adminpb.ListRolesResponse, project string) []terraform_utils.Resource {
+	resources := []terraform_utils.Resource{}
+	for _, role := range rolesResponse.Roles {
+		resources = append(resources, terraform_utils.NewResource(
+			role.Name,
+			role.Name,
+			"google_project_iam_custom_role",
+			"google",
+			map[string]string{
+				"role_id": role.Name,
+				"project": project,
+			},
+			IamAllowEmptyValues,
+			map[string]interface{}{
+				"stage": role.Stage.String(),
+			},
+		))
+	}
+
+	return resources
+}
+
+func (g *IamGenerator) createIamBindingResources(policy *cloudresourcemanager.Policy, project string) []terraform_utils.Resource {
+	resources := []terraform_utils.Resource{}
+	for _, b := range policy.Bindings {
+		resources = append(resources, terraform_utils.NewResource(
+			b.Role,
+			b.Role,
+			"google_project_iam_binding",
+			"google",
+			map[string]string{
+				"role":    b.Role,
+				"project": project,
+			},
+			IamAllowEmptyValues,
+			IamAdditionalFields,
+		))
+	}
+
+	return resources
+}
+
 func (g *IamGenerator) InitResources() error {
 	ctx := context.Background()
 
@@ -64,8 +107,24 @@ func (g *IamGenerator) InitResources() error {
 		log.Fatal(err)
 	}
 	serviceAccountsIterator := client.ListServiceAccounts(ctx, &adminpb.ListServiceAccountsRequest{Name: "projects/" + projectID})
+	rolesResponse, err := client.ListRoles(ctx, &adminpb.ListRolesRequest{Parent: "projects/" + projectID})
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	g.Resources = g.createResources(serviceAccountsIterator)
+	cm, err := cloudresourcemanager.NewService(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	rb := &cloudresourcemanager.GetIamPolicyRequest{}
+	policyResponse, err := cm.Projects.GetIamPolicy(projectID, rb).Context(context.Background()).Do()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	g.Resources = g.createServiceAccountResources(serviceAccountsIterator)
+	g.Resources = append(g.Resources, g.createIamCustomRoleResources(rolesResponse, projectID)...)
+	g.Resources = append(g.Resources, g.createIamBindingResources(policyResponse, projectID)...)
 	return nil
 
 }

--- a/providers/gcp/iam.go
+++ b/providers/gcp/iam.go
@@ -65,6 +65,10 @@ func (IamGenerator) createServiceAccountResources(serviceAccountsIterator *admin
 func (g *IamGenerator) createIamCustomRoleResources(rolesResponse *adminpb.ListRolesResponse, project string) []terraform_utils.Resource {
 	resources := []terraform_utils.Resource{}
 	for _, role := range rolesResponse.Roles {
+		if role.Deleted {
+			// Note: no need to log that the resource has been deleted
+			continue
+		}
 		resources = append(resources, terraform_utils.NewResource(
 			role.Name,
 			role.Name,


### PR DESCRIPTION
This implements `google_project_iam_member` and `google_project_iam_custom_role` from #108 

It also adds a regex-check to the existing `google_service_account` import. When importing "google-managed" service accounts (which start with a number), subsequent `terraform plan`s would fail because "user-managed" service accounts cannot start with a number.

I've chosen for `_member` instead of `_policy`/`_binding` because having authoritative permissions on the project level, in combination with filtering, makes it very easy to break your IAM permissions by accident. 

Maybe it would be nice to have a GCP specific flag to be able to specify the type of IAM import you want? For now I've decided to keep this PR straightforward. 
