### PR TITLE
Escape AWS interpolation in IAM + S3 Policies

### DIFF
--- a/providers/aws/aws_service.go
+++ b/providers/aws/aws_service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/external"
 	"github.com/aws/aws-sdk-go-v2/aws/stscreds"
 	"os"
+	"regexp"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 )
@@ -27,6 +28,8 @@ import (
 type AWSService struct {
 	terraform_utils.Service
 }
+
+var AWS_VARIABLE = regexp.MustCompile(`(\${[0-9A-Za-z:]+})`)
 
 func (s *AWSService) generateConfig() (aws.Config, error) {
 	config, e := s.buildBaseConfig()
@@ -66,4 +69,9 @@ func (s *AWSService) buildBaseConfig() (aws.Config, error) {
 	} else {
 		return external.LoadDefaultAWSConfig(external.WithMFATokenFunc(stscreds.StdinTokenProvider))
 	}
+}
+
+// for CF interpolation and IAM Policy variables
+func (_ *AWSService) escapeAwsInterpolation(str string) string {
+	return AWS_VARIABLE.ReplaceAllString(str, "$$$1")
 }

--- a/providers/aws/cloudformation.go
+++ b/providers/aws/cloudformation.go
@@ -19,7 +19,6 @@ import (
 	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
-	"regexp"
 )
 
 var cloudFormationAllowEmptyValues = []string{"tags."}
@@ -88,13 +87,11 @@ func (g *CloudFormationGenerator) InitResources() error {
 }
 
 func (g *CloudFormationGenerator) PostConvertHook() error {
-	cfInterpolation := regexp.MustCompile(`(\${[0-9A-Za-z:]+})`)
 	for _, resource := range g.Resources {
 		if resource.InstanceInfo.Type == "aws_cloudformation_stack" {
 			delete(resource.Item, "outputs")
 			if templateBody, ok := resource.InstanceState.Attributes["template_body"]; ok {
-				str := cfInterpolation.ReplaceAllString(templateBody, "$$$1")
-				resource.Item["template_body"] = str
+				resource.Item["template_body"] = g.escapeAwsInterpolation(templateBody)
 			}
 		}
 	}

--- a/providers/aws/iam.go
+++ b/providers/aws/iam.go
@@ -294,12 +294,12 @@ func (g *IamGenerator) PostConvertHook() error {
 			resource.InstanceInfo.Type == "aws_iam_user_policy" ||
 			resource.InstanceInfo.Type == "aws_iam_group_policy" ||
 			resource.InstanceInfo.Type == "aws_iam_role_policy" {
-			policy := resource.Item["policy"].(string)
+			policy := g.escapeAwsInterpolation(resource.Item["policy"].(string))
 			resource.Item["policy"] = fmt.Sprintf(`<<POLICY
 %s
 POLICY`, policy)
 		} else if resource.InstanceInfo.Type == "aws_iam_role" {
-			policy := resource.Item["assume_role_policy"].(string)
+			policy := g.escapeAwsInterpolation(resource.Item["assume_role_policy"].(string))
 			g.Resources[i].Item["assume_role_policy"] = fmt.Sprintf(`<<POLICY
 %s
 POLICY`, policy)

--- a/providers/aws/s3.go
+++ b/providers/aws/s3.go
@@ -111,7 +111,7 @@ func (g *S3Generator) PostConvertHook() error {
 		if resource.InstanceInfo.Type != "aws_s3_bucket_policy" {
 			continue
 		}
-		policy := resource.Item["policy"].(string)
+		policy := g.escapeAwsInterpolation(resource.Item["policy"].(string))
 		g.Resources[i].Item["policy"] = fmt.Sprintf(`<<POLICY
 %s
 POLICY`, policy)


### PR DESCRIPTION
IAM policies can contain variables [1] that can break TF format, as same as CF templates, so they must be escaped.

[1] https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html