### PR TITLE
add support for github_organization_block

### DIFF
--- a/README.md
+++ b/README.md
@@ -972,6 +972,8 @@ Supports only organizational resources. List of supported resources:
 
 *   `members`
     * `github_membership`
+*   `organization_block`
+    * `github_organization_block`
 *   `organization_webhooks`
     * `github_organization_webhook`
 *   `repositories`

--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -90,6 +90,7 @@ func (p *GithubProvider) InitService(serviceName string, verbose bool) error {
 func (p *GithubProvider) GetSupportedService() map[string]terraform_utils.ServiceGenerator {
 	return map[string]terraform_utils.ServiceGenerator{
 		"members":               &MembersGenerator{},
+		"organization_block":    &OrganizationBlockGenerator{},
 		"organization_webhooks": &OrganizationWebhooksGenerator{},
 		"repositories":          &RepositoriesGenerator{},
 		"teams":                 &TeamsGenerator{},

--- a/providers/github/organization_block.go
+++ b/providers/github/organization_block.go
@@ -1,0 +1,67 @@
+// Copyright 2020 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"context"
+	"log"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+
+	githubAPI "github.com/google/go-github/v25/github"
+	"golang.org/x/oauth2"
+)
+
+type OrganizationBlockGenerator struct {
+	GithubService
+}
+
+// Generate TerraformResources from Github API,
+func (g *OrganizationBlockGenerator) InitResources() error {
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: g.Args["token"].(string)},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+
+	client := githubAPI.NewClient(tc)
+
+	opt := &githubAPI.ListOptions{PerPage: 100}
+
+	// List all organization blocks for the authenticated user
+	for {
+		blocks, resp, err := client.Organizations.ListBlockedUsers(ctx, g.Args["organization"].(string), opt)
+		if err != nil {
+			log.Println(err)
+			return nil
+		}
+
+		for _, block := range blocks {
+			g.Resources = append(g.Resources, terraform_utils.NewSimpleResource(
+				block.GetLogin(),
+				block.GetLogin(),
+				"github_organization_block",
+				"github",
+				[]string{},
+			))
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
+	}
+	return nil
+}


### PR DESCRIPTION
Adds support for the [`github_organization_block`](https://www.terraform.io/docs/providers/github/r/organization_block.html) resource.