### PR TITLE
Add import support for aws_xray_sampling_rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,8 @@ In that case terraformer will not know with which region resources are associate
     * `aws_vpn_connection`
 *   `vpn_gateway`
     * `aws_vpn_gateway`
+*   `xray`
+    * `aws_xray_sampling_rule`
 
 #### Global services
 

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -292,5 +292,6 @@ func (p *AWSProvider) GetSupportedService() map[string]terraform_utils.ServiceGe
 		"vpc_peering":       &VpcPeeringConnectionGenerator{},
 		"vpn_connection":    &VpnConnectionGenerator{},
 		"vpn_gateway":       &VpnGatewayGenerator{},
+		"xray":              &XrayGenerator{},
 	}
 }

--- a/providers/aws/xray.go
+++ b/providers/aws/xray.go
@@ -1,0 +1,43 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
+	"github.com/aws/aws-sdk-go-v2/service/xray"
+)
+
+var xrayAllowEmptyValues = []string{"tags."}
+
+type XrayGenerator struct {
+	AWSService
+}
+
+func (g *XrayGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := xray.New(config)
+
+	p := xray.NewGetSamplingRulesPaginator(svc.GetSamplingRulesRequest(&xray.GetSamplingRulesInput{}))
+	for p.Next(context.Background()) {
+		for _, samplingRule := range p.CurrentPage().SamplingRuleRecords {
+			// NOTE: Builtin rule with unmodifiable name and 10000 prirority (lowest)
+			if *samplingRule.SamplingRule.RuleName != "Default" {
+				g.Resources = append(g.Resources, terraform_utils.NewSimpleResource(
+					*samplingRule.SamplingRule.RuleName,
+					*samplingRule.SamplingRule.RuleName,
+					"aws_xray_sampling_rule",
+					"aws",
+					xrayAllowEmptyValues))
+
+				if err := p.Err(); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,6 +214,7 @@ github.com/aws/aws-sdk-go-v2/service/sqs
 github.com/aws/aws-sdk-go-v2/service/sts
 github.com/aws/aws-sdk-go-v2/service/waf
 github.com/aws/aws-sdk-go-v2/service/wafregional
+github.com/aws/aws-sdk-go-v2/service/xray
 # github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 github.com/bgentry/go-netrc/netrc
 # github.com/bgentry/speakeasy v0.1.0


### PR DESCRIPTION
```
❯ ./terraformer import aws --resources xray --regions ap-southeast-1                                                  
2020/03/30 19:31:36 aws importing region ap-southeast-1
2020/03/30 19:31:36 aws importing... xray                                         
2020/03/30 19:31:40 Refreshing state... aws_xray_sampling_rule.tfer--testRule                
2020/03/30 19:31:40 Refreshing state... aws_xray_sampling_rule.tfer--Default
2020/03/30 19:31:40 aws Connecting....                                                                     
2020/03/30 19:31:40 aws save xray     
2020/03/30 19:31:40 aws save tfstate for xray           

```
