### PR TITLE
Add partial cosmosdb resources support (Azure Table / SQL) for azurerm provider 

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,6 +716,11 @@ List of supported Azure resources:
 
 *   `analysis`
     * `azurerm_analysis_services_server`
+*   `cosmosdb`
+	* `azurerm_cosmosdb_account`
+	* `azurerm_cosmosdb_sql_container`
+	* `azurerm_cosmosdb_sql_database`
+	* `azurerm_cosmosdb_table`
 *   `database`
 	* `azurerm_mariadb_configuration`
 	* `azurerm_mariadb_database`

--- a/providers/azure/azure_provider.go
+++ b/providers/azure/azure_provider.go
@@ -146,6 +146,7 @@ func (AzureProvider) GetResourceConnections() map[string]map[string][]string {
 func (p *AzureProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
 	return map[string]terraformutils.ServiceGenerator{
 		"analysis":               &AnalysisGenerator{},
+		"cosmosdb":               &CosmosDBGenerator{},
 		"database":               &DatabasesGenerator{},
 		"disk":                   &DiskGenerator{},
 		"network_interface":      &NetworkInterfaceGenerator{},

--- a/providers/azure/cosmosdb.go
+++ b/providers/azure/cosmosdb.go
@@ -136,20 +136,14 @@ func (g *CosmosDBGenerator) listAndAddForDatabaseAccounts() ([]terraformutils.Re
 		if err != nil {
 			return nil, err
 		}
-		for _, table := range tables {
-			resources = append(resources, table)
-		}
+		resources = append(resources, tables...)
 
 		sqlDatabases, sqlContainers, err := g.listSQLDatabasesAndContainersBehind(id.ResourceGroup, *account.Name)
 		if err != nil {
 			return nil, err
 		}
-		for _, sqlDatabase := range sqlDatabases {
-			resources = append(resources, sqlDatabase)
-		}
-		for _, sqlContainer := range sqlContainers {
-			resources = append(resources, sqlContainer)
-		}
+		resources = append(resources, sqlDatabases...)
+		resources = append(resources, sqlContainers...)
 	}
 
 	return resources, nil

--- a/providers/azure/cosmosdb.go
+++ b/providers/azure/cosmosdb.go
@@ -1,0 +1,172 @@
+// Copyright 2020 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2020-03-01/documentdb"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/hashicorp/go-azure-helpers/authentication"
+)
+
+type CosmosDBGenerator struct {
+	AzureService
+}
+
+func (g *CosmosDBGenerator) listSQLDatabasesAndContainersBehind(resourceGroupName string, accountName string) ([]terraformutils.Resource, []terraformutils.Resource, error) {
+	var resourcesDatabase []terraformutils.Resource
+	var resourcesContainer []terraformutils.Resource
+	ctx := context.Background()
+	subscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	SQLResourcesClient := documentdb.NewSQLResourcesClient(subscriptionID, subscriptionID)
+	SQLResourcesClient.Authorizer = g.Args["authorizer"].(autorest.Authorizer)
+
+	sqlDatabases, err := SQLResourcesClient.ListSQLDatabases(ctx, resourceGroupName, accountName)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, sqlDatabase := range *sqlDatabases.Value {
+		// NOTE:
+		// For a similar reason as
+		// https://github.com/terraform-providers/terraform-provider-azurerm/issues/7472#issuecomment-650684349
+		// The cosmosdb resource format change is NOT yet addressed in terraform provider
+		// This line is a workaround to convert to old format, and might be removed if they deprecate the old format
+		sqlDatabaseIDInOldFormat := strings.Replace(*sqlDatabase.ID, "sqlDatabases", "databases", 1)
+		resourcesDatabase = append(resourcesDatabase, terraformutils.NewSimpleResource(
+			sqlDatabaseIDInOldFormat,
+			*sqlDatabase.Name,
+			"azurerm_cosmosdb_sql_database",
+			g.ProviderName,
+			[]string{}))
+
+		sqlContainers, err := SQLResourcesClient.ListSQLContainers(ctx, resourceGroupName, accountName, *sqlDatabase.Name)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, sqlContainer := range *sqlContainers.Value {
+			// NOTE:
+			// For a similar reason as
+			// https://github.com/terraform-providers/terraform-provider-azurerm/issues/7472#issuecomment-650684349
+			// The cosmosdb resource format change is NOT yet addressed in terraform provider
+			// This line is a workaround to convert to old format, and might be removed if they deprecate the old format
+			sqlContainerIDInOldFormat := strings.Replace(*sqlContainer.ID, "sqlDatabases", "databases", 1)
+			resourcesContainer = append(resourcesContainer, terraformutils.NewSimpleResource(
+				sqlContainerIDInOldFormat,
+				*sqlContainer.Name,
+				"azurerm_cosmosdb_sql_container",
+				g.ProviderName,
+				[]string{}))
+		}
+	}
+
+	return resourcesDatabase, resourcesContainer, nil
+}
+
+func (g *CosmosDBGenerator) listTables(resourceGroupName string, accountName string) ([]terraformutils.Resource, error) {
+	var resources []terraformutils.Resource
+	ctx := context.Background()
+	subscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	// NOTE:
+	// there will be a parameter simplification for interface if we update the package
+	// https://github.com/Azure/azure-sdk-for-go/blob/v42.0.0/services/cosmos-db/mgmt/2020-03-01/documentdb/tableresources.go#L35
+	// https://github.com/Azure/azure-sdk-for-go/blob/v44.0.0/services/cosmos-db/mgmt/2020-03-01/documentdb/tableresources.go#L35
+	TableResourcesClient := documentdb.NewTableResourcesClient(subscriptionID, subscriptionID)
+	TableResourcesClient.Authorizer = g.Args["authorizer"].(autorest.Authorizer)
+
+	tables, err := TableResourcesClient.ListTables(ctx, resourceGroupName, accountName)
+	if err != nil {
+		return nil, err
+	}
+	for _, table := range *tables.Value {
+		resources = append(resources, terraformutils.NewSimpleResource(
+			*table.ID,
+			*table.Name,
+			"azurerm_cosmosdb_table",
+			g.ProviderName,
+			[]string{}))
+	}
+
+	return resources, nil
+}
+
+func (g *CosmosDBGenerator) listAndAddForDatabaseAccounts() ([]terraformutils.Resource, error) {
+	var resources []terraformutils.Resource
+	ctx := context.Background()
+	subscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	// NOTE:
+	// there will be a parameter simplification for interface if we update the package
+	// https://github.com/Azure/azure-sdk-for-go/blob/v42.0.0/services/cosmos-db/mgmt/2020-03-01/documentdb/databaseaccounts.go#L35
+	// https://github.com/Azure/azure-sdk-for-go/blob/v44.0.0/services/cosmos-db/mgmt/2020-03-01/documentdb/databaseaccounts.go#L35
+	DatabaseAccountsClient := documentdb.NewDatabaseAccountsClient(subscriptionID, subscriptionID)
+	DatabaseAccountsClient.Authorizer = g.Args["authorizer"].(autorest.Authorizer)
+
+	accounts, err := DatabaseAccountsClient.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, account := range *accounts.Value {
+		resources = append(resources, terraformutils.NewSimpleResource(
+			*account.ID,
+			*account.Name,
+			"azurerm_cosmosdb_account",
+			g.ProviderName,
+			[]string{}))
+
+		id, err := ParseAzureResourceID(*account.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		tables, err := g.listTables(id.ResourceGroup, *account.Name)
+		if err != nil {
+			return nil, err
+		}
+		for _, table := range tables {
+			resources = append(resources, table)
+		}
+
+		sqlDatabases, sqlContainers, err := g.listSQLDatabasesAndContainersBehind(id.ResourceGroup, *account.Name)
+		if err != nil {
+			return nil, err
+		}
+		for _, sqlDatabase := range sqlDatabases {
+			resources = append(resources, sqlDatabase)
+		}
+		for _, sqlContainer := range sqlContainers {
+			resources = append(resources, sqlContainer)
+		}
+	}
+
+	return resources, nil
+}
+
+func (g *CosmosDBGenerator) InitResources() error {
+	functions := []func() ([]terraformutils.Resource, error){
+		g.listAndAddForDatabaseAccounts,
+	}
+
+	for _, f := range functions {
+		resources, err := f()
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, resources...)
+	}
+
+	return nil
+}


### PR DESCRIPTION
- There are minor workarounds,please refer to the `NOTE:` blocks 
  [azure resource id renaming & function interface changing across versions ]

```
╰─ ./terraformer import  azure --resources cosmosdb                                                                                                        ─╯
2020/07/05 19:52:29 Testing if Service Principal / Client Certificate is applicable for Authentication..
2020/07/05 19:52:29 Testing if Multi Tenant Service Principal / Client Secret is applicable for Authentication..
2020/07/05 19:52:29 Testing if Service Principal / Client Secret is applicable for Authentication..
2020/07/05 19:52:29 Testing if Managed Service Identity is applicable for Authentication..
2020/07/05 19:52:29 Testing if Obtaining a token from the Azure CLI is applicable for Authentication..
2020/07/05 19:52:29 Using Obtaining a token from the Azure CLI for Authentication
2020/07/05 19:52:29 Getting OAuth config for endpoint https://login.microsoftonline.com/ with  tenant 528f4467-9372-4a5a-8c94-fa270285215d
2020/07/05 19:52:31 azurerm importing... cosmosdb
2020/07/05 19:52:44 Refreshing state... azurerm_cosmosdb_account.tfer--account1
2020/07/05 19:52:44 Refreshing state... azurerm_cosmosdb_sql_database.tfer--ToDoList
2020/07/05 19:52:44 Refreshing state... azurerm_cosmosdb_account.tfer--cosmos-002D-test-002D-azure-002D-table-002D-ac
2020/07/05 19:52:44 Refreshing state... azurerm_cosmosdb_sql_container.tfer--Items
2020/07/05 19:52:44 Refreshing state... azurerm_cosmosdb_table.tfer--table1
2020/07/05 19:52:49 azurerm Connecting....
2020/07/05 19:52:49 azurerm save cosmosdb
2020/07/05 19:52:49 azurerm save tfstate for cosmosdb
```

```
❯ terraform refresh
azurerm_cosmosdb_sql_container.tfer--Items: Refreshing state... [id=/subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/account1/databases/ToDoList/containers/Items]
azurerm_cosmosdb_sql_database.tfer--ToDoList: Refreshing state... [id=/subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/account1/databases/ToDoList]
azurerm_cosmosdb_table.tfer--table1: Refreshing state... [id=/subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/cosmos-test-azure-table-ac/tables/table1]
azurerm_cosmosdb_account.tfer--cosmos-002D-test-002D-azure-002D-table-002D-ac: Refreshing state... [id=/subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/cosmos-test-azure-table-ac]
azurerm_cosmosdb_account.tfer--account1: Refreshing state... [id=/subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/account1]

Outputs:

azurerm_cosmosdb_account_tfer--account1_id = /subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/account1
azurerm_cosmosdb_account_tfer--cosmos-002D-test-002D-azure-002D-table-002D-ac_id = /subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/cosmos-test-azure-table-ac
azurerm_cosmosdb_sql_container_tfer--Items_id = /subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/account1/databases/ToDoList/containers/Items
azurerm_cosmosdb_sql_database_tfer--ToDoList_id = /subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/account1/databases/ToDoList
azurerm_cosmosdb_table_tfer--table1_id = /subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/cosmos-test-azure-table-ac/tables/table1
```