### PR TITLE
add support for aws_devicefarm_project

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,8 @@ In that case terraformer will not know with which region resources are associate
     * `aws_codepipeline_webhook`
 *   `datapipeline`
     * `aws_datapipeline_pipeline`
+*   `devicefarm`
+    * `aws_devicefarm_project`
 *   `dynamodb`
     * `aws_dynamodb_table`
 *   `ec2_instance`

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -237,6 +237,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraform_utils.ServiceGe
 		"codedeploy":        &CodeDeployGenerator{},
 		"codepipeline":      &CodePipelineGenerator{},
 		"datapipeline":      &DataPipelineGenerator{},
+		"devicefarm":        &DeviceFarmGenerator{},
 		"dynamodb":          &DynamoDbGenerator{},
 		"ebs":               &EbsGenerator{},
 		"ec2_instance":      &Ec2Generator{},

--- a/providers/aws/devicefarm.go
+++ b/providers/aws/devicefarm.go
@@ -1,0 +1,53 @@
+// Copyright 2020 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/devicefarm"
+)
+
+var devicefarmAllowEmptyValues = []string{"tags."}
+
+type DeviceFarmGenerator struct {
+	AWSService
+}
+
+func (g *DeviceFarmGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := devicefarm.New(config)
+	p := devicefarm.NewListProjectsPaginator(svc.ListProjectsRequest(&devicefarm.ListProjectsInput{}))
+	var resources []terraform_utils.Resource
+	for p.Next(context.Background()) {
+		for _, project := range p.CurrentPage().Projects {
+			projectArn := aws.StringValue(project.Arn)
+			projectName := aws.StringValue(project.Name)
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				projectArn,
+				projectName,
+				"aws_devicefarm_project",
+				"aws",
+				devicefarmAllowEmptyValues))
+		}
+	}
+	g.Resources = resources
+	return p.Err()
+}


### PR DESCRIPTION
Adds support for the [`aws_devicefarm_project`](https://www.terraform.io/docs/providers/aws/r/devicefarm_project.html) resource.