### PR TITLE
Add preliminary import support for aws_appsync_graphql_api

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,8 @@ In that case terraformer will not know with which region resources are associate
     * `aws_api_gateway_stage`
     * `aws_api_gateway_usage_plan`
     * `aws_api_gateway_vpc_link`
+*   `appsync`
+    * `aws_appsync_graphql_api`
 *   `auto_scaling`
     * `aws_autoscaling_group`
     * `aws_launch_configuration`

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,7 @@ github.com/aws/aws-sdk-go-v2 v0.18.0 h1:qZ+woO4SamnH/eEbjM2IDLhRNwIwND/RQyVlBLp3
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/aws/aws-sdk-go-v2 v0.19.0 h1:jVKVeRBQah2OwqXRoy8bnWWgpo2sXk/bWf2J2tog+lk=
 github.com/aws/aws-sdk-go-v2 v0.19.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
+github.com/aws/aws-sdk-go-v2 v0.20.0 h1:/yefUjgMrda9PNFwWctBU63nL10CJMdBwkAmaQ4w4Hs=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f h1:ZNv7On9kyUzm7fvRZumSyy/IUiSC7AzL0I1jKKtwooA=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/providers/aws/appsync.go
+++ b/providers/aws/appsync.go
@@ -1,0 +1,45 @@
+package aws
+
+import (
+	"context"
+	"log"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/aws/aws-sdk-go-v2/service/appsync"
+)
+
+type AppSyncGenerator struct {
+	AWSService
+}
+
+func (g *AppSyncGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+
+	svc := appsync.New(config)
+
+	// TODO:
+	// * Service does not provides a `NewXXXXXXXXXXXPaginator` like other services' "NewListClustersPaginator" right now
+	apis, err := svc.ListGraphqlApisRequest(&appsync.ListGraphqlApisInput{}).Send(context.Background())
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	var resources []terraform_utils.Resource
+	for _, api := range apis.GraphqlApis {
+		var id = *api.ApiId
+		var name = *api.Name
+		resources = append(resources, terraform_utils.NewSimpleResource(
+			id,
+			name,
+			"aws_appsync_graphql_api",
+			"aws",
+			[]string{}))
+	}
+
+	g.Resources = resources
+	return nil
+}

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -234,6 +234,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraform_utils.ServiceGe
 		"acm":               &ACMGenerator{},
 		"alb":               &AlbGenerator{},
 		"api_gateway":       &ApiGatewayGenerator{},
+		"appsync":           &AppSyncGenerator{},
 		"auto_scaling":      &AutoScalingGenerator{},
 		"budgets":           &BudgetsGenerator{},
 		"cloud9":            &Cloud9Generator{},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -166,6 +166,7 @@ github.com/aws/aws-sdk-go-v2/private/protocol/xml/xmlutil
 github.com/aws/aws-sdk-go-v2/service/accessanalyzer
 github.com/aws/aws-sdk-go-v2/service/acm
 github.com/aws/aws-sdk-go-v2/service/apigateway
+github.com/aws/aws-sdk-go-v2/service/appsync
 github.com/aws/aws-sdk-go-v2/service/autoscaling
 github.com/aws/aws-sdk-go-v2/service/budgets
 github.com/aws/aws-sdk-go-v2/service/cloud9


### PR DESCRIPTION
```
❯ terraform output
aws_appsync_graphql_api_tfer--AppSyncTest_id = dpwxm4lkvjg2rmvvfcvz7g3gku
```
AppSyncTest being api name here

There are other sub-resources related to this service (https://www.terraform.io/docs/providers/aws/r/appsync_graphql_api.html)
they can be added later too
