### PR TITLE
Fixed Route 53 record name

### DIFF
--- a/providers/aws/route53.go
+++ b/providers/aws/route53.go
@@ -63,7 +63,7 @@ func (g Route53Generator) createZonesResources(svc *route53.Client) []terraform_
 }
 
 func (Route53Generator) createRecordsResources(svc *route53.Client, zoneID string) []terraform_utils.Resource {
-	resources := []terraform_utils.Resource{}
+	var resources []terraform_utils.Resource
 	listParams := &route53.ListResourceRecordSetsInput{
 		HostedZoneId: aws.String(zoneID),
 	}
@@ -79,7 +79,7 @@ func (Route53Generator) createRecordsResources(svc *route53.Client, zoneID strin
 				"aws_route53_record",
 				"aws",
 				map[string]string{
-					"name":           recordName,
+					"name":           strings.TrimSuffix(recordName, "."),
 					"zone_id":        zoneID,
 					"type":           typeString,
 					"set_identifier": aws.StringValue(record.SetIdentifier),


### PR DESCRIPTION
Removing trailing dot in record names since Terraform requires a domain name without a trailing dot.

It is required to provide a set identifier for an AWS Route 53 Record in order for Terraform to import a correct record. The TF might have not ideal logic (see e.g. terraform-providers/terraform-provider-aws#11677) but the Terraformer logic is correct.

closes #118 