### PR TITLE
`--filter` use service name instead of resource name

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Flags:
   -b, --bucket string         gs://terraform-state
   -c, --connect                (default true)
   -С, --compact                (default false)
-  -f, --filter strings        google_compute_firewall=id1:id2:id4
+  -f, --filter strings        compute_firewall=id1:id2:id4
   -h, --help                  help for google
   -O, --output string         output format hcl or json (default "hcl")
   -o, --path-output string     (default "generated")
@@ -108,7 +108,7 @@ Filtering is based on Terraform resource ID patterns. To find valid ID patterns 
 Example usage:
 
 ```
-terraformer import aws --resources=vpc,subnet --filter=aws_vpc=myvpcid --regions=eu-west-1
+terraformer import aws --resources=vpc,subnet --filter=vpc=myvpcid --regions=eu-west-1
 ```
 Will only import the vpc with id `myvpcid`. This form of filters can help when it's necessary to select resources by its identifiers.
 
@@ -225,7 +225,7 @@ Example:
 
 ```
 terraformer import google --resources=gcs,forwardingRules,httpHealthChecks --connect=true --regions=europe-west1,europe-west4 --projects=aaa,fff
-terraformer import google --resources=gcs,forwardingRules,httpHealthChecks --filter=google_compute_firewall=rule1:rule2:rule3 --regions=europe-west1 --projects=aaa,fff
+terraformer import google --resources=gcs,forwardingRules,httpHealthChecks --filter=compute_firewall=rule1:rule2:rule3 --regions=europe-west1 --projects=aaa,fff
 ```
 
 List of supported GCP services:
@@ -387,7 +387,7 @@ Example:
 
 ```
  terraformer import aws --resources=vpc,subnet --connect=true --regions=eu-west-1 --profile=prod
- terraformer import aws --resources=vpc,subnet --filter=aws_vpc=vpc_id1:vpc_id2:vpc_id3 --regions=eu-west-1
+ terraformer import aws --resources=vpc,subnet --filter=vpc=vpc_id1:vpc_id2:vpc_id3 --regions=eu-west-1
 ```
 
 #### Profiles support
@@ -682,7 +682,7 @@ terraformer import aws --resources=ec2_instance,ebs --filter=Type=ec2_instance;N
 ```
 Will work as same as example above with a change the filter will be applicable only to `ec2_instance` resources.
 
-Due to fact API Gateway generates a lot of resources, it's possible to issue a filtering query to retrieve resources related to a given REST API by tags. To fetch resources related to a REST API resource with a tag `STAGE` and value `dev`, add parameter `--filter="Type=aws_api_gateway_rest_api;Name=tags.STAGE;Value=dev"`.
+Due to fact API Gateway generates a lot of resources, it's possible to issue a filtering query to retrieve resources related to a given REST API by tags. To fetch resources related to a REST API resource with a tag `STAGE` and value `dev`, add parameter `--filter="Type=api_gateway_rest_api;Name=tags.STAGE;Value=dev"`.
 
 #### SQS queues retrieval
 
@@ -1108,7 +1108,7 @@ Example:
 
 ```
  terraformer import kubernetes --resources=deployments,services,storageclasses
- terraformer import kubernetes --resources=deployments,services,storageclasses --filter=kubernetes_deployment=name1:name2:name3
+ terraformer import kubernetes --resources=deployments,services,storageclasses --filter=deployment=name1:name2:name3
 ```
 
 All Kubernetes resources that are currently supported by the Kubernetes provider, are also supported by this module. Here is the list of resources which are currently supported by Kubernetes provider v.1.4:
@@ -1194,7 +1194,7 @@ Example:
  export RABBITMQ_PASSWORD=[RABBITMQ_PASSWORD]
 
  terraformer import rabbitmq --resources=vhosts,queues,exchanges
- terraformer import rabbitmq --resources=vhosts,queues,exchanges --filter=rabbitmq_vhost=name1:name2:name3
+ terraformer import rabbitmq --resources=vhosts,queues,exchanges --filter=vhost=name1:name2:name3
 ```
 
 All RabbitMQ resources that are currently supported by the RabbitMQ provider, are also supported by this module. Here is the list of resources which are currently supported by RabbitMQ provider v.1.1.0:
