### PR TITLE
Improved resource import

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,12 +496,13 @@ In that case terraformer will not know with which region resources are associate
     * `aws_iam_group_policy_attachment`
     * `aws_iam_instance_profile`
     * `aws_iam_policy`
-    * `aws_iam_policy_attachment`
     * `aws_iam_role`
     * `aws_iam_role_policy`
+    * `aws_iam_role_policy_attachment`
     * `aws_iam_user`
     * `aws_iam_user_group_membership`
     * `aws_iam_user_policy`
+    * `aws_iam_user_policy_attachment`
 *   `igw`
     * `aws_internet_gateway`
 *   `iot`

--- a/providers/aws/iam.go
+++ b/providers/aws/iam.go
@@ -107,7 +107,7 @@ func (g *IamGenerator) getRoles(svc *iam.Client) error {
 						"aws_iam_role_policy_attachment",
 						"aws",
 						map[string]string{
-							"name":       roleName,
+							"role":       roleName,
 							"policy_arn": *attachedPolicy.PolicyArn,
 						},
 						IamAllowEmptyValues,


### PR DESCRIPTION
Improved resource import. In some cases Terraform is unable to perform resource refresh and the only option that is left is a regular resource import. That import will not import attributes into TF file but should be sufficient for resources with small number of attributes e.g. `aws_iam_role_policy_attachment `.

The fix might solve other resources that return error _Read resource response is null for resource ..._ e.g. #482 #489 #473 and others

fixes #467