### PR TITLE
Add preliminary import support for aws_cognito_userpool/aws_cognito_identity_pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,9 @@ In that case terraformer will not know with which region resources are associate
 *   `codepipeline`
     * `aws_codepipeline`
     * `aws_codepipeline_webhook`
+*   `cognito`
+    * `aws_cognito_identity_pool`
+    * `aws_cognito_user_pool`
 *   `customer_gateway`
     * `aws_customer_gateway`
 *   `datapipeline`

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -245,6 +245,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraform_utils.ServiceGe
 		"codecommit":        &CodeCommitGenerator{},
 		"codedeploy":        &CodeDeployGenerator{},
 		"codepipeline":      &CodePipelineGenerator{},
+		"cognito":           &CognitoGenerator{},
 		"customer_gateway":  &CustomerGatewayGenerator{},
 		"datapipeline":      &DataPipelineGenerator{},
 		"devicefarm":        &DeviceFarmGenerator{},

--- a/providers/aws/cognito.go
+++ b/providers/aws/cognito.go
@@ -1,0 +1,86 @@
+package aws
+
+import (
+	"context"
+	"log"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cognitoidentity"
+	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
+)
+
+type CognitoGenerator struct {
+	AWSService
+}
+
+func (g *CognitoGenerator) loadIdentityPools(svc *cognitoidentity.Client) error {
+	// TODO:
+	// * Cognito does not provides a `NewIdentityPoolsPaginator` like other services' "NewListClustersPaginator"
+	// ? Replace if it being avaialble, 60 being the max under constraint currently
+	const maxIdentityPool = 60
+	pools, err := svc.ListIdentityPoolsRequest(&cognitoidentity.ListIdentityPoolsInput{MaxResults: aws.Int64(maxIdentityPool)}).Send(context.Background())
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	for _, pool := range pools.IdentityPools {
+		var id = *pool.IdentityPoolId
+		var resourceName = *pool.IdentityPoolName
+		g.Resources = append(g.Resources, terraform_utils.NewSimpleResource(
+			id,
+			resourceName,
+			"aws_cognito_identity_pool",
+			"aws",
+			[]string{}))
+	}
+
+	return nil
+}
+
+func (g *CognitoGenerator) loadUserPools(svc *cognitoidentityprovider.Client) error {
+	// ? Replace if it being avaialble, 60 being the max under constraint currently
+	const maxUserPool = 60
+	req := svc.ListUserPoolsRequest(&cognitoidentityprovider.ListUserPoolsInput{MaxResults: aws.Int64(maxUserPool)})
+	p := cognitoidentityprovider.NewListUserPoolsPaginator(req)
+
+	for p.Next(context.Background()) {
+		page := p.CurrentPage()
+		for _, pool := range page.UserPools {
+			id := *pool.Id
+			resourceName := *pool.Name
+			g.Resources = append(g.Resources, terraform_utils.NewSimpleResource(
+				id,
+				resourceName,
+				"aws_cognito_user_pool",
+				"aws",
+				[]string{}))
+		}
+	}
+
+	if err := p.Err(); err != nil {
+		log.Println(p.Err())
+		return err
+	}
+	return nil
+}
+
+func (g *CognitoGenerator) InitResources() error {
+
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+
+	svcCognitoIdentity := cognitoidentity.New(config)
+	if err := g.loadIdentityPools(svcCognitoIdentity); err != nil {
+		return err
+	}
+	svcCognitoIdentityProvider := cognitoidentityprovider.New(config)
+	if err := g.loadUserPools(svcCognitoIdentityProvider); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -178,6 +178,8 @@ github.com/aws/aws-sdk-go-v2/service/codebuild
 github.com/aws/aws-sdk-go-v2/service/codecommit
 github.com/aws/aws-sdk-go-v2/service/codedeploy
 github.com/aws/aws-sdk-go-v2/service/codepipeline
+github.com/aws/aws-sdk-go-v2/service/cognitoidentity
+github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider
 github.com/aws/aws-sdk-go-v2/service/datapipeline
 github.com/aws/aws-sdk-go-v2/service/devicefarm
 github.com/aws/aws-sdk-go-v2/service/dynamodb


### PR DESCRIPTION
```
❯ ./terraformer import aws --resources cognito --regions ap-southeast-1
2020/03/27 13:53:05 aws importing region ap-southeast-1
2020/03/27 13:53:05 aws importing... cognito
2020/03/27 13:53:05 aws importing cognito_identity_pool: ap-southeast-1:9e3f8239-0c8a-43ab-ac5c-c936b14649d2
2020/03/27 13:53:05 aws importing cognito_user_pool: ap-southeast-1_bZWf5VS8d
2020/03/27 13:53:10 Refreshing state... aws_cognito_identity_pool.tfer--test_cognitoidentity
2020/03/27 13:53:10 Refreshing state... aws_cognito_user_pool.tfer--testUserPool
2020/03/27 13:53:11 aws Connecting.... 
2020/03/27 13:53:11 aws save cognito
2020/03/27 13:53:11 aws save tfstate for cognito
```


Support of `aws_cognito_user_pool_client` is not straightforward (What to fill to the call parameter for CreateResource for `id` so that it would not complain), need further investigate along the ReadResource path