### PR TITLE
add support for aws_servicecatalog_portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ In that case terraformer will not know with which region resources are associate
     * `aws_db_option_group`
     * `aws_db_event_subscription`
 *   `resourcegroups`
-    `aws_resourcegroups_group`
+    * `aws_resourcegroups_group`
 *   `route53`
     * `aws_route53_zone`
     * `aws_route53_record`
@@ -563,6 +563,8 @@ In that case terraformer will not know with which region resources are associate
     * `aws_securityhub_account`
     * `aws_securityhub_member`
     * `aws_securityhub_standards_subscription`
+*   `servicecatalog`
+    * `aws_servicecatalog_portfolio`
 *   `ses`
     * `aws_ses_configuration_set`
     * `aws_ses_domain_identity`

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -285,6 +285,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"s3":                &AwsFacade{service: &S3Generator{}},
 		"secretsmanager":    &AwsFacade{service: &SecretsManagerGenerator{}},
 		"securityhub":       &AwsFacade{service: &SecurityhubGenerator{}},
+		"servicecatalog":    &AwsFacade{service: &ServiceCatalogGenerator{}},
 		"ses":               &AwsFacade{service: &SesGenerator{}},
 		"sfn":               &AwsFacade{service: &SfnGenerator{}},
 		"sg":                &AwsFacade{service: &SecurityGenerator{}},

--- a/providers/aws/servicecatalog.go
+++ b/providers/aws/servicecatalog.go
@@ -1,0 +1,53 @@
+// Copyright 2020 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/servicecatalog"
+)
+
+var servicecatalogAllowEmptyValues = []string{"tags."}
+
+type ServiceCatalogGenerator struct {
+	AWSService
+}
+
+func (g *ServiceCatalogGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := servicecatalog.New(config)
+	p := servicecatalog.NewListPortfoliosPaginator(svc.ListPortfoliosRequest(&servicecatalog.ListPortfoliosInput{}))
+	var resources []terraformutils.Resource
+	for p.Next(context.Background()) {
+		for _, portfolio := range p.CurrentPage().PortfolioDetails {
+			portfolioID := aws.StringValue(portfolio.Id)
+			portfolioName := aws.StringValue(portfolio.DisplayName)
+			resources = append(resources, terraformutils.NewSimpleResource(
+				portfolioID,
+				portfolioName,
+				"aws_servicecatalog_portfolio",
+				"aws",
+				servicecatalogAllowEmptyValues))
+		}
+	}
+	g.Resources = resources
+	return p.Err()
+}


### PR DESCRIPTION
Adds support for the [`aws_servicecatalog_portfolio`](https://www.terraform.io/docs/providers/aws/r/servicecatalog_portfolio.html) resource.