### PR TITLE
Fix fastly import issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,17 +15,15 @@ require (
 	github.com/aliyun/alibaba-cloud-sdk-go v1.60.295
 	github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20190307165228-86c17b95fcd5 // indirect
 	github.com/aliyun/aliyun-tablestore-go-sdk v4.1.3+incompatible
-	github.com/aws/aws-sdk-go v1.26.5 // indirect
-
+	github.com/aws/aws-sdk-go v1.26.5
 	github.com/aws/aws-sdk-go-v2 v0.19.0
 	github.com/bmatcuk/doublestar v1.2.2 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cloudflare/cloudflare-go v0.11.0
 	github.com/denverdino/aliyungo v0.0.0-20191217032211-d5785803c365
-	github.com/dghubble/sling v1.1.0
 	github.com/digitalocean/godo v1.29.0
 	github.com/dollarshaveclub/new-relic-synthetics-go v0.0.0-20170605224734-4dc3dd6ae884
-	github.com/fastly/go-fastly v1.3.0
+	github.com/fastly/go-fastly v1.7.0
 	github.com/go-resty/resty v0.0.0-00010101000000-000000000000 // indirect
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -225,6 +225,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fastly/go-fastly v1.3.0 h1:halI6tkEmn5JIeW888P2bNGprGP7OYot+o1akPXvPyY=
 github.com/fastly/go-fastly v1.3.0/go.mod h1:cBtWXhszIFx9xpzgm9L/3PW3Ixszo153xJBEHJghGUk=
+github.com/fastly/go-fastly v1.7.0 h1:IiDMXzoSSJZjQP5VIjv+BU4WMoo3DeMGIy2xm9BDuL8=
+github.com/fastly/go-fastly v1.7.0/go.mod h1:cBtWXhszIFx9xpzgm9L/3PW3Ixszo153xJBEHJghGUk=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=


### PR DESCRIPTION
# before the change

```
$ terraformer version
Terraformer v0.8.6

$ terraformer import  fastly -r service_v1
...
goroutine 1092 [chan receive]:
github.com/GoogleCloudPlatform/terraformer/terraform_utils.RefreshResourceWorker(0xc0001926c0, 0xc00072cb90, 0xc0004a25a0)
	/private/tmp/terraformer-20200207-19342-s2q293/src/github.com/GoogleCloudPlatform/terraformer/terraform_utils/utils.go:107 +0xf6
created by github.com/GoogleCloudPlatform/terraformer/terraform_utils.RefreshResources
	/private/tmp/terraformer-20200207-19342-s2q293/src/github.com/GoogleCloudPlatform/terraformer/terraform_utils/utils.go:79 +0x103

goroutine 1093 [chan receive]:
github.com/GoogleCloudPlatform/terraformer/terraform_utils.RefreshResourceWorker(0xc0001926c0, 0xc00072cb90, 0xc0004a25a0)
	/private/tmp/terraformer-20200207-19342-s2q293/src/github.com/GoogleCloudPlatform/terraformer/terraform_utils/utils.go:107 +0xf6
created by github.com/GoogleCloudPlatform/terraformer/terraform_utils.RefreshResources
	/private/tmp/terraformer-20200207-19342-s2q293/src/github.com/GoogleCloudPlatform/terraformer/terraform_utils/utils.go:79 +0x103

goroutine 1094 [chan receive]:
github.com/GoogleCloudPlatform/terraformer/terraform_utils.RefreshResourceWorker(0xc0001926c0, 0xc00072cb90, 0xc0004a25a0)
	/private/tmp/terraformer-20200207-19342-s2q293/src/github.com/GoogleCloudPlatform/terraformer/terraform_utils/utils.go:107 +0xf6
created by github.com/GoogleCloudPlatform/terraformer/terraform_utils.RefreshResources
	/private/tmp/terraformer-20200207-19342-s2q293/src/github.com/GoogleCloudPlatform/terraformer/terraform_utils/utils.go:79 +0x103
```

# After the change

Tested with the local build

```
./terraformer import  fastly -r service_v1

2020/03/20 01:02:43 Refreshing state... fastly_service_dynamic_snippet_content_v1.tfer--28szFJHt45jj8iNQPxPFiF
2020/03/20 01:02:51 fastly Connecting....
2020/03/20 01:02:51 fastly save service_v1
2020/03/20 01:02:51 fastly save tfstate for service_v1
```