@@ -1256,7 +1256,7 @@ Example:
 
 ```
  ./terraformer import github --organizations=YOUR_ORGANIZATION --resources=repositories --token=YOUR_TOKEN // or GITHUB_TOKEN in env
- ./terraformer import github --organizations=YOUR_ORGANIZATION --resources=repositories --filter=github_repository=id1:id2:id4 --token=YOUR_TOKEN // or GITHUB_TOKEN in env
+ ./terraformer import github --organizations=YOUR_ORGANIZATION --resources=repositories --filter=repository=id1:id2:id4 --token=YOUR_TOKEN // or GITHUB_TOKEN in env
 ```
 
 Supports only organizational resources. List of supported resources:
@@ -1292,7 +1292,7 @@ Example:
 
 ```
  ./terraformer import datadog --resources=monitor --api-key=YOUR_DATADOG_API_KEY // or DATADOG_API_KEY in env --app-key=YOUR_DATADOG_APP_KEY // or DATADOG_APP_KEY in env
- ./terraformer import datadog --resources=monitor --filter=datadog_monitor=id1:id2:id4 --api-key=YOUR_DATADOG_API_KEY // or DATADOG_API_KEY in env --app-key=YOUR_DATADOG_APP_KEY // or DATADOG_APP_KEY in env
+ ./terraformer import datadog --resources=monitor --filter=monitor=id1:id2:id4 --api-key=YOUR_DATADOG_API_KEY // or DATADOG_API_KEY in env --app-key=YOUR_DATADOG_APP_KEY // or DATADOG_APP_KEY in env
 ```
 
 List of supported Datadog services:
@@ -1345,7 +1345,7 @@ Example:
  export KEYCLOAK_CLIENT_SECRET=[KEYCLOAK_CLIENT_SECRET]
 
  terraformer import keycloak --resources=realms
- terraformer import keycloak --resources=realms --filter=keycloak_realm=name1:name2:name3
+ terraformer import keycloak --resources=realms --filter=realm=name1:name2:name3
  terraformer import keycloak --resources=realms --targets realmA,realmB
 ```
 

--- a/cmd/provider_cmd_alicloud.go
+++ b/cmd/provider_cmd_alicloud.go
@@ -43,7 +43,7 @@ func newCmdAliCloudImporter(options ImportOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(listCmd(newAliCloudProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "vpc,subnet,nacl", "alicloud_slb=id1:id2:id4")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "vpc,subnet,nacl", "slb=id1:id2:id4")
 	cmd.PersistentFlags().StringVar(&options.Profile, "profile", "default", "prod")
 	cmd.PersistentFlags().StringSliceVarP(&options.Regions, "regions", "", []string{}, "cn-hangzhou")
 	return cmd

--- a/cmd/provider_cmd_aws.go
+++ b/cmd/provider_cmd_aws.go
@@ -64,7 +64,7 @@ func newCmdAwsImporter(options ImportOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(listCmd(newAWSProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "vpc,subnet,nacl", "aws_elb=id1:id2:id4")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "vpc,subnet,nacl", "elb=id1:id2:id4")
 
 	cmd.PersistentFlags().StringVarP(&options.Profile, "profile", "", "default", "prod")
 	cmd.PersistentFlags().StringSliceVarP(&options.Regions, "regions", "", []string{}, "eu-west-1,eu-west-2,us-east-1")

--- a/cmd/provider_cmd_cloudflare.go
+++ b/cmd/provider_cmd_cloudflare.go
@@ -36,7 +36,7 @@ func newCmdCloudflareImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newCloudflareProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "zone", "cloudflare_access_application=id1:id2:id4")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "zone", "access_application=id1:id2:id4")
 	return cmd
 }
 

--- a/cmd/provider_cmd_commercetools.go
+++ b/cmd/provider_cmd_commercetools.go
@@ -66,7 +66,7 @@ func newCmdCommercetoolsImporter(options ImportOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(listCmd(newCommercetoolsProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "types", "commercetools_type=id1:id2:id4")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "types", "type=id1:id2:id4")
 	return cmd
 }
 

--- a/cmd/provider_cmd_datadog.go
+++ b/cmd/provider_cmd_datadog.go
@@ -35,7 +35,7 @@ func newCmdDatadogImporter(options ImportOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(listCmd(newDataDogProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "monitors,users", "datadog_monitor=id1:id2:id4")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "monitors,users", "monitor=id1:id2:id4")
 	cmd.PersistentFlags().StringVarP(&apiKey, "api-key", "", "", "YOUR_DATADOG_API_KEY or env param DATADOG_API_KEY")
 	cmd.PersistentFlags().StringVarP(&appKey, "app-key", "", "", "YOUR_DATADOG_APP_KEY or env param DATADOG_APP_KEY")
 	return cmd

--- a/cmd/provider_cmd_digitalocean.go
+++ b/cmd/provider_cmd_digitalocean.go
@@ -36,7 +36,7 @@ func newCmdDigitalOceanImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newDigitalOceanProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "project,droplet", "digitalocean_project=name1:name2:name3")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "project,droplet", "project=name1:name2:name3")
 
 	return cmd
 }

--- a/cmd/provider_cmd_fastly.go
+++ b/cmd/provider_cmd_fastly.go
@@ -36,7 +36,7 @@ func newCmdFastlyImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newFastlyProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "service_v1", "fastly_service_v1=id1:id2:id3")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "service_v1", "service_v1=id1:id2:id3")
 	return cmd
 }
 

--- a/cmd/provider_cmd_github.go
+++ b/cmd/provider_cmd_github.go
@@ -45,7 +45,7 @@ func newCmdGithubImporter(options ImportOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(listCmd(newGitHubProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "repository", "github_repository=id1:id2:id4")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "repository", "repository=id1:id2:id4")
 	cmd.PersistentFlags().StringVarP(&token, "token", "t", "", "YOUR_GITHUB_TOKEN or env param GITHUB_TOKEN")
 	cmd.PersistentFlags().StringSliceVarP(&organizations, "organizations", "", []string{}, "")
 	return cmd

--- a/cmd/provider_cmd_gmailfilter.go
+++ b/cmd/provider_cmd_gmailfilter.go
@@ -40,7 +40,7 @@ func newCmdGmailfilterImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newGmailfilterProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "label,filter", "gmailfilter_label=name1:name2")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "label,filter", "label=name1:name2")
 	cmd.PersistentFlags().StringVarP(&creds, "credentials", "", "", "/path/to/client_secret.json")
 	cmd.PersistentFlags().StringVarP(&impersonatedUserEmail, "email", "", "", "foobar@example.com")
 	return cmd

--- a/cmd/provider_cmd_google.go
+++ b/cmd/provider_cmd_google.go
@@ -45,7 +45,7 @@ func newCmdGoogleImporter(options ImportOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(listCmd(newGoogleProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "firewalls,networks", "google_compute_firewall=id1:id2:id4")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "firewalls,networks", "compute_firewall=id1:id2:id4")
 	cmd.PersistentFlags().StringSliceVarP(&options.Regions, "regions", "z", []string{"global"}, "europe-west1,")
 	cmd.PersistentFlags().StringSliceVarP(&options.Projects, "projects", "", []string{}, "")
 	_ = cmd.MarkPersistentFlagRequired("projects")

--- a/cmd/provider_cmd_heroku.go
+++ b/cmd/provider_cmd_heroku.go
@@ -36,7 +36,7 @@ func newCmdHerokuImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newHerokuProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "app,addon", "heroku_app=name1:name2:name3")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "app,addon", "app=name1:name2:name3")
 	return cmd
 }
 

--- a/cmd/provider_cmd_keycloak.go
+++ b/cmd/provider_cmd_keycloak.go
@@ -87,7 +87,7 @@ func newCmdKeycloakImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newKeycloakProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "realms", "keycloak_type=id1:id2:id4")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "realms", "type=id1:id2:id4")
 	cmd.PersistentFlags().StringSliceVarP(&targets, "targets", "", []string{}, "")
 	return cmd
 }

--- a/cmd/provider_cmd_kubernetes.go
+++ b/cmd/provider_cmd_kubernetes.go
@@ -37,7 +37,7 @@ func newCmdKubernetesImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newKubernetesProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "configmaps,deployments,services", "kubernetes_deployment=name1:name2:name3")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "configmaps,deployments,services", "deployment=name1:name2:name3")
 	return cmd
 }
 

--- a/cmd/provider_cmd_linode.go
+++ b/cmd/provider_cmd_linode.go
@@ -36,7 +36,7 @@ func newCmdLinodeImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newLinodeProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "instance", "linode_instance=name1:name2:name3")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "instance", "instance=name1:name2:name3")
 	return cmd
 }
 

--- a/cmd/provider_cmd_logzio.go
+++ b/cmd/provider_cmd_logzio.go
@@ -50,7 +50,7 @@ func newCmdLogzioImporter(options ImportOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(listCmd(newLogzioProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "repository", "logzio_alert=id1:id2:id4")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "repository", "alert=id1:id2:id4")
 	return cmd
 }
 

--- a/cmd/provider_cmd_mikrotik.go
+++ b/cmd/provider_cmd_mikrotik.go
@@ -35,7 +35,7 @@ func newCmdMikrotikImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newMikrotikProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "instance", "mikrotik_dhcp_lease=name1:name2:name3")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "instance", "dhcp_lease=name1:name2:name3")
 	return cmd
 }
 

--- a/cmd/provider_cmd_newrelic.go
+++ b/cmd/provider_cmd_newrelic.go
@@ -36,7 +36,7 @@ func newCmdNewRelicImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newNewRelicProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "alert", "newrelic_dashboard=id1:id2:id4")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "alert", "dashboard=id1:id2:id4")
 	return cmd
 }
 

--- a/cmd/provider_cmd_openstack.go
+++ b/cmd/provider_cmd_openstack.go
@@ -42,7 +42,7 @@ func newCmdOpenStackImporter(options ImportOptions) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(listCmd(newOpenStackProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "compute,networking", "openstack_compute_instance_v2=id1:id2:id4")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "compute,networking", "compute_instance_v2=id1:id2:id4")
 	cmd.PersistentFlags().StringSliceVarP(&options.Regions, "regions", "", []string{}, "RegionOne")
 	return cmd
 }

--- a/cmd/provider_cmd_rabbitmq.go
+++ b/cmd/provider_cmd_rabbitmq.go
@@ -49,7 +49,7 @@ func newCmdRabbitMQImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newRabbitMQProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "vhosts", "rabbitmq_type=id1:id2:id4")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "vhosts", "type=id1:id2:id4")
 	return cmd
 }
 

--- a/cmd/provider_cmd_vultr.go
+++ b/cmd/provider_cmd_vultr.go
@@ -36,7 +36,7 @@ func newCmdVultrImporter(options ImportOptions) *cobra.Command {
 	}
 
 	cmd.AddCommand(listCmd(newVultrProvider()))
-	baseProviderFlags(cmd.PersistentFlags(), &options, "server", "vultr_server=name1:name2:name3")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "server", "server=name1:name2:name3")
 	return cmd
 }
 

--- a/providers/aws/api_gateway.go
+++ b/providers/aws/api_gateway.go
@@ -89,7 +89,7 @@ func (g *APIGatewayGenerator) loadRestApis(svc *apigateway.Client) error {
 
 func (g *APIGatewayGenerator) shouldFilterRestAPI(tags map[string]string) bool {
 	for _, filter := range g.Filter {
-		if strings.HasPrefix(filter.FieldPath, "tags.") && filter.IsApplicable("aws_api_gateway_rest_api") {
+		if strings.HasPrefix(filter.FieldPath, "tags.") && filter.IsApplicable("api_gateway_rest_api") {
 			tagName := strings.Replace(filter.FieldPath, "tags.", "", 1)
 			if val, ok := tags[tagName]; ok {
 				return !terraformerstring.ContainsString(filter.AcceptableValues, val)

--- a/providers/aws/autoscaling.go
+++ b/providers/aws/autoscaling.go
@@ -148,14 +148,14 @@ func (g *AutoScalingGenerator) PostConvertHook() error {
 				if err != nil {
 					continue
 				}
-				fileName := "userdata-" + r.ResourceName + ".txt"
+				fileName := "userdata-" + r.ServiceName + ".txt"
 				err = ioutil.WriteFile(fileName, userData, os.ModePerm) // TODO write files in tf file path
 				if err != nil {
 					continue
 				}
 				userDataFile := terraformutils.NewResource(
-					r.ResourceName+"_userdata",
-					r.ResourceName+"_userdata",
+					r.ServiceName+"_userdata",
+					r.ServiceName+"_userdata",
 					"template_file",
 					"",
 					map[string]string{},
@@ -168,7 +168,7 @@ func (g *AutoScalingGenerator) PostConvertHook() error {
 				}
 
 				delete(g.Resources[i].Item, "user_data_base64")
-				g.Resources[i].Item["user_data"] = "${template_file." + userDataFile.ResourceName + ".rendered}"
+				g.Resources[i].Item["user_data"] = "${template_file." + userDataFile.ServiceName + ".rendered}"
 				templateFiles = append(templateFiles, userDataFile)
 			}
 		}

--- a/providers/aws/ebs.go
+++ b/providers/aws/ebs.go
@@ -44,7 +44,7 @@ func (g *EbsGenerator) InitResources() error {
 	svc := ec2.New(config)
 	var filters []ec2.Filter
 	for _, filter := range g.Filter {
-		if strings.HasPrefix(filter.FieldPath, "tags.") && filter.IsApplicable("aws_ebs_volume") {
+		if strings.HasPrefix(filter.FieldPath, "tags.") && filter.IsApplicable("ebs_volume") {
 			filters = append(filters, ec2.Filter{
 				Name:   aws.String("tag:" + strings.TrimPrefix(filter.FieldPath, "tags.")),
 				Values: filter.AcceptableValues,

--- a/providers/aws/ec2.go
+++ b/providers/aws/ec2.go
@@ -38,7 +38,7 @@ func (g *Ec2Generator) InitResources() error {
 	svc := ec2.New(config)
 	var filters []ec2.Filter
 	for _, filter := range g.Filter {
-		if strings.HasPrefix(filter.FieldPath, "tags.") && filter.IsApplicable("aws_instance") {
+		if strings.HasPrefix(filter.FieldPath, "tags.") && filter.IsApplicable("instance") {
 			filters = append(filters, ec2.Filter{
 				Name:   aws.String("tag:" + strings.TrimPrefix(filter.FieldPath, "tags.")),
 				Values: filter.AcceptableValues,

--- a/providers/aws/s3.go
+++ b/providers/aws/s3.go
@@ -129,9 +129,9 @@ func (g *S3Generator) ParseFilters(rawFilters []string) {
 		filters := g.ParseFilter(rawFilter)
 		for _, resourceFilter := range filters {
 			g.Filter = append(g.Filter, resourceFilter)
-			if resourceFilter.ResourceName == "aws_s3_bucket" {
+			if resourceFilter.ServiceName == "aws_s3_bucket" {
 				g.Filter = append(g.Filter, terraformutils.ResourceFilter{
-					ResourceName:     "aws_s3_bucket_policy",
+					ServiceName:      "aws_s3_bucket_policy",
 					FieldPath:        resourceFilter.FieldPath,
 					AcceptableValues: resourceFilter.AcceptableValues,
 				})

--- a/terraformutils/resource.go
+++ b/terraformutils/resource.go
@@ -51,7 +51,7 @@ type ResourceFilter struct {
 }
 
 func (rf *ResourceFilter) Filter(resource Resource) bool {
-	if !rf.IsApplicable(strings.TrimPrefix(resource.InstanceInfo.Type, resource.Provider + "_")) {
+	if !rf.IsApplicable(strings.TrimPrefix(resource.InstanceInfo.Type, resource.Provider+"_")) {
 		return true
 	}
 	var vals []interface{}

--- a/terraformutils/resource.go
+++ b/terraformutils/resource.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils/providerwrapper"
@@ -44,13 +45,13 @@ type ApplicableFilter interface {
 
 type ResourceFilter struct {
 	ApplicableFilter
-	ResourceName     string
+	ServiceName      string
 	FieldPath        string
 	AcceptableValues []string
 }
 
 func (rf *ResourceFilter) Filter(resource Resource) bool {
-	if !rf.IsApplicable(resource.InstanceInfo.Type) {
+	if !rf.IsApplicable(strings.TrimPrefix(resource.InstanceInfo.Type, resource.Provider + "_")) {
 		return true
 	}
 	var vals []interface{}
@@ -72,8 +73,8 @@ func (rf *ResourceFilter) Filter(resource Resource) bool {
 	return false
 }
 
-func (rf *ResourceFilter) IsApplicable(resourceName string) bool {
-	return rf.ResourceName == "" || rf.ResourceName == resourceName
+func (rf *ResourceFilter) IsApplicable(serviceName string) bool {
+	return rf.ServiceName == "" || rf.ServiceName == serviceName
 }
 
 func (rf *ResourceFilter) isInitial() bool {

--- a/terraformutils/service.go
+++ b/terraformutils/service.go
@@ -68,9 +68,9 @@ func (s *Service) ParseFilter(rawFilter string) []ResourceFilter {
 	var filters []ResourceFilter
 	if len(strings.Split(rawFilter, "=")) == 2 {
 		parts := strings.Split(rawFilter, "=")
-		resourceName, resourcesID := parts[0], parts[1]
+		serviceName, resourcesID := parts[0], parts[1]
 		filters = append(filters, ResourceFilter{
-			ResourceName:     resourceName,
+			ServiceName:      serviceName,
 			FieldPath:        "id",
 			AcceptableValues: ParseFilterValues(resourcesID),
 		})
@@ -80,21 +80,21 @@ func (s *Service) ParseFilter(rawFilter string) []ResourceFilter {
 			log.Print("Invalid filter: " + rawFilter)
 			return filters
 		}
-		var ResourceNamePart string
+		var ServiceNamePart string
 		var FieldPathPart string
 		var AcceptableValuesPart string
 		if len(parts) == 2 {
-			ResourceNamePart = ""
+			ServiceNamePart = ""
 			FieldPathPart = parts[0]
 			AcceptableValuesPart = parts[1]
 		} else {
-			ResourceNamePart = strings.TrimPrefix(parts[0], "Type=")
+			ServiceNamePart = strings.TrimPrefix(parts[0], "Type=")
 			FieldPathPart = parts[1]
 			AcceptableValuesPart = parts[2]
 		}
 
 		filters = append(filters, ResourceFilter{
-			ResourceName:     ResourceNamePart,
+			ServiceName:      ServiceNamePart,
 			FieldPath:        strings.TrimPrefix(FieldPathPart, "Name="),
 			AcceptableValues: ParseFilterValues(strings.TrimPrefix(AcceptableValuesPart, "Value=")),
 		})

--- a/terraformutils/service_test.go
+++ b/terraformutils/service_test.go
@@ -22,7 +22,7 @@ func TestIdFiltersParsing(t *testing.T) {
 
 	if !reflect.DeepEqual(service.Filter, []ResourceFilter{
 		{
-			ResourceName:     "aws_vpc",
+			ServiceName:      "aws_vpc",
 			FieldPath:        "id",
 			AcceptableValues: []string{"myid"},
 		}}) {
@@ -36,7 +36,7 @@ func TestComplexIdFiltersParsing(t *testing.T) {
 
 	if !reflect.DeepEqual(service.Filter, []ResourceFilter{
 		{
-			ResourceName:     "resource",
+			ServiceName:      "resource",
 			FieldPath:        "id",
 			AcceptableValues: []string{"id1", "project:dataset_id"},
 		}}) {
@@ -50,7 +50,7 @@ func TestEdgeIdFiltersParsing(t *testing.T) {
 
 	if !reflect.DeepEqual(service.Filter, []ResourceFilter{
 		{
-			ResourceName:     "aws_vpc",
+			ServiceName:      "aws_vpc",
 			FieldPath:        "id",
 			AcceptableValues: []string{"myid"},
 		}}) {

--- a/terraformutils/tfstate_converter_test.go
+++ b/terraformutils/tfstate_converter_test.go
@@ -34,7 +34,7 @@ func TestBasicConvert(t *testing.T) {
 		name:         "basic tfstate",
 		expect: []TerraformResource{
 			{
-				ResourceName: "resource-id",
+				ServiceName: "resource-id",
 				ResourceType: "google_compute_firewall",
 				ID:           "resource-id",
 				Item: map[string]interface{}{
@@ -60,7 +60,7 @@ func TestBasicIgnoreKeyConvert(t *testing.T) {
 		name:         "basic tfstate",
 		expect: []TerraformResource{
 			{
-				ResourceName: "resource-id",
+				ServiceName: "resource-id",
 				ResourceType: "google_compute_firewall",
 				ID:           "resource-id",
 				Item: map[string]interface{}{
@@ -90,7 +90,7 @@ func TestBasicAllowEmptyConvert(t *testing.T) {
 		name:         "basic tfstate",
 		expect: []TerraformResource{
 			{
-				ResourceName: "resource-id",
+				ServiceName: "resource-id",
 				ResourceType: "google_compute_firewall",
 				ID:           "resource-id",
 				Item: map[string]interface{}{
@@ -120,7 +120,7 @@ func TestBasicAdditionalFieldsConvert(t *testing.T) {
 		name:         "basic tfstate",
 		expect: []TerraformResource{
 			{
-				ResourceName: "resource-id",
+				ServiceName: "resource-id",
 				ResourceType: "google_compute_firewall",
 				ID:           "resource-id",
 				Item: map[string]interface{}{
@@ -150,7 +150,7 @@ func TestBasicTfstate2(t *testing.T) {
 		name:         "basic tfstate 2",
 		expect: []TerraformResource{
 			{
-				ResourceName: "resource-idA",
+				ServiceName: "resource-idA",
 				ResourceType: "google_compute_firewall",
 				ID:           "resource-idA",
 				Item: map[string]interface{}{
@@ -162,7 +162,7 @@ func TestBasicTfstate2(t *testing.T) {
 				Provider: "google",
 			},
 			{
-				ResourceName: "resource-idB",
+				ServiceName: "resource-idB",
 				ResourceType: "google_compute_firewall",
 				ID:           "resource-idB",
 				Item: map[string]interface{}{
@@ -191,7 +191,7 @@ func TestBasicArray(t *testing.T) {
 		name:         "basic array",
 		expect: []TerraformResource{
 			{
-				ResourceName: "resource-id",
+				ServiceName: "resource-id",
 				ResourceType: "google_compute_firewall",
 				ID:           "resource-id",
 				Item: map[string]interface{}{
@@ -227,7 +227,7 @@ func TestBasicArray2(t *testing.T) {
 		name:         "basic array 2",
 		expect: []TerraformResource{
 			{
-				ResourceName: "resource-id",
+				ServiceName: "resource-id",
 				ResourceType: "google_compute_firewall",
 				ID:           "resource-id",
 				Item: map[string]interface{}{
@@ -265,7 +265,7 @@ func TestBasicArray3(t *testing.T) {
 		name:         "basic array 3",
 		expect: []TerraformResource{
 			{
-				ResourceName: "resource-id",
+				ServiceName: "resource-id",
 				ResourceType: "google_compute_firewall",
 				ID:           "resource-id",
 				Item: map[string]interface{}{
@@ -304,7 +304,7 @@ func TestBasicArray4(t *testing.T) {
 		name:         "basic array 4",
 		expect: []TerraformResource{
 			{
-				ResourceName: "resource-id",
+				ServiceName: "resource-id",
 				ResourceType: "google_compute_firewall",
 				ID:           "resource-id",
 				Item: map[string]interface{}{


### PR DESCRIPTION
Currently, `--resources` option uses service name (e.g.
`resource_group` for azure) (assuming this is because the provider
name has already appeared in the command, no need to repeat).

Whilst, `--filter` option uses resource name (e.g. `azurerm_resource_group`).

This inconsistency causes confusion and is easy to make mistake
(actually current README and helper message have those mistakes).

To make them consistent addresses this issue. This PR chooses to make
`--filter` to use the service name, following the convention as
`--resources`.