### PR TITLE
Fix undefined key in Commercetools shipping_zone 

### DIFF
--- a/providers/commercetools/shipping_zone.go
+++ b/providers/commercetools/shipping_zone.go
@@ -41,9 +41,14 @@ func (g *ShippingZoneGenerator) InitResources() error {
 		return err
 	}
 	for _, zone := range zones.Results {
+		resourceName := zone.Key
+		if resourceName == "" {
+			resourceName = zone.Name
+		}
+
 		g.Resources = append(g.Resources, terraform_utils.NewResource(
 			zone.ID,
-			zone.Key,
+			resourceName,
 			"commercetools_shipping_zone",
 			"commercetools",
 			map[string]string{},


### PR DESCRIPTION
The shipping_zone [key is optional in Commercetools](https://docs.commercetools.com/http-api-projects-zones#zone), this PR change the logic to use the name field instead when the key is not defined.

close https://github.com/GoogleCloudPlatform/terraformer/issues/479