### PR TITLE
feat: keycloak v2, consolidate all under realms, add new mappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1191,43 +1191,42 @@ Example:
  export KEYCLOAK_CLIENT_ID=[KEYCLOAK_CLIENT_ID]
  export KEYCLOAK_CLIENT_SECRET=[KEYCLOAK_CLIENT_SECRET]
 
- terraformer import keycloak --resources=realms,openid_clients
+ terraformer import keycloak --resources=realms
  terraformer import keycloak --resources=realms --filter=keycloak_realm=name1:name2:name3
- terraformer import keycloak --resources=realms,groups --targets realmA,realmB
+ terraformer import keycloak --resources=realms --targets realmA,realmB
 ```
 
-Here is the list of resources which are currently supported by Keycloak provider v.1.12.0:
+Here is the list of resources which are currently supported by Keycloak provider v.1.17.1:
 
-- `groups`
+- `realms`
+  - `keycloak_default_groups`
   - `keycloak_group`
   - `keycloak_group_memberships`
   - `keycloak_group_roles`
-  - `keycloak_default_groups`
-- `openid_clients`
-  - `keycloak_openid_client`
-  - `keycloak_openid_client_service_account_role`
-  - `keycloak_openid_user_attribute_protocol_mapper`
-  - `keycloak_openid_user_property_protocol_mapper`
-  - `keycloak_openid_full_name_protocol_mapper`
-  - `keycloak_openid_audience_protocol_mapper`
-  - `keycloak_openid_group_membership_protocol_mapper`
-  - `keycloak_openid_hardcoded_claim_protocol_mapper`
-  - `keycloak_openid_hardcoded_role_protocol_mapper`
-- `realms`
-  - `keycloak_realm`
-  - `keycloak_ldap_user_federation`
   - `keycloak_ldap_full_name_mapper`
   - `keycloak_ldap_group_mapper`
+  - `keycloak_ldap_hardcoded_group_mapper`
+  - `keycloak_ldap_hardcoded_role_mapper`
+  - `keycloak_ldap_msad_lds_user_account_control_mapper`
   - `keycloak_ldap_msad_user_account_control_mapper`
   - `keycloak_ldap_user_attribute_mapper`
-  - `keycloak_required_action`
-- `roles`
-  - `keycloak_role`
-- `scopes`
-  - `keycloak_openid_client_scope`
+  - `keycloak_ldap_user_federation`
+  - `keycloak_openid_audience_protocol_mapper`
+  - `keycloak_openid_client`
   - `keycloak_openid_client_default_scopes`
   - `keycloak_openid_client_optional_scopes`
-- `users`
+  - `keycloak_openid_client_scope`
+  - `keycloak_openid_client_service_account_role`
+  - `keycloak_openid_full_name_protocol_mapper`
+  - `keycloak_openid_group_membership_protocol_mapper`
+  - `keycloak_openid_hardcoded_claim_protocol_mapper`
+  - `keycloak_openid_hardcoded_group_protocol_mapper`
+  - `keycloak_openid_hardcoded_role_protocol_mapper`
+  - `keycloak_openid_user_attribute_protocol_mapper`
+  - `keycloak_openid_user_property_protocol_mapper`
+  - `keycloak_realm`
+  - `keycloak_required_action`
+  - `keycloak_role`
   - `keycloak_user`
 
 ### Use with Logz.io

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/linode/linodego v0.12.2
 	github.com/mattn/go-isatty v0.0.11 // indirect
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
-	github.com/mrparkers/terraform-provider-keycloak v0.0.0-20191218161228-a467c7185cbc
+	github.com/mrparkers/terraform-provider-keycloak v0.0.0-20200413144118-2212afc81161
 	github.com/paultyng/go-newrelic v3.1.0+incompatible // indirect
 	github.com/paultyng/go-newrelic/v4 v4.10.0
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -577,6 +577,8 @@ github.com/mrparkers/terraform-provider-keycloak v0.0.0-20191216155057-102097851
 github.com/mrparkers/terraform-provider-keycloak v0.0.0-20191216155057-102097851a3c/go.mod h1:pYObjfuBa5lKIMaDrE3TbTGRBySW3i7DX7/I2PxwHUA=
 github.com/mrparkers/terraform-provider-keycloak v0.0.0-20191218161228-a467c7185cbc h1:GQrdInqMDNIwpJJVGeN95lTaQL1VLoF4+H9EyE8mpl0=
 github.com/mrparkers/terraform-provider-keycloak v0.0.0-20191218161228-a467c7185cbc/go.mod h1:oQ8jZBFBNqqhgPYnop7wJp5EwNwYrHPINZs5mrTXrQE=
+github.com/mrparkers/terraform-provider-keycloak v0.0.0-20200413144118-2212afc81161 h1:s4S6wLg05Xp7ZfynnhMSsrj0ueFelTSV55gvDIgwwAY=
+github.com/mrparkers/terraform-provider-keycloak v0.0.0-20200413144118-2212afc81161/go.mod h1:q1krA85sGCNuxTOIcH9WSFf4nEO7he+IDDf5SW+xs1s=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=

--- a/providers/keycloak/generator.go
+++ b/providers/keycloak/generator.go
@@ -1,0 +1,486 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keycloak
+
+import (
+	"errors"
+	"sort"
+	"strings"
+
+	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
+)
+
+type RealmGenerator struct {
+	KeycloakService
+}
+
+func (g *RealmGenerator) InitResources() error {
+	var realms []*keycloak.Realm
+	var realmsGroups []*keycloak.Group
+
+	// Connect to keycloak instance
+	kck, err := keycloak.NewKeycloakClient(g.GetArgs()["url"].(string), g.GetArgs()["client_id"].(string), g.GetArgs()["client_secret"].(string), g.GetArgs()["realm"].(string), "", "", true, g.GetArgs()["client_timeout"].(int), g.GetArgs()["root_ca_certificate"].(string), g.GetArgs()["tls_insecure_skip_verify"].(bool))
+	if err != nil {
+		return errors.New("keycloak: could not connect to Keycloak")
+	}
+
+	// Get realm resources
+	target := g.GetArgs()["target"].(string)
+	if target == "" {
+		realms, err = kck.GetRealms()
+		if err != nil {
+			return errors.New("keycloak: could not get realms attributes in Keycloak")
+		}
+	} else {
+		realm, err := kck.GetRealm(target)
+		if err != nil {
+			return errors.New("keycloak: could not get " + target + " realm attributes in Keycloak")
+		}
+		realms = append(realms, realm)
+	}
+	g.Resources = append(g.Resources, g.createRealmResources(realms)...)
+
+	// For each realm, get resources
+	for _, realm := range realms {
+
+		// Get required actions resources
+		requiredActions, err := kck.GetRequiredActions(realm.Id)
+		if err != nil {
+			return errors.New("keycloak: could not get required actions of realm " + realm.Id + " in Keycloak")
+		}
+		g.Resources = append(g.Resources, g.createRequiredActionResources(requiredActions)...)
+
+		// Get custom federations resources
+		// TODO: support kerberos user federation
+		customUserFederations, err := kck.GetCustomUserFederations(realm.Id)
+		if err != nil {
+			return errors.New("keycloak: could not get custom user federations of realm " + realm.Id + " in Keycloak")
+		}
+		g.Resources = append(g.Resources, g.createCustomUserFederationResources(customUserFederations)...)
+
+		// For each custom federation, get mappers resources
+		for _, customUserFederation := range *customUserFederations {
+			switch customUserFederation.ProviderId {
+			case "ldap":
+				mappers, err := kck.GetLdapUserFederationMappers(realm.Id, customUserFederation.Id)
+				if err != nil {
+					return errors.New("keycloak: could not get mappers of ldap user federation " + customUserFederation.Name + " of realm " + realm.Id + " in Keycloak")
+				}
+				g.Resources = append(g.Resources, g.createLdapMapperResources(realm.Id, customUserFederation.Name, mappers)...)
+			}
+		}
+
+		// Get groups tree and default groups resources
+		realmGroups, err := kck.GetGroups(realm.Id)
+		if err != nil {
+			return errors.New("keycloak: could not get groups of realm " + realm.Id + " in Keycloak")
+		}
+		realmsGroups = append(realmsGroups, realmGroups...)
+		g.Resources = append(g.Resources, g.createDefaultGroupResource(realm.Id))
+
+		// Get users resources
+		realmUsers, err := kck.GetUsers(realm.Id)
+		if err != nil {
+			return errors.New("keycloak: could not get users of realm " + realm.Id + " in Keycloak")
+		}
+		g.Resources = append(g.Resources, g.createUserResources(realmUsers)...)
+
+		// Get realm open id client scopes resources
+		realmScopes, err := kck.ListOpenidClientScopesWithFilter(realm.Id, func(scope *keycloak.OpenidClientScope) bool { return true })
+		if err != nil {
+			return errors.New("keycloak: could not get realm scopes of realm " + realm.Id + " in Keycloak")
+		}
+		g.Resources = append(g.Resources, g.createScopeResources(realm.Id, realmScopes)...)
+
+		// Get open id clients
+		realmClients, err := kck.GetOpenidClients(realm.Id, true)
+		if err != nil {
+			return errors.New("keycloak: could not get open id clients of realm " + realm.Id + " in Keycloak")
+		}
+		g.Resources = append(g.Resources, g.createOpenIdClientResources(realmClients)...)
+
+		// For earch open id client, get resources
+		mapServiceAccountIds := map[string]map[string]string{}
+		mapContainerIDs := map[string]string{}
+		mapClientIDs := map[string]string{}
+		for _, client := range realmClients {
+			mapClientIDs[client.Id] = client.ClientId
+			mapContainerIDs[client.Id] = "_" + client.ClientId
+
+			// Get open id client protocol mappers resources
+			clientMappers, err := kck.GetGenericClientProtocolMappers(realm.Id, client.Id)
+			if err != nil {
+				return errors.New("keycloak: could not get protocol mappers of open id client " + client.ClientId + " of realm " + realm.Id + " in Keycloak")
+			}
+			g.Resources = append(g.Resources, g.createOpenIdProtocolMapperResources(client.ClientId, clientMappers)...)
+
+			// Get open id client default scopes resources
+			clientScopes, err := kck.GetOpenidDefaultClientScopes(realm.Id, client.Id)
+			if err != nil {
+				return errors.New("keycloak: could not get default client scopes of open id client " + client.ClientId + " of realm " + realm.Id + " in Keycloak")
+			}
+			if len(*clientScopes) > 0 {
+				g.Resources = append(g.Resources, g.createOpenidClientScopesResources(realm.Id, client.Id, client.ClientId, "default", clientScopes))
+			}
+
+			// Get open id client optional scopes resources
+			clientScopes, err = kck.GetOpenidOptionalClientScopes(realm.Id, client.Id)
+			if err != nil {
+				return errors.New("keycloak: could not get optional client scopes of open id client " + client.ClientId + " of realm " + realm.Id + " in Keycloak")
+			}
+			if len(*clientScopes) > 0 {
+				g.Resources = append(g.Resources, g.createOpenidClientScopesResources(realm.Id, client.Id, client.ClientId, "optional", clientScopes))
+			}
+
+			// Prepare a slice to be able to link roles associated to service account roles to be associated to the open id client, only if service accounts are enabled
+			if !client.ServiceAccountsEnabled {
+				continue
+			}
+			serviceAccountUser, err := kck.GetOpenidClientServiceAccountUserId(realm.Id, client.Id)
+			if err != nil {
+				return errors.New("keycloak: could not get service account user associated to open id client " + client.ClientId + " of realm " + realm.Id + " in Keycloak")
+			}
+			mapServiceAccountIds[serviceAccountUser.Id] = map[string]string{}
+			mapServiceAccountIds[serviceAccountUser.Id]["Id"] = client.Id
+			mapServiceAccountIds[serviceAccountUser.Id]["ClientId"] = client.ClientId
+		}
+
+		// Get open id client roles
+		clientRoles, err := kck.GetClientRoles(realm.Id, realmClients)
+		if err != nil {
+			return errors.New("keycloak: could not get open id clients roles of realm " + realm.Id + " in Keycloak")
+		}
+
+		// Get roles
+		realmRoles, err := kck.GetRealmRoles(realm.Id)
+		if err != nil {
+			return errors.New("keycloak: could not get realm roles of realm " + realm.Id + " in Keycloak")
+		}
+
+		// Set ContainerId of the roles, for realm = "", for open id clients = "_" + client.ClientId
+		// and get roles resources
+		mapContainerIDs[realm.Id] = ""
+		roles := append(clientRoles, realmRoles...)
+		for _, role := range roles {
+			role.ContainerId = mapContainerIDs[role.ContainerId]
+		}
+		g.Resources = append(g.Resources, g.createRoleResources(roles)...)
+
+		// Get service account roles resources
+		usersInRole, err := kck.GetClientRoleUsers(realm.Id, clientRoles)
+		if err != nil {
+			return errors.New("keycloak: could not get users roles of realm " + realm.Id + " in Keycloak")
+		}
+		g.Resources = append(g.Resources, g.createServiceAccountClientRolesResources(realm.Id, clientRoles, *usersInRole, mapServiceAccountIds, mapClientIDs)...)
+	}
+
+	// Parse the groups trees, and get all the groups
+	// Get groups resources
+	groups := g.flattenGroups(realmsGroups, "", "")
+	g.Resources = append(g.Resources, g.createGroupResources(groups)...)
+
+	// For each group, get group memberships and roles resources
+	for _, group := range groups {
+
+		// Get group members resources
+		members, err := kck.GetGroupMembers(group.RealmId, group.Id)
+		if err != nil {
+			return errors.New("keycloak: could not get group members of group " + group.Name + " in Keycloak")
+		}
+		if len(members) > 0 {
+			groupMembers := make([]string, len(members))
+			for k, member := range members {
+				groupMembers[k] = member.Username
+			}
+			g.Resources = append(g.Resources, g.createGroupMembershipsResource(group.RealmId, group.Id, group.Name, groupMembers))
+		}
+
+		// Get group roles resources
+		// For realm roles and open id clients roles
+		groupDetails, err := kck.GetGroup(group.RealmId, group.Id)
+		if err != nil {
+			return errors.New("keycloak: could not get details about group " + group.Name + " in Keycloak")
+		}
+		groupRoles := []string{}
+		if len(groupDetails.RealmRoles) > 0 {
+			for _, realmRole := range groupDetails.RealmRoles {
+				groupRoles = append(groupRoles, realmRole)
+			}
+		}
+		if len(groupDetails.ClientRoles) > 0 {
+			for _, clientRoles := range groupDetails.ClientRoles {
+				for _, clientRole := range clientRoles {
+					groupRoles = append(groupRoles, clientRole)
+				}
+			}
+		}
+		if len(groupRoles) > 0 {
+			g.Resources = append(g.Resources, g.createGroupRolesResource(group.RealmId, group.Id, group.Name, groupRoles))
+		}
+	}
+
+	return nil
+}
+
+func (g *RealmGenerator) PostConvertHook() error {
+	mapRealmIDs := map[string]string{}
+	mapUserFederationIDs := map[string]string{}
+	mapGroupIDs := map[string]string{}
+	mapClientIDs := map[string]string{}
+	mapClientNames := map[string]string{}
+	mapClientClientIDs := map[string]string{}
+	mapClientClientNames := map[string]string{}
+	mapServiceAccountUserIDs := map[string]string{}
+	mapRoleIDs := map[string]string{}
+	mapClientRoleNames := map[string]string{}
+	mapClientRoleShortNames := map[string]string{}
+	mapScopeNames := map[string]string{}
+	mapUserNames := map[string]string{}
+	mapGroupNames := map[string]string{}
+
+	// Set slices to be able to map IDs with Terraform variables
+	for _, r := range g.Resources {
+		if r.InstanceInfo.Type != "keycloak_realm" &&
+			r.InstanceInfo.Type != "keycloak_ldap_user_federation" &&
+			r.InstanceInfo.Type != "keycloak_group" &&
+			r.InstanceInfo.Type != "keycloak_openid_client" &&
+			r.InstanceInfo.Type != "keycloak_role" &&
+			r.InstanceInfo.Type != "keycloak_openid_client_scope" &&
+			r.InstanceInfo.Type != "keycloak_user" {
+			continue
+		}
+		if r.InstanceInfo.Type == "keycloak_realm" {
+			mapRealmIDs[r.InstanceState.ID] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".id}"
+		}
+		if r.InstanceInfo.Type == "keycloak_ldap_user_federation" {
+			mapUserFederationIDs[r.Item["realm_id"].(string)+"_"+r.InstanceState.ID] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".id}"
+		}
+		if r.InstanceInfo.Type == "keycloak_group" {
+			mapGroupIDs[r.Item["realm_id"].(string)+"_"+r.InstanceState.ID] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".id}"
+			mapGroupNames[r.Item["realm_id"].(string)+"_"+r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
+		}
+		if r.InstanceInfo.Type == "keycloak_openid_client" {
+			mapClientIDs[r.Item["realm_id"].(string)+"_"+r.InstanceState.ID] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".id}"
+			mapClientNames[r.Item["realm_id"].(string)+"_"+r.InstanceState.ID] = r.Item["client_id"].(string)
+			mapClientClientNames[r.Item["realm_id"].(string)+"_"+r.InstanceState.ID] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".client_id}"
+			mapClientClientIDs[r.Item["realm_id"].(string)+"_"+r.InstanceState.Attributes["client_id"]] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".client_id}"
+			if _, exist := r.InstanceState.Attributes["service_account_user_id"]; exist {
+				mapServiceAccountUserIDs[r.Item["realm_id"].(string)+"_"+r.InstanceState.Attributes["service_account_user_id"]] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".service_account_user_id}"
+			}
+		}
+		if r.InstanceInfo.Type == "keycloak_role" {
+			mapRoleIDs[r.Item["realm_id"].(string)+"_"+r.InstanceState.ID] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".id}"
+			if _, exist := r.Item["client_id"]; exist {
+				mapClientRoleNames[r.Item["realm_id"].(string)+"_"+mapClientNames[r.Item["realm_id"].(string)+"_"+r.Item["client_id"].(string)]+"."+r.Item["name"].(string)] = mapClientClientNames[r.Item["realm_id"].(string)+"_"+r.Item["client_id"].(string)] + ".${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
+				mapClientRoleShortNames[r.Item["realm_id"].(string)+"_"+mapClientNames[r.Item["realm_id"].(string)+"_"+r.Item["client_id"].(string)]+"."+r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
+			} else {
+				mapClientRoleNames[r.Item["realm_id"].(string)+"_"+r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
+			}
+		}
+		if r.InstanceInfo.Type == "keycloak_openid_client_scope" {
+			mapScopeNames[r.Item["realm_id"].(string)+"_"+r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
+		}
+		if r.InstanceInfo.Type == "keycloak_user" {
+			mapUserNames[r.Item["realm_id"].(string)+"_"+r.Item["username"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".username}"
+		}
+	}
+
+	// For each resources, modify import if needed...
+	for i, r := range g.Resources {
+
+		// Escape keycloak text inputs not to get unpredictable results or errors when Terraform will try to interpret variables ($ vs $$)
+		// TODO: ensure that we escape all existing fields
+		if strings.Contains(r.InstanceState.Attributes["consent_screen_text"], "$") {
+			g.Resources[i].Item["consent_screen_text"] = strings.ReplaceAll(r.InstanceState.Attributes["consent_screen_text"], "$", "$$")
+		}
+		if strings.Contains(r.InstanceState.Attributes["name"], "$") {
+			g.Resources[i].Item["name"] = strings.ReplaceAll(r.InstanceState.Attributes["name"], "$", "$$")
+		}
+		if strings.Contains(r.InstanceState.Attributes["description"], "$") {
+			g.Resources[i].Item["description"] = strings.ReplaceAll(r.InstanceState.Attributes["description"], "$", "$$")
+		}
+
+		// Sort supported_locales to get reproducible results for keycloak_realm resources
+		if r.InstanceInfo.Type == "keycloak_realm" {
+			if _, exist := r.Item["internationalization"]; exist {
+				for _, v := range r.Item["internationalization"].([]interface{}) {
+					sortedSupportedLocales := make([]string, len(v.(map[string]interface{})["supported_locales"].([]interface{})))
+					for k, vv := range v.(map[string]interface{})["supported_locales"].([]interface{}) {
+						sortedSupportedLocales[k] = vv.(string)
+					}
+					sort.Strings(sortedSupportedLocales)
+					v.(map[string]interface{})["supported_locales"] = sortedSupportedLocales
+				}
+			}
+		}
+
+		// Sort group_ids to get reproducible results for keycloak_default_groups resources
+		// Set an empty string slice if the attribute doesn't exist as it is mandatory
+		if r.InstanceInfo.Type == "keycloak_default_groups" {
+			if _, exist := r.Item["group_ids"]; exist {
+				renamedGroupIDs := make([]string, len(r.Item["group_ids"].([]interface{})))
+				for k, v := range r.Item["group_ids"].([]interface{}) {
+					renamedGroupIDs[k] = mapGroupIDs[r.Item["realm_id"].(string)+"_"+v.(string)]
+				}
+				sort.Strings(renamedGroupIDs)
+				g.Resources[i].Item["group_ids"] = renamedGroupIDs
+			} else {
+				g.Resources[i].Item["group_ids"] = []string{}
+			}
+		}
+
+		// Sort valid_redirect_uris and web_origins to get reproducible results for keycloak_openid_client resources
+		if r.InstanceInfo.Type == "keycloak_openid_client" {
+			if _, exist := r.Item["valid_redirect_uris"]; exist {
+				sortedValidRedirectUris := make([]string, len(r.Item["valid_redirect_uris"].([]interface{})))
+				for k, v := range r.Item["valid_redirect_uris"].([]interface{}) {
+					sortedValidRedirectUris[k] = v.(string)
+				}
+				sort.Strings(sortedValidRedirectUris)
+				g.Resources[i].Item["valid_redirect_uris"] = sortedValidRedirectUris
+			}
+
+			if _, exist := r.Item["web_origins"]; exist {
+				sortedWebOrigins := make([]string, len(r.Item["web_origins"].([]interface{})))
+				for k, v := range r.Item["web_origins"].([]interface{}) {
+					sortedWebOrigins[k] = v.(string)
+				}
+				sort.Strings(sortedWebOrigins)
+				g.Resources[i].Item["web_origins"] = sortedWebOrigins
+			}
+		}
+
+		// Sort composite_roles to get reproducible results for keycloak_role resources
+		if _, exist := r.Item["composite_roles"]; exist && r.InstanceInfo.Type == "keycloak_role" {
+			renamedCompositeRoles := make([]string, len(r.Item["composite_roles"].([]interface{})))
+			for k, v := range r.Item["composite_roles"].([]interface{}) {
+				renamedCompositeRoles[k] = mapRoleIDs[r.Item["realm_id"].(string)+"_"+v.(string)]
+			}
+			sort.Strings(renamedCompositeRoles)
+			g.Resources[i].Item["composite_roles"] = renamedCompositeRoles
+		}
+
+		// Sort default_scopes to get reproducible results for keycloak_openid_client_default_scopes resources
+		if _, exist := r.Item["default_scopes"]; exist && r.InstanceInfo.Type == "keycloak_openid_client_default_scopes" {
+			renamedScopes := make([]string, len(r.Item["default_scopes"].([]interface{})))
+			for k, v := range r.Item["default_scopes"].([]interface{}) {
+				renamedScopes[k] = mapScopeNames[r.Item["realm_id"].(string)+"_"+v.(string)]
+			}
+			sort.Strings(renamedScopes)
+			g.Resources[i].Item["default_scopes"] = renamedScopes
+		}
+
+		// Sort optional_scopes to get reproducible results for keycloak_openid_client_optional_scopes resources
+		if _, exist := r.Item["optional_scopes"]; exist && r.InstanceInfo.Type == "keycloak_openid_client_optional_scopes" {
+			renamedScopes := make([]string, len(r.Item["optional_scopes"].([]interface{})))
+			for k, v := range r.Item["optional_scopes"].([]interface{}) {
+				renamedScopes[k] = mapScopeNames[r.Item["realm_id"].(string)+"_"+v.(string)]
+			}
+			sort.Strings(renamedScopes)
+			g.Resources[i].Item["optional_scopes"] = renamedScopes
+		}
+
+		// Sort role_ids to get reproducible results for keycloak_group_roles resources
+		if r.InstanceInfo.Type == "keycloak_group_roles" {
+			sortedRoles := make([]string, len(r.Item["role_ids"].([]interface{})))
+			for k, v := range r.Item["role_ids"].([]interface{}) {
+				sortedRoles[k] = mapRoleIDs[r.Item["realm_id"].(string)+"_"+v.(string)]
+			}
+			sort.Strings(sortedRoles)
+			g.Resources[i].Item["role_ids"] = sortedRoles
+		}
+
+		// Sort members to get reproducible results for keycloak_group_memberships resources
+		// Map members to keycloak_user.foo.username Terraform variables
+		if r.InstanceInfo.Type == "keycloak_group_memberships" {
+			sortedMembers := make([]string, len(r.Item["members"].([]interface{})))
+			for k, v := range r.Item["members"].([]interface{}) {
+				if mapUserNames[r.Item["realm_id"].(string)+"_"+v.(string)] != "" {
+					sortedMembers[k] = mapUserNames[r.Item["realm_id"].(string)+"_"+v.(string)]
+				} else {
+					sortedMembers[k] = v.(string)
+				}
+			}
+			sort.Strings(sortedMembers)
+			g.Resources[i].Item["members"] = sortedMembers
+		}
+
+		// Map ldap_user_federation_id attributes to keycloak_ldap_user_federation.foo.id Terraform variables for ldap mappers resources
+		if r.InstanceInfo.Type == "keycloak_ldap_full_name_mapper" ||
+			r.InstanceInfo.Type == "keycloak_ldap_group_mapper" ||
+			r.InstanceInfo.Type == "keycloak_ldap_role_mapper" ||
+			r.InstanceInfo.Type == "keycloak_ldap_hardcoded_group_mapper" ||
+			r.InstanceInfo.Type == "keycloak_ldap_hardcoded_role_mapper" ||
+			r.InstanceInfo.Type == "keycloak_ldap_msad_lds_user_account_control_mapper" ||
+			r.InstanceInfo.Type == "keycloak_ldap_msad_user_account_control_mapper" ||
+			r.InstanceInfo.Type == "keycloak_ldap_user_attribute_mapper" {
+			g.Resources[i].Item["ldap_user_federation_id"] = mapUserFederationIDs[r.Item["realm_id"].(string)+"_"+g.Resources[i].Item["ldap_user_federation_id"].(string)]
+		}
+
+		// Map group to keycloak_group.foo.name Terraform variables for ldap hardcoded group mapper resources
+		if r.InstanceInfo.Type == "keycloak_ldap_hardcoded_group_mapper" {
+			g.Resources[i].Item["group"] = mapGroupNames[r.Item["realm_id"].(string)+"_"+r.Item["group"].(string)]
+		}
+
+		// Map role to Terraform variables for ldap hardcoded role mapper resources
+		if r.InstanceInfo.Type == "keycloak_ldap_hardcoded_role_mapper" {
+			g.Resources[i].Item["role"] = mapClientRoleNames[r.Item["realm_id"].(string)+"_"+r.Item["role"].(string)]
+		}
+
+		// Map parent_id to keycloak_group.foo.id Terraform variables for keycloak_group resources
+		if _, exist := r.Item["parent_id"]; exist && r.InstanceInfo.Type == "keycloak_group" {
+			g.Resources[i].Item["parent_id"] = mapGroupIDs[r.Item["realm_id"].(string)+"_"+r.Item["parent_id"].(string)]
+		}
+
+		// Map group_id to keycloak_group.foo.id Terraform variables for keycloak_group_memberships and keycloak_group_roles resources
+		if r.InstanceInfo.Type == "keycloak_group_memberships" || r.InstanceInfo.Type == "keycloak_group_roles" {
+			g.Resources[i].Item["group_id"] = mapGroupIDs[r.Item["realm_id"].(string)+"_"+r.Item["group_id"].(string)]
+		}
+
+		// Map service_account_user_id to keycloak_openid_client.foo.service_account_user_id Terraform variables for service account role resources
+		if r.InstanceInfo.Type == "keycloak_openid_client_service_account_role" {
+			g.Resources[i].Item["service_account_user_id"] = mapServiceAccountUserIDs[r.Item["realm_id"].(string)+"_"+r.Item["service_account_user_id"].(string)]
+			g.Resources[i].Item["role"] = mapClientRoleShortNames[r.Item["realm_id"].(string)+"_"+mapClientNames[r.Item["realm_id"].(string)+"_"+r.Item["client_id"].(string)]+"."+r.Item["role"].(string)]
+		}
+
+		// Map client_id attributes to keycloak_openid_client.foo.id Terraform variables for open id mappers resources
+		if _, exist := r.Item["client_id"]; exist && (r.InstanceInfo.Type == "keycloak_openid_client_service_account_role" ||
+			r.InstanceInfo.Type == "keycloak_openid_audience_protocol_mapper" ||
+			r.InstanceInfo.Type == "keycloak_openid_full_name_protocol_mapper" ||
+			r.InstanceInfo.Type == "keycloak_openid_group_membership_protocol_mapper" ||
+			r.InstanceInfo.Type == "keycloak_openid_hardcoded_claim_protocol_mapper" ||
+			r.InstanceInfo.Type == "keycloak_openid_hardcoded_group_protocol_mapper" ||
+			r.InstanceInfo.Type == "keycloak_openid_hardcoded_role_protocol_mapper" ||
+			r.InstanceInfo.Type == "keycloak_openid_user_attribute_protocol_mapper" ||
+			r.InstanceInfo.Type == "keycloak_openid_user_property_protocol_mapper" ||
+			r.InstanceInfo.Type == "keycloak_openid_user_realm_role_protocol_mapper" ||
+			r.InstanceInfo.Type == "keycloak_openid_client_default_scopes" ||
+			r.InstanceInfo.Type == "keycloak_openid_client_optional_scopes" ||
+			r.InstanceInfo.Type == "keycloak_role") {
+			g.Resources[i].Item["client_id"] = mapClientIDs[r.Item["realm_id"].(string)+"_"+r.Item["client_id"].(string)]
+		}
+
+		// Map included_client_audience to keycloak_openid_client.foo.client_id Terraform variables for open id audience mapper resources
+		if _, exist := r.Item["included_client_audience"]; exist && r.InstanceInfo.Type == "keycloak_openid_audience_protocol_mapper" {
+			g.Resources[i].Item["included_client_audience"] = mapClientClientIDs[r.Item["realm_id"].(string)+"_"+r.Item["included_client_audience"].(string)]
+		}
+
+		// Map realm_id attributes to keycloak_realm.foo.id Terraform variables for all the resources (almost all resources have this attribute)
+		if _, exist := r.Item["realm_id"]; exist {
+			g.Resources[i].Item["realm_id"] = mapRealmIDs[r.Item["realm_id"].(string)]
+		}
+	}
+	return nil
+}

--- a/providers/keycloak/keycloak_provider.go
+++ b/providers/keycloak/keycloak_provider.go
@@ -16,6 +16,7 @@ package keycloak
 
 import (
 	"errors"
+	"strconv"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 	"github.com/GoogleCloudPlatform/terraformer/terraform_utils/provider_wrapper"
@@ -24,11 +25,22 @@ import (
 
 type KeycloakProvider struct {
 	terraform_utils.Provider
-	url          string
-	clientID     string
-	clientSecret string
-	realm        string
-	target       string
+	url                   string
+	clientID              string
+	clientSecret          string
+	realm                 string
+	clientTimeout         int
+	caCert                string
+	tlsInsecureSkipVerify bool
+	target                string
+}
+
+func getArg(arg string) string {
+	if arg == "-" {
+		return ""
+	} else {
+		return arg
+	}
 }
 
 func (p *KeycloakProvider) Init(args []string) error {
@@ -36,7 +48,10 @@ func (p *KeycloakProvider) Init(args []string) error {
 	p.clientID = args[1]
 	p.clientSecret = args[2]
 	p.realm = args[3]
-	p.target = args[4]
+	p.clientTimeout, _ = strconv.Atoi(args[4])
+	p.caCert = getArg(args[5])
+	p.tlsInsecureSkipVerify, _ = strconv.ParseBool(args[6])
+	p.target = getArg(args[7])
 	return nil
 }
 
@@ -56,10 +71,13 @@ func (p *KeycloakProvider) GetProviderData(arg ...string) map[string]interface{}
 
 func (p *KeycloakProvider) GetConfig() cty.Value {
 	return cty.ObjectVal(map[string]cty.Value{
-		"url":           cty.StringVal(p.url),
-		"client_id":     cty.StringVal(p.clientID),
-		"client_secret": cty.StringVal(p.clientSecret),
-		"realm":         cty.StringVal(p.realm),
+		"url":                      cty.StringVal(p.url),
+		"client_id":                cty.StringVal(p.clientID),
+		"client_secret":            cty.StringVal(p.clientSecret),
+		"realm":                    cty.StringVal(p.realm),
+		"client_timeout":           cty.NumberIntVal(int64(p.clientTimeout)),
+		"root_ca_certificate":      cty.StringVal(p.caCert),
+		"tls_insecure_skip_verify": cty.BoolVal(p.tlsInsecureSkipVerify),
 	})
 }
 
@@ -77,46 +95,24 @@ func (p *KeycloakProvider) InitService(serviceName string, verbose bool) error {
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
-		"url":           p.url,
-		"client_id":     p.clientID,
-		"client_secret": p.clientSecret,
-		"realm":         p.realm,
-		"target":        p.target,
+		"url":                      p.url,
+		"client_id":                p.clientID,
+		"client_secret":            p.clientSecret,
+		"realm":                    p.realm,
+		"client_timeout":           p.clientTimeout,
+		"root_ca_certificate":      p.caCert,
+		"tls_insecure_skip_verify": p.tlsInsecureSkipVerify,
+		"target":                   p.target,
 	})
 	return nil
 }
 
 func (p *KeycloakProvider) GetSupportedService() map[string]terraform_utils.ServiceGenerator {
 	return map[string]terraform_utils.ServiceGenerator{
-		"groups":         &GroupGenerator{},
-		"openid_clients": &OpenIDClientGenerator{},
-		"realms":         &RealmGenerator{},
-		"roles":          &RoleGenerator{},
-		"scopes":         &ScopeGenerator{},
-		"users":          &UserGenerator{},
+		"realms": &RealmGenerator{},
 	}
 }
 
 func (KeycloakProvider) GetResourceConnections() map[string]map[string][]string {
-	return map[string]map[string][]string{
-		"openid_clients": {
-			"realms": []string{"realm_id", "self_link"},
-		},
-		"users": {
-			"realms": []string{"realm_id", "self_link"},
-		},
-		"roles": {
-			"openid_clients": []string{"client_id", "self_link"},
-			"realms":         []string{"realm_id", "self_link"},
-		},
-		"scopes": {
-			"openid_clients": []string{"client_id", "self_link"},
-			"realms":         []string{"realm_id", "self_link"},
-		},
-		"groups": {
-			"realms": []string{"realm_id", "self_link"},
-			"roles":  []string{"role_ids", "self_link"},
-			"users":  []string{"members", "username"},
-		},
-	}
+	return map[string]map[string][]string{}
 }

--- a/providers/keycloak/openid_client.go
+++ b/providers/keycloak/openid_client.go
@@ -15,22 +15,11 @@
 package keycloak
 
 import (
-	"errors"
-	"sort"
-	"strings"
-
 	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
 )
 
-type OpenIDClientGenerator struct {
-	KeycloakService
-}
-
-var OpenIDClientAllowEmptyValues = []string{"web_origins"}
-var OpenIDClientAdditionalFields = map[string]interface{}{}
-
-func (g OpenIDClientGenerator) createResources(openIDClients []*keycloak.OpenidClient) []terraform_utils.Resource {
+func (g RealmGenerator) createOpenIdClientResources(openIDClients []*keycloak.OpenidClient) []terraform_utils.Resource {
 	var resources []terraform_utils.Resource
 	for _, openIDClient := range openIDClients {
 		resources = append(resources, terraform_utils.NewResource(
@@ -41,14 +30,14 @@ func (g OpenIDClientGenerator) createResources(openIDClients []*keycloak.OpenidC
 			map[string]string{
 				"realm_id": openIDClient.RealmId,
 			},
-			OpenIDClientAllowEmptyValues,
-			OpenIDClientAdditionalFields,
+			[]string{"web_origins"},
+			map[string]interface{}{},
 		))
 	}
 	return resources
 }
 
-func (g OpenIDClientGenerator) createServiceAccountClientRolesResources(realmId string, clientRoles []*keycloak.Role, usersInRole []keycloak.UsersInRole, mapServiceAccountIds map[string]map[string]string, mapClientIDs map[string]string) []terraform_utils.Resource {
+func (g RealmGenerator) createServiceAccountClientRolesResources(realmId string, clientRoles []*keycloak.Role, usersInRole []keycloak.UsersInRole, mapServiceAccountIds map[string]map[string]string, mapClientIDs map[string]string) []terraform_utils.Resource {
 	var resources []terraform_utils.Resource
 	for _, role := range clientRoles {
 		for _, users := range usersInRole {
@@ -81,7 +70,7 @@ func (g OpenIDClientGenerator) createServiceAccountClientRolesResources(realmId 
 	return resources
 }
 
-func (g OpenIDClientGenerator) createOpenIdGenericProtocolMapperResource(protocolMapperType, protocolMapperId, protocolMapperName, realmId, clientId, clientName string) terraform_utils.Resource {
+func (g RealmGenerator) createOpenIdGenericProtocolMapperResource(protocolMapperType, protocolMapperId, protocolMapperName, realmId, clientId, clientName string) terraform_utils.Resource {
 	return terraform_utils.NewResource(
 		protocolMapperId,
 		"openid_"+protocolMapperType+"_protocol_mapper_"+normalizeResourceName(realmId)+"_"+normalizeResourceName(clientName)+"_"+normalizeResourceName(protocolMapperName),
@@ -96,7 +85,7 @@ func (g OpenIDClientGenerator) createOpenIdGenericProtocolMapperResource(protoco
 	)
 }
 
-func (g OpenIDClientGenerator) createOpenIdProtocolMapperResources(clientId string, openidClient *keycloak.OpenidClientWithGenericClientProtocolMappers) []terraform_utils.Resource {
+func (g RealmGenerator) createOpenIdProtocolMapperResources(clientId string, openidClient *keycloak.OpenidClientWithGenericClientProtocolMappers) []terraform_utils.Resource {
 	var resources []terraform_utils.Resource
 	for _, protocolMapper := range openidClient.ProtocolMappers {
 		switch protocolMapper.ProtocolMapper {
@@ -108,6 +97,8 @@ func (g OpenIDClientGenerator) createOpenIdProtocolMapperResources(clientId stri
 			resources = append(resources, g.createOpenIdGenericProtocolMapperResource("group_membership", protocolMapper.Id, protocolMapper.Name, openidClient.RealmId, openidClient.ClientId, clientId))
 		case "oidc-hardcoded-claim-mapper":
 			resources = append(resources, g.createOpenIdGenericProtocolMapperResource("hardcoded_claim", protocolMapper.Id, protocolMapper.Name, openidClient.RealmId, openidClient.ClientId, clientId))
+		case "oidc-hardcoded-group-mapper":
+			resources = append(resources, g.createOpenIdGenericProtocolMapperResource("hardcoded_group", protocolMapper.Id, protocolMapper.Name, openidClient.RealmId, openidClient.ClientId, clientId))
 		case "oidc-hardcoded-role-mapper":
 			// Not supported for the moment
 			// Only works with client roles
@@ -124,137 +115,4 @@ func (g OpenIDClientGenerator) createOpenIdProtocolMapperResources(clientId stri
 		}
 	}
 	return resources
-}
-
-func (g *OpenIDClientGenerator) InitResources() error {
-	var openIDClientsFull []*keycloak.OpenidClient
-	mapClientIDs := map[string]string{}
-	client, err := keycloak.NewKeycloakClient(g.Args["url"].(string), g.Args["client_id"].(string), g.Args["client_secret"].(string), g.Args["realm"].(string), "", "", true, 5)
-	if err != nil {
-		return errors.New("keycloak: could not connect to Keycloak")
-	}
-	var realms []*keycloak.Realm
-	if g.Args["target"].(string) == "" {
-		realms, err = client.GetRealms()
-		if err != nil {
-			return err
-		}
-	} else {
-		realm, err := client.GetRealm(g.Args["target"].(string))
-		if err != nil {
-			return err
-		}
-		realms = append(realms, realm)
-	}
-	for _, realm := range realms {
-		openIDClients, err := client.GetOpenidClients(realm.Id, true)
-		if err != nil {
-			return err
-		}
-		mapServiceAccountIds := map[string]map[string]string{}
-		for _, openIDClient := range openIDClients {
-			mapClientIDs[openIDClient.Id] = openIDClient.ClientId
-			openidClientWithGenericClientProtocolMappers, err := client.GetGenericClientProtocolMappers(realm.Id, openIDClient.Id)
-			if err != nil {
-				return err
-			}
-			g.Resources = append(g.Resources, g.createOpenIdProtocolMapperResources(openIDClient.ClientId, openidClientWithGenericClientProtocolMappers)...)
-
-			if !openIDClient.ServiceAccountsEnabled {
-				continue
-			}
-			serviceAccountUser, err := client.GetOpenidClientServiceAccountUserId(realm.Id, openIDClient.Id)
-			if err != nil {
-				return err
-			}
-			mapServiceAccountIds[serviceAccountUser.Id] = map[string]string{}
-			mapServiceAccountIds[serviceAccountUser.Id]["Id"] = openIDClient.Id
-			mapServiceAccountIds[serviceAccountUser.Id]["ClientId"] = openIDClient.ClientId
-		}
-		openIDClientsFull = append(openIDClientsFull, openIDClients...)
-
-		clientRoles, err := client.GetClientRoles(realm.Id, openIDClients)
-		if err != nil {
-			return err
-		}
-
-		usersInRole, err := client.GetClientRoleUsers(realm.Id, clientRoles)
-		if err != nil {
-			return err
-		}
-
-		g.Resources = append(g.Resources, g.createServiceAccountClientRolesResources(realm.Id, clientRoles, *usersInRole, mapServiceAccountIds, mapClientIDs)...)
-	}
-	g.Resources = append(g.Resources, g.createResources(openIDClientsFull)...)
-	return nil
-}
-
-func (g *OpenIDClientGenerator) PostConvertHook() error {
-	mapClientIDs := map[string]string{}
-	mapClientClientIDs := map[string]string{}
-	mapServiceAccountUserIDs := map[string]string{}
-	for _, r := range g.Resources {
-		if r.InstanceInfo.Type != "keycloak_openid_client" {
-			continue
-		}
-		mapClientIDs[r.InstanceState.ID] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".id}"
-		mapClientClientIDs[r.InstanceState.Attributes["client_id"]] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".client_id}"
-		if _, exist := r.InstanceState.Attributes["service_account_user_id"]; exist {
-			mapServiceAccountUserIDs[r.InstanceState.Attributes["service_account_user_id"]] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".service_account_user_id}"
-		}
-	}
-	for i, r := range g.Resources {
-		if r.InstanceInfo.Type != "keycloak_openid_client" &&
-			r.InstanceInfo.Type != "keycloak_openid_client_service_account_role" &&
-			r.InstanceInfo.Type != "keycloak_openid_audience_protocol_mapper" &&
-			r.InstanceInfo.Type != "keycloak_openid_full_name_protocol_mapper" &&
-			r.InstanceInfo.Type != "keycloak_openid_group_membership_protocol_mapper" &&
-			r.InstanceInfo.Type != "keycloak_openid_hardcoded_claim_protocol_mapper" &&
-			r.InstanceInfo.Type != "keycloak_openid_hardcoded_role_protocol_mapper" &&
-			r.InstanceInfo.Type != "keycloak_openid_user_attribute_protocol_mapper" &&
-			r.InstanceInfo.Type != "keycloak_openid_user_property_protocol_mapper" &&
-			r.InstanceInfo.Type != "keycloak_openid_user_realm_role_protocol_mapper" {
-			continue
-		}
-		if _, exist := r.Item["client_id"]; exist && (r.InstanceInfo.Type == "keycloak_openid_client_service_account_role" ||
-			r.InstanceInfo.Type == "keycloak_openid_audience_protocol_mapper" ||
-			r.InstanceInfo.Type == "keycloak_openid_full_name_protocol_mapper" ||
-			r.InstanceInfo.Type == "keycloak_openid_group_membership_protocol_mapper" ||
-			r.InstanceInfo.Type == "keycloak_openid_hardcoded_claim_protocol_mapper" ||
-			r.InstanceInfo.Type == "keycloak_openid_hardcoded_role_protocol_mapper" ||
-			r.InstanceInfo.Type == "keycloak_openid_user_attribute_protocol_mapper" ||
-			r.InstanceInfo.Type == "keycloak_openid_user_property_protocol_mapper" ||
-			r.InstanceInfo.Type == "keycloak_openid_user_realm_role_protocol_mapper") {
-			r.Item["client_id"] = mapClientIDs[r.Item["client_id"].(string)]
-		}
-		if r.InstanceInfo.Type == "keycloak_openid_client" {
-			if _, exist := r.Item["valid_redirect_uris"]; exist {
-				sortedValidRedirectUris := []string{}
-				for _, v := range r.Item["valid_redirect_uris"].([]interface{}) {
-					sortedValidRedirectUris = append(sortedValidRedirectUris, v.(string))
-				}
-				sort.Strings(sortedValidRedirectUris)
-				r.Item["valid_redirect_uris"] = sortedValidRedirectUris
-			}
-
-			if _, exist := r.Item["web_origins"]; exist {
-				sortedWebOrigins := []string{}
-				for _, v := range r.Item["web_origins"].([]interface{}) {
-					sortedWebOrigins = append(sortedWebOrigins, v.(string))
-				}
-				sort.Strings(sortedWebOrigins)
-				r.Item["web_origins"] = sortedWebOrigins
-			}
-		}
-		if _, exist := r.Item["included_client_audience"]; exist && r.InstanceInfo.Type == "keycloak_openid_audience_protocol_mapper" {
-			r.Item["included_client_audience"] = mapClientClientIDs[r.Item["included_client_audience"].(string)]
-		}
-		if _, exist := r.Item["service_account_user_id"]; exist && r.InstanceInfo.Type == "keycloak_openid_client_service_account_role" {
-			r.Item["service_account_user_id"] = mapServiceAccountUserIDs[r.Item["service_account_user_id"].(string)]
-		}
-		if strings.Contains(r.InstanceState.Attributes["name"], "$") {
-			g.Resources[i].Item["name"] = strings.ReplaceAll(r.InstanceState.Attributes["name"], "$", "$$")
-		}
-	}
-	return nil
 }

--- a/providers/keycloak/scope.go
+++ b/providers/keycloak/scope.go
@@ -15,22 +15,13 @@
 package keycloak
 
 import (
-	"errors"
-	"sort"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraform_utils"
 	"github.com/mrparkers/terraform-provider-keycloak/keycloak"
 )
 
-type ScopeGenerator struct {
-	KeycloakService
-}
-
-var ScopeAllowEmptyValues = []string{}
-var ScopeAdditionalFields = map[string]interface{}{}
-
-func (g ScopeGenerator) createResources(realmId string, openidClientScopes []*keycloak.OpenidClientScope) []terraform_utils.Resource {
+func (g RealmGenerator) createScopeResources(realmId string, openidClientScopes []*keycloak.OpenidClientScope) []terraform_utils.Resource {
 	var resources []terraform_utils.Resource
 	for _, openidClientScope := range openidClientScopes {
 		resources = append(resources, terraform_utils.NewResource(
@@ -41,14 +32,14 @@ func (g ScopeGenerator) createResources(realmId string, openidClientScopes []*ke
 			map[string]string{
 				"realm_id": realmId,
 			},
-			ScopeAllowEmptyValues,
-			ScopeAdditionalFields,
+			[]string{},
+			map[string]interface{}{},
 		))
 	}
 	return resources
 }
 
-func (g ScopeGenerator) createOpenidClientScopesResources(realmId, clientId, clientClientId, t string, openidClientScopes *[]keycloak.OpenidClientScope) terraform_utils.Resource {
+func (g RealmGenerator) createOpenidClientScopesResources(realmId, clientId, clientClientId, t string, openidClientScopes *[]keycloak.OpenidClientScope) terraform_utils.Resource {
 	var scopes []string
 	for _, openidClientScope := range *openidClientScopes {
 		scopes = append(scopes, openidClientScope.Name)
@@ -66,89 +57,4 @@ func (g ScopeGenerator) createOpenidClientScopesResources(realmId, clientId, cli
 		[]string{},
 		map[string]interface{}{},
 	)
-}
-
-func (g *ScopeGenerator) InitResources() error {
-	client, err := keycloak.NewKeycloakClient(g.Args["url"].(string), g.Args["client_id"].(string), g.Args["client_secret"].(string), g.Args["realm"].(string), "", "", true, 5)
-	if err != nil {
-		return errors.New("keycloak: could not connect to Keycloak")
-	}
-	var realms []*keycloak.Realm
-	if g.Args["target"].(string) == "" {
-		realms, err = client.GetRealms()
-		if err != nil {
-			return err
-		}
-	} else {
-		realm, err := client.GetRealm(g.Args["target"].(string))
-		if err != nil {
-			return err
-		}
-		realms = append(realms, realm)
-	}
-	for _, realm := range realms {
-		// Scopes at Realm level
-		openidClientScopes, err := client.ListOpenidClientScopesWithFilter(realm.Id, func(scope *keycloak.OpenidClientScope) bool { return true })
-		if err != nil {
-			return err
-		}
-		g.Resources = append(g.Resources, g.createResources(realm.Id, openidClientScopes)...)
-		openIDClients, err := client.GetOpenidClients(realm.Id, true)
-		if err != nil {
-			return err
-		}
-		// Scopes at OpenId Client level
-		for _, openIDClient := range openIDClients {
-			openidClientScopes, err := client.GetOpenidDefaultClientScopes(realm.Id, openIDClient.Id)
-			if err != nil {
-				return err
-			}
-			if len(*openidClientScopes) > 0 {
-				g.Resources = append(g.Resources, g.createOpenidClientScopesResources(realm.Id, openIDClient.Id, openIDClient.ClientId, "default", openidClientScopes))
-			}
-			openidClientScopes, err = client.GetOpenidOptionalClientScopes(realm.Id, openIDClient.Id)
-			if err != nil {
-				return err
-			}
-			if len(*openidClientScopes) > 0 {
-				g.Resources = append(g.Resources, g.createOpenidClientScopesResources(realm.Id, openIDClient.Id, openIDClient.ClientId, "optional", openidClientScopes))
-			}
-		}
-	}
-	return nil
-}
-
-func (g *ScopeGenerator) PostConvertHook() error {
-	mapScopeNames := map[string]string{}
-	for _, r := range g.Resources {
-		if r.InstanceInfo.Type != "keycloak_openid_client_scope" {
-			continue
-		}
-		mapScopeNames[r.Item["realm_id"].(string)+"_"+r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
-	}
-	for i, r := range g.Resources {
-		if r.InstanceInfo.Type != "keycloak_openid_client_scope" && r.InstanceInfo.Type != "keycloak_openid_client_default_scopes" && r.InstanceInfo.Type != "keycloak_openid_client_optional_scopes" {
-			continue
-		}
-		if strings.Contains(r.InstanceState.Attributes["consent_screen_text"], "$") {
-			g.Resources[i].Item["consent_screen_text"] = strings.ReplaceAll(r.InstanceState.Attributes["consent_screen_text"], "$", "$$")
-		}
-		if _, exist := r.Item["default_scopes"]; exist {
-			renamedScopes := []string{}
-			for _, v := range r.Item["default_scopes"].([]interface{}) {
-				renamedScopes = append(renamedScopes, mapScopeNames[r.Item["realm_id"].(string)+"_"+v.(string)])
-			}
-			sort.Strings(renamedScopes)
-			r.Item["default_scopes"] = renamedScopes
-		}
-		if _, exist := r.Item["optional_scopes"]; exist {
-			renamedScopes := []string{}
-			for _, v := range r.Item["optional_scopes"].([]interface{}) {
-				renamedScopes = append(renamedScopes, mapScopeNames[r.Item["realm_id"].(string)+"_"+v.(string)])
-			}
-			sort.Strings(renamedScopes)
-			r.Item["optional_scopes"] = renamedScopes
-		}
-	}
-	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -522,7 +522,7 @@ github.com/mitchellh/reflectwalk
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
-# github.com/mrparkers/terraform-provider-keycloak v0.0.0-20191218161228-a467c7185cbc
+# github.com/mrparkers/terraform-provider-keycloak v0.0.0-20200413144118-2212afc81161
 ## explicit
 github.com/mrparkers/terraform-provider-keycloak/keycloak
 # github.com/oklog/run v1.0.0


### PR DESCRIPTION
Hi,

Here is a new version of my provider. I changed a lot of things.
I removed terraformer resources and kept only `realms` elsewhere I have to much loop dependencies when I use the terraform generated code to initialize an empty keycloak instance.
I support new resources, but not all the resources supported by the terraform provider.

Regards,

Pierre