### PR TITLE
Add azurerm_private_dns_* support

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,6 +775,16 @@ List of supported Azure resources:
     * `azurerm_network_interface`
 *   `network_security_group`
     * `azurerm_network_security_group`
+*   `private_dns`
+    * `azurerm_private_dns_a_record`
+    * `azurerm_private_dns_aaaa_record`
+    * `azurerm_private_dns_cname_record`
+    * `azurerm_private_dns_mx_record`
+    * `azurerm_private_dns_ptr_record`
+    * `azurerm_private_dns_srv_record`
+    * `azurerm_private_dns_txt_record`
+    * `azurerm_private_dns_zone`
+    * `azurerm_private_dns_zone_virtual_network_link`
 *   `resource_group`
     * `azurerm_resource_group`
 *   `scaleset`

--- a/providers/azure/azure_provider.go
+++ b/providers/azure/azure_provider.go
@@ -156,6 +156,7 @@ func (p *AzureProvider) GetSupportedService() map[string]terraformutils.ServiceG
 		"load_balancer":                        &LoadBalancerGenerator{},
 		"network_interface":                    &NetworkInterfaceGenerator{},
 		"network_security_group":               &NetworkSecurityGroupGenerator{},
+		"private_dns":                          &PrivateDNSGenerator{},
 		"resource_group":                       &ResourceGroupGenerator{},
 		"scaleset":                             &ScaleSetGenerator{},
 		"security_center_contact":              &SecurityCenterContactGenerator{},

--- a/providers/azure/private_dns.go
+++ b/providers/azure/private_dns.go
@@ -1,0 +1,167 @@
+// Copyright 2020 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/hashicorp/go-azure-helpers/authentication"
+)
+
+type PrivateDNSGenerator struct {
+	AzureService
+}
+
+func (g *PrivateDNSGenerator) listRecordSets(resourceGroupName string, privateZoneName string, top *int32) ([]terraformutils.Resource, error) {
+	var resources []terraformutils.Resource
+	ctx := context.Background()
+	subscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	RecordSetsClient := privatedns.NewRecordSetsClient(subscriptionID)
+	RecordSetsClient.Authorizer = g.Args["authorizer"].(autorest.Authorizer)
+
+	recordSetIterator, err := RecordSetsClient.ListComplete(ctx, resourceGroupName, privateZoneName, top, "")
+	if err != nil {
+		return nil, err
+	}
+	for recordSetIterator.NotDone() {
+		recordSet := recordSetIterator.Value()
+		// NOTE:
+		// Format example: "Microsoft.Network/privateDnsZones/CNAME"
+		recordTypeSplitted := strings.Split(*recordSet.Type, "/")
+		recordType := recordTypeSplitted[len(recordTypeSplitted)-1]
+		typeResourceNameMap := map[string]string{
+			"A":     "azurerm_private_dns_a_record",
+			"AAAA":  "azurerm_private_dns_aaaa_record",
+			"CNAME": "azurerm_private_dns_cname_record",
+			"MX":    "azurerm_private_dns_mx_record",
+			"PTR":   "azurerm_private_dns_ptr_record",
+			"SRV":   "azurerm_private_dns_srv_record",
+			"TXT":   "azurerm_private_dns_txt_record",
+		}
+		if resName, exist := typeResourceNameMap[recordType]; exist {
+			resources = append(resources, terraformutils.NewSimpleResource(
+				*recordSet.ID,
+				*recordSet.Name,
+				resName,
+				g.ProviderName,
+				[]string{}))
+		}
+
+		if err := recordSetIterator.Next(); err != nil {
+			log.Println(err)
+			break
+		}
+
+	}
+	return resources, nil
+}
+
+func (g *PrivateDNSGenerator) listVirtualNetworkLinks(resourceGroupName string, privateZoneName string, pageSize *int32) ([]terraformutils.Resource, error) {
+	var resources []terraformutils.Resource
+	ctx := context.Background()
+	subscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	VirtualNetworkLinksClient := privatedns.NewVirtualNetworkLinksClient(subscriptionID)
+	VirtualNetworkLinksClient.Authorizer = g.Args["authorizer"].(autorest.Authorizer)
+
+	virtualNetworkLinkIterator, err := VirtualNetworkLinksClient.ListComplete(ctx, resourceGroupName, privateZoneName, pageSize)
+	if err != nil {
+		return nil, err
+	}
+	for virtualNetworkLinkIterator.NotDone() {
+		virtualNetworkLink := virtualNetworkLinkIterator.Value()
+		resources = append(resources, terraformutils.NewSimpleResource(
+			*virtualNetworkLink.ID,
+			*virtualNetworkLink.Name,
+			"azurerm_private_dns_zone_virtual_network_link",
+			g.ProviderName,
+			[]string{}))
+
+		if err := virtualNetworkLinkIterator.Next(); err != nil {
+			log.Println(err)
+			break
+		}
+
+	}
+
+	return resources, nil
+}
+
+func (g *PrivateDNSGenerator) listAndAddForPrivateDNSZone() ([]terraformutils.Resource, error) {
+	var resources []terraformutils.Resource
+	ctx := context.Background()
+	subscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	PrivateDNSZonesClient := privatedns.NewPrivateZonesClient(subscriptionID)
+	PrivateDNSZonesClient.Authorizer = g.Args["authorizer"].(autorest.Authorizer)
+
+	var pageSize int32 = 50
+	dnsZoneIterator, err := PrivateDNSZonesClient.ListComplete(ctx, &pageSize)
+	if err != nil {
+		return nil, err
+	}
+	for dnsZoneIterator.NotDone() {
+		zone := dnsZoneIterator.Value()
+		resources = append(resources, terraformutils.NewSimpleResource(
+			*zone.ID,
+			*zone.Name,
+			"azurerm_private_dns_zone",
+			g.ProviderName,
+			[]string{}))
+
+		id, err := ParseAzureResourceID(*zone.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		records, err := g.listRecordSets(id.ResourceGroup, *zone.Name, &pageSize)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, records...)
+
+		networkLinks, err := g.listVirtualNetworkLinks(id.ResourceGroup, *zone.Name, &pageSize)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, networkLinks...)
+
+		if err := dnsZoneIterator.Next(); err != nil {
+			log.Println(err)
+			break
+		}
+	}
+
+	return resources, nil
+}
+
+func (g *PrivateDNSGenerator) InitResources() error {
+	functions := []func() ([]terraformutils.Resource, error){
+		g.listAndAddForPrivateDNSZone,
+	}
+
+	for _, f := range functions {
+		resources, err := f()
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, resources...)
+	}
+
+	return nil
+}


