### PR TITLE
refactor github resources to be plural

### DIFF
--- a/README.md
+++ b/README.md
@@ -972,9 +972,9 @@ Supports only organizational resources. List of supported resources:
 
 *   `members`
     * `github_membership`
-*   `organization_block`
+*   `organization_blocks`
     * `github_organization_block`
-*   `organization_project`
+*   `organization_projects`
     * `github_organization_project`
 *   `organization_webhooks`
     * `github_organization_webhook`
@@ -988,7 +988,7 @@ Supports only organizational resources. List of supported resources:
     * `github_team`
     * `github_team_membership`
     * `github_team_repository`
-*   `user_ssh_key`
+*   `user_ssh_keys`
     * `github_user_ssh_key`
 
 Notes:

--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -90,11 +90,11 @@ func (p *GithubProvider) InitService(serviceName string, verbose bool) error {
 func (p *GithubProvider) GetSupportedService() map[string]terraform_utils.ServiceGenerator {
 	return map[string]terraform_utils.ServiceGenerator{
 		"members":               &MembersGenerator{},
-		"organization_block":    &OrganizationBlockGenerator{},
-		"organization_project":  &OrganizationProjectGenerator{},
+		"organization_blocks":   &OrganizationBlockGenerator{},
+		"organization_projects": &OrganizationProjectGenerator{},
 		"organization_webhooks": &OrganizationWebhooksGenerator{},
 		"repositories":          &RepositoriesGenerator{},
 		"teams":                 &TeamsGenerator{},
-		"user_ssh_key":          &UserSSHKeyGenerator{},
+		"user_ssh_keys":         &UserSSHKeyGenerator{},
 	}
 }


### PR DESCRIPTION
Renames the resource options that I added to the GitHub provider to be plural so they align with the rest of the existing supported GitHub options.