### PR TITLE
Version 0.8.7

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "v0.8.6"
+const version = "v0.8.7"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",


### PR DESCRIPTION
Bumping a version to pull this PR (https://github.com/GoogleCloudPlatform/terraformer/pull/377) which fixes a stack overflow bug when using `terraformer`. 

We'll probably need to tag this commit, but I don't think I can do that from a PR. 