### PR DESCRIPTION
```
azurerm_private_dns_txt_record.tfer--testtxt: Refreshing state... [id=/subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/testprivatedns.dns/TXT/testtxt]
azurerm_private_dns_mx_record.tfer--testmx: Refreshing state... [id=/subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/testprivatedns.dns/MX/testmx]
azurerm_private_dns_a_record.tfer--testa: Refreshing state... [id=/subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/testprivatedns.dns/A/testa]
azurerm_private_dns_ptr_record.tfer--testptr: Refreshing state... [id=/subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/testprivatedns.dns/PTR/testptr]
azurerm_private_dns_cname_record.tfer--testcname: Refreshing state... [id=/subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/testprivatedns.dns/CNAME/testcname]
azurerm_private_dns_aaaa_record.tfer--testaaaa: Refreshing state... [id=/subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/testprivatedns.dns/AAAA/testaaaa]
azurerm_private_dns_zone.tfer--testprivatedns-002E-dns: Refreshing state... [id=/subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/testprivatedns.dns]
azurerm_private_dns_zone_virtual_network_link.tfer--testvirtualnetworklink: Refreshing state... [id=/subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/testprivatedns.dns/virtualNetworkLinks/testvirtualnetworklink]
azurerm_private_dns_srv_record.tfer--_testsrv-002E-_testdsad: Refreshing state... [id=/subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/testprivatedns.dns/SRV/_testsrv._testdsad]

Outputs:

azurerm_private_dns_a_record_tfer--testa_id = /subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/testprivatedns.dns/A/testa
azurerm_private_dns_aaaa_record_tfer--testaaaa_id = /subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/testprivatedns.dns/AAAA/testaaaa
azurerm_private_dns_cname_record_tfer--testcname_id = /subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/testprivatedns.dns/CNAME/testcname
azurerm_private_dns_mx_record_tfer--testmx_id = /subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/testprivatedns.dns/MX/testmx
azurerm_private_dns_ptr_record_tfer--testptr_id = /subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/testprivatedns.dns/PTR/testptr
azurerm_private_dns_srv_record_tfer--_testsrv-002E-_testdsad_id = /subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/testprivatedns.dns/SRV/_testsrv._testdsad
azurerm_private_dns_txt_record_tfer--testtxt_id = /subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/testprivatedns.dns/TXT/testtxt
azurerm_private_dns_zone_tfer--testprivatedns-002E-dns_id = /subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/testprivatedns.dns
azurerm_private_dns_zone_virtual_network_link_tfer--testvirtualnetworklink_id = /subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/testprivatedns.dns/virtualNetworkLinks/testvirtualnetworklink
```