### PR TITLE
Replace the deprecated azurerm_virtual_machine

### DIFF
--- a/providers/azure/virtual_machine.go
+++ b/providers/azure/virtual_machine.go
@@ -33,12 +33,24 @@ func (g VirtualMachineGenerator) createResources(virtualMachineListResultPage co
 	for virtualMachineListResultPage.NotDone() {
 		vms := virtualMachineListResultPage.Values()
 		for _, vm := range vms {
-			resources = append(resources, terraform_utils.NewSimpleResource(
-				*vm.ID,
-				*vm.Name,
-				"azurerm_virtual_machine",
-				"azurerm",
-				[]string{}))
+			var newResource terraform_utils.Resource
+			if vm.VirtualMachineProperties.OsProfile.WindowsConfiguration != nil {
+				newResource = terraform_utils.NewSimpleResource(
+					*vm.ID,
+					*vm.Name,
+					"azurerm_windows_virtual_machine",
+					"azurerm",
+					[]string{})
+			} else {
+				newResource = terraform_utils.NewSimpleResource(
+					*vm.ID,
+					*vm.Name,
+					"azurerm_linux_virtual_machine",
+					"azurerm",
+					[]string{})
+			}
+
+			resources = append(resources, newResource)
 		}
 		if err := virtualMachineListResultPage.Next(); err != nil {
 			log.Println(err)


### PR DESCRIPTION
Hey guys!
Cool tool!

I was testing it out, and noticed it was creating `azurerm_virtual_machine` ([here](https://www.terraform.io/docs/providers/azurerm/r/virtual_machine.html)) for all of my instances. However:
![image](https://user-images.githubusercontent.com/16308767/80407012-9b18fa00-88cd-11ea-837f-43770bd47d1e.png)
So I added an `if` that handles this case.
