### PR TITLE
Add azurerm_public_ip* support

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,7 +785,7 @@ List of supported Azure resources:
     * `azurerm_private_dns_txt_record`
     * `azurerm_private_dns_zone`
     * `azurerm_private_dns_zone_virtual_network_link`
-*   `pubilc`
+*   `pubilc_ip`
     * `azurerm_public_ip`
     * `azurerm_public_ip_prefix`
 *   `resource_group`

--- a/README.md
+++ b/README.md
@@ -785,6 +785,9 @@ List of supported Azure resources:
     * `azurerm_private_dns_txt_record`
     * `azurerm_private_dns_zone`
     * `azurerm_private_dns_zone_virtual_network_link`
+*   `pubilc`
+    * `azurerm_public_ip`
+    * `azurerm_public_ip_prefix`
 *   `resource_group`
     * `azurerm_resource_group`
 *   `scaleset`

--- a/providers/azure/azure_provider.go
+++ b/providers/azure/azure_provider.go
@@ -156,6 +156,7 @@ func (p *AzureProvider) GetSupportedService() map[string]terraformutils.ServiceG
 		"load_balancer":                        &LoadBalancerGenerator{},
 		"network_interface":                    &NetworkInterfaceGenerator{},
 		"network_security_group":               &NetworkSecurityGroupGenerator{},
+		"public_ip":                            &PublicIPGenerator{},
 		"private_dns":                          &PrivateDNSGenerator{},
 		"resource_group":                       &ResourceGroupGenerator{},
 		"scaleset":                             &ScaleSetGenerator{},

--- a/providers/azure/public_ip.go
+++ b/providers/azure/public_ip.go
@@ -1,0 +1,104 @@
+// Copyright 2020 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"context"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/hashicorp/go-azure-helpers/authentication"
+)
+
+type PublicIPGenerator struct {
+	AzureService
+}
+
+func (g *PublicIPGenerator) listAndAddForPublicIPAddress() ([]terraformutils.Resource, error) {
+	var resources []terraformutils.Resource
+	ctx := context.Background()
+	subscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	PublicIPAddressesClient := network.NewPublicIPAddressesClient(subscriptionID)
+	PublicIPAddressesClient.Authorizer = g.Args["authorizer"].(autorest.Authorizer)
+
+	publicIPAddressIterator, err := PublicIPAddressesClient.ListAllComplete(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for publicIPAddressIterator.NotDone() {
+		publicIP := publicIPAddressIterator.Value()
+		resources = append(resources, terraformutils.NewSimpleResource(
+			*publicIP.ID,
+			*publicIP.Name,
+			"azurerm_public_ip",
+			g.ProviderName,
+			[]string{}))
+
+		if err := publicIPAddressIterator.Next(); err != nil {
+			log.Println(err)
+			break
+		}
+	}
+
+	return resources, nil
+}
+
+func (g *PublicIPGenerator) listAndAddForPublicIPPrefix() ([]terraformutils.Resource, error) {
+	var resources []terraformutils.Resource
+	ctx := context.Background()
+	subscriptionID := g.Args["config"].(authentication.Config).SubscriptionID
+	PublicIPPrefixesClient := network.NewPublicIPPrefixesClient(subscriptionID)
+	PublicIPPrefixesClient.Authorizer = g.Args["authorizer"].(autorest.Authorizer)
+
+	publicIPPrefixIterator, err := PublicIPPrefixesClient.ListAllComplete(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for publicIPPrefixIterator.NotDone() {
+		publicIPPrefix := publicIPPrefixIterator.Value()
+		resources = append(resources, terraformutils.NewSimpleResource(
+			*publicIPPrefix.ID,
+			*publicIPPrefix.Name,
+			"azurerm_public_ip_prefix",
+			g.ProviderName,
+			[]string{}))
+
+		if err := publicIPPrefixIterator.Next(); err != nil {
+			log.Println(err)
+			break
+		}
+	}
+
+	return resources, nil
+}
+
+func (g *PublicIPGenerator) InitResources() error {
+	functions := []func() ([]terraformutils.Resource, error){
+		g.listAndAddForPublicIPAddress,
+		g.listAndAddForPublicIPPrefix,
+	}
+
+	for _, f := range functions {
+		resources, err := f()
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, resources...)
+	}
+
+	return nil
+}


### PR DESCRIPTION
```
azurerm_public_ip_prefix.tfer--testPublicIPPrefixInsance: Refreshing state... [id=/subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/testPublicIPPrefixInsance]
azurerm_public_ip.tfer--testPublicAddress: Refreshing state... [id=/subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/testPublicAddress]

Outputs:

azurerm_public_ip_prefix_tfer--testPublicIPPrefixInsance_id = /subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/testPublicIPPrefixInsance
azurerm_public_ip_tfer--testPublicAddress_id = /subscriptions/8f9a5467-a960-422a-8e53-c899499da131/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/testPublicAddress
```