### PR TITLE
add support for aws_media_store_container

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,8 @@ In that case terraformer will not know with which region resources are associate
     * `aws_lambda_layer_version`
 *   `media_package`
     * `aws_media_package_channel`
+*   `media_store`
+    * `aws_media_store_container`
 *   `msk`
     * `aws_msk_cluster`
 *   `nat`

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -270,6 +270,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraform_utils.ServiceGe
 		"kms":               &KmsGenerator{},
 		"lambda":            &LambdaGenerator{},
 		"media_package":     &MediaPackageGenerator{},
+		"media_store":       &MediaStoreGenerator{},
 		"msk":               &MskGenerator{},
 		"nacl":              &NaclGenerator{},
 		"nat":               &NatGatewayGenerator{},

--- a/providers/aws/media_store.go
+++ b/providers/aws/media_store.go
@@ -1,0 +1,52 @@
+// Copyright 2020 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/mediastore"
+)
+
+var mediastoreAllowEmptyValues = []string{"tags."}
+
+type MediaStoreGenerator struct {
+	AWSService
+}
+
+func (g *MediaStoreGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := mediastore.New(config)
+	p := mediastore.NewListContainersPaginator(svc.ListContainersRequest(&mediastore.ListContainersInput{}))
+	var resources []terraform_utils.Resource
+	for p.Next(context.Background()) {
+		for _, container := range p.CurrentPage().Containers {
+			containerName := aws.StringValue(container.Name)
+			resources = append(resources, terraform_utils.NewSimpleResource(
+				containerName,
+				containerName,
+				"aws_media_store_container",
+				"aws",
+				mediastoreAllowEmptyValues))
+		}
+	}
+	g.Resources = resources
+	return p.Err()
+}


### PR DESCRIPTION
Adds support for the [`aws_media_store_container`](https://www.terraform.io/docs/providers/aws/r/media_store_container.html) resource.