### PR TITLE
add support for aws_datapipeline_pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,8 @@ In that case terraformer will not know with which region resources are associate
 *   `codepipeline`
     * `aws_codepipeline`
     * `aws_codepipeline_webhook`
+*   `datapipeline`
+    * `aws_datapipeline_pipeline`
 *   `dynamodb`
     * `aws_dynamodb_table`
 *   `ec2_instance`

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -234,6 +234,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraform_utils.ServiceGe
 		"codecommit":        &CodeCommitGenerator{},
 		"codedeploy":        &CodeDeployGenerator{},
 		"codepipeline":      &CodePipelineGenerator{},
+		"datapipeline":      &DataPipelineGenerator{},
 		"dynamodb":          &DynamoDbGenerator{},
 		"ebs":               &EbsGenerator{},
 		"ec2_instance":      &Ec2Generator{},

--- a/providers/aws/datapipeline.go
+++ b/providers/aws/datapipeline.go
@@ -1,0 +1,53 @@
+// Copyright 2020 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/datapipeline"
+)
+
+var datapipelineAllowEmptyValues = []string{"tags."}
+
+type DataPipelineGenerator struct {
+	AWSService
+}
+
+func (g *DataPipelineGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := datapipeline.New(config)
+	p := datapipeline.NewListPipelinesPaginator(svc.ListPipelinesRequest(&datapipeline.ListPipelinesInput{}))
+	var resources []terraform_utils.Resource
+	for p.Next(context.Background()) {
+		for _, pipeline := range p.CurrentPage().PipelineIdList {
+			pipelineID := aws.StringValue(pipeline.Id)
+			pipelineName := aws.StringValue(pipeline.Name)
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				pipelineID,
+				pipelineName,
+				"aws_datapipeline_pipeline",
+				"aws",
+				datapipelineAllowEmptyValues))
+		}
+	}
+	g.Resources = resources
+	return p.Err()
+}


### PR DESCRIPTION
Adds support for the [`aws_datapipeline_pipeline`](https://www.terraform.io/docs/providers/aws/r/datapipeline_pipeline.html) resource.