### PR TITLE
Fix missing output variables when compact output

### DIFF
--- a/terraformutils/resource.go
+++ b/terraformutils/resource.go
@@ -167,3 +167,7 @@ func (r *Resource) ConvertTFstate(provider *providerwrapper.ProviderWrapper) err
 	impliedType := schema.ResourceTypes[r.InstanceInfo.Type].Block.ImpliedType()
 	return r.ParseTFstate(parser, impliedType)
 }
+
+func (r *Resource) ServiceName() string {
+	return strings.TrimPrefix(r.InstanceInfo.Type, r.Provider+"_")
+}

--- a/terraformutils/terraformoutput/hcl.go
+++ b/terraformutils/terraformoutput/hcl.go
@@ -42,7 +42,7 @@ func OutputHclFiles(resources []terraformutils.Resource, provider terraformutils
 	for i, r := range resources {
 		outputState := map[string]*terraform.OutputState{}
 		outputsByResource[r.InstanceInfo.Type+"_"+r.ResourceName+"_"+r.GetIDKey()] = map[string]interface{}{
-			"value": "${" + r.InstanceInfo.Type + "." + r.ResourceName + "." + r.GetIDKey() + "}",
+			"value": r.InstanceInfo.Type + "." + r.ResourceName + "." + r.GetIDKey(),
 		}
 		outputState[r.InstanceInfo.Type+"_"+r.ResourceName+"_"+r.GetIDKey()] = &terraform.OutputState{
 			Type:  "string",
@@ -50,7 +50,7 @@ func OutputHclFiles(resources []terraformutils.Resource, provider terraformutils
 		}
 		for _, v := range provider.GetResourceConnections() {
 			for k, ids := range v {
-				if k == serviceName {
+				if (serviceName != "" && k == serviceName) || (serviceName == "" && k == r.ServiceName()) {
 					if _, exist := r.InstanceState.Attributes[ids[1]]; exist {
 						key := ids[1]
 						if ids[1] == "self_link" || ids[1] == "id" {
@@ -58,7 +58,7 @@ func OutputHclFiles(resources []terraformutils.Resource, provider terraformutils
 						}
 						linkKey := r.InstanceInfo.Type + "_" + r.ResourceName + "_" + key
 						outputsByResource[linkKey] = map[string]interface{}{
-							"value": "${" + r.InstanceInfo.Type + "." + r.ResourceName + "." + key + "}",
+							"value": r.InstanceInfo.Type + "." + r.ResourceName + "." + key,
 						}
 						outputState[linkKey] = &terraform.OutputState{
 							Type:  "string",


### PR DESCRIPTION
When user specify `-C`, current code doesn't record the referenced
attributes in the output config.

This PR addresses that issue by adding an additional check on whether
we are in compact mode. If yes, then it means the `resources` under
iteration belongs to different services, and we will only record the
output for current resource when the connection's target service is
the same as this resource's service type.