### PR TITLE
Correct bucket reference in generated  variables.tf

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -217,7 +217,7 @@ func printService(provider terraform_utils.ProviderGenerator, serviceName string
 					}
 					variables["data"]["terraform_remote_state"][k] = map[string]interface{}{
 						"backend": "gcs",
-						"config": bucket.BucketGetTfData(path),
+						"config": bucket.BucketGetTfData(strings.Replace(path, serviceName, k, -1)),
 					}
 				}
 			} else {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -217,10 +217,7 @@ func printService(provider terraform_utils.ProviderGenerator, serviceName string
 					}
 					variables["data"]["terraform_remote_state"][k] = map[string]interface{}{
 						"backend": "gcs",
-						"config": map[string]interface{}{
-							"bucket": strings.Replace(bucket.Name, "gs://", "", -1),
-							"prefix": bucket.BucketPrefix(strings.Replace(path, serviceName, k, -1)),
-						},
+						"config": bucket.BucketGetTfData(path),
 					}
 				}
 			} else {
@@ -256,10 +253,7 @@ func printService(provider terraform_utils.ProviderGenerator, serviceName string
 				}
 				variables["data"]["terraform_remote_state"]["local"] = map[string]interface{}{
 					"backend": "gcs",
-					"config": map[string]interface{}{
-						"bucket": strings.Replace(bucket.Name, "gs://", "", -1),
-						"prefix": bucket.BucketPrefix(path),
-					},
+					"config": bucket.BucketGetTfData(path),
 				}
 			} else {
 				variables["data"]["terraform_remote_state"]["local"] = map[string]interface{}{

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -218,7 +218,7 @@ func printService(provider terraform_utils.ProviderGenerator, serviceName string
 					variables["data"]["terraform_remote_state"][k] = map[string]interface{}{
 						"backend": "gcs",
 						"config": map[string]interface{}{
-							"bucket": bucket.Name,
+							"bucket": strings.Replace(bucket.Name, "gs://", "", -1),
 							"prefix": bucket.BucketPrefix(strings.Replace(path, serviceName, k, -1)),
 						},
 					}
@@ -257,7 +257,7 @@ func printService(provider terraform_utils.ProviderGenerator, serviceName string
 				variables["data"]["terraform_remote_state"]["local"] = map[string]interface{}{
 					"backend": "gcs",
 					"config": map[string]interface{}{
-						"bucket": bucket.Name,
+						"bucket": strings.Replace(bucket.Name, "gs://", "", -1),
 						"prefix": bucket.BucketPrefix(path),
 					},
 				}


### PR DESCRIPTION
The generated variables.tf currently looks like:
```
data "terraform_remote_state" "local" {
  backend = "gcs"

  config = {
    bucket = "gs://blah-tf-state"
    prefix = "."
  }
}
```

This change corrects the "bucket" field to:

```
data "terraform_remote_state" "local" {
  backend = "gcs"

  config = {
    bucket = "blah-tf-state"
    prefix = "."
  }
}
```

Without this change, terraform complains that it cannot find
this resource.

```
terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

data.terraform_remote_state.local: Refreshing state...

Error: Error loading state error

  on variables.tf line 2, in data "terraform_remote_state" "local":
   2:   backend = "gcs"

error loading the remote state: Failed to open state file at
gs://gs://blah-tf-state/default.tfstate: googleapi: got HTTP response
code 400 with body: <?xml version='1.0'
encoding='UTF-8'?><Error><Code>InvalidBucketName</Code><Message>The specified
bucket is not valid.</Message><Details>Invalid bucket name:
'gs:'</Details></Error>
```

Should have made this change in https://github.com/GoogleCloudPlatform/terraformer/commit/0b249339a1638c634718a67ba952f9750947abf8
but overlooked it... my bad.