### PR TITLE
Truncate the plan file before writing to prevent invalid JSON

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -117,7 +117,7 @@ func ExportPlanFile(plan *ImportPlan, path, filename string) error {
 		return err
 	}
 
-	f, err := os.OpenFile(planfilePath, os.O_RDWR|os.O_CREATE, os.ModePerm)
+	f, err := os.OpenFile(planfilePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.ModePerm)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently the plan file is opened for writing without being truncated, so if used for multiple consecutive runs the new plan can end up only partially overwriting the old one, resulting in invalid json.

Adding `O_TRUNC` to the `OpenFile` flags resolves this.

Tested using AWS provider on Windows.