### PR TITLE
Add support for github_user_ssh_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -984,6 +984,8 @@ Supports only organizational resources. List of supported resources:
     * `github_team`
     * `github_team_membership`
     * `github_team_repository`
+*   `user`
+    * `github_user_ssh_key`
 
 Notes:
 * Terraformer can't get webhook secrets from the GitHub API. If you use a secret token in any of your webhooks, running `terraform plan` will result in a change being detected:

--- a/README.md
+++ b/README.md
@@ -984,7 +984,7 @@ Supports only organizational resources. List of supported resources:
     * `github_team`
     * `github_team_membership`
     * `github_team_repository`
-*   `user`
+*   `user_ssh_key`
     * `github_user_ssh_key`
 
 Notes:

--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -93,6 +93,6 @@ func (p *GithubProvider) GetSupportedService() map[string]terraform_utils.Servic
 		"organization_webhooks": &OrganizationWebhooksGenerator{},
 		"repositories":          &RepositoriesGenerator{},
 		"teams":                 &TeamsGenerator{},
-		"users":                 &UsersGenerator{},
+		"user_ssh_key":          &UserSSHKeyGenerator{},
 	}
 }

--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -93,5 +93,6 @@ func (p *GithubProvider) GetSupportedService() map[string]terraform_utils.Servic
 		"organization_webhooks": &OrganizationWebhooksGenerator{},
 		"repositories":          &RepositoriesGenerator{},
 		"teams":                 &TeamsGenerator{},
+		"users":                 &UsersGenerator{},
 	}
 }

--- a/providers/github/users.go
+++ b/providers/github/users.go
@@ -1,0 +1,82 @@
+// Copyright 2020 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"context"
+	"log"
+	"strconv"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+
+	githubAPI "github.com/google/go-github/v25/github"
+	"golang.org/x/oauth2"
+)
+
+type UsersGenerator struct {
+	GithubService
+}
+
+// Generate TerraformResources from Github API,
+func (g *UsersGenerator) InitResources() error {
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: g.Args["token"].(string)},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+
+	client := githubAPI.NewClient(tc)
+
+	opt := &githubAPI.UserListOptions{}
+
+	// List all users for the authenticated user
+	users, _, err := client.Users.ListAll(ctx, opt)
+	if err != nil {
+		log.Println(err)
+		return nil
+	}
+
+	for _, user := range users {
+		log.Println("User:", user.GetName())
+		opt := &githubAPI.ListOptions{PerPage: 100}
+
+		// List all ssh keys for the user
+		for {
+			keys, resp, err := client.Users.ListKeys(ctx, user.GetName(), opt)
+			if err != nil {
+				log.Println(err)
+				return nil
+			}
+
+			for _, key := range keys {
+				log.Println("Key:", key.GetID())
+				g.Resources = append(g.Resources, terraform_utils.NewSimpleResource(
+					strconv.FormatInt(key.GetID(), 10),
+					strconv.FormatInt(key.GetID(), 10),
+					"github_user_ssh_key",
+					"github",
+					[]string{},
+				))
+			}
+
+			if resp.NextPage == 0 {
+				break
+			}
+			opt.Page = resp.NextPage
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds support for the [`github_user_ssh_key`](https://www.terraform.io/docs/providers/github/r/user_ssh_key.html) resource.