### PR TITLE
azurerm: support subnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,6 +805,11 @@ List of supported Azure resources:
     * `azurerm_virtual_machine`
 *   `virtual_network`
     * `azurerm_virtual_network`
+    * `azurerm_subnet`
+
+#### Virtual networks and subnets
+
+Terraformer will import `azurerm_virtual_network` config with inlined subnet information swipped, in order to avoid any potential circular dependencies. To import the subnet information, please also import `azurerm_subnet`.
 
 ### Use with AliCloud
 

--- a/providers/azure/azure_provider.go
+++ b/providers/azure/azure_provider.go
@@ -165,6 +165,7 @@ func (p *AzureProvider) GetSupportedService() map[string]terraformutils.ServiceG
 		"storage_account":                      &StorageAccountGenerator{},
 		"storage_container":                    &StorageContainerGenerator{},
 		"storage_blob":                         &StorageBlobGenerator{},
+		"subnet":                               &SubnetGenerator{},
 		"virtual_machine":                      &VirtualMachineGenerator{},
 		"virtual_network":                      &VirtualNetworkGenerator{},
 	}

--- a/providers/azure/subnet.go
+++ b/providers/azure/subnet.go
@@ -1,0 +1,91 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"context"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-08-01/network"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/hashicorp/go-azure-helpers/authentication"
+)
+
+type SubnetGenerator struct {
+	AzureService
+}
+
+func (g SubnetGenerator) createResources(ctx context.Context, iter network.SubnetListResultIterator) ([]terraformutils.Resource, error) {
+	var resources []terraformutils.Resource
+	for iter.NotDone() {
+		subnet := iter.Value()
+		resources = append(resources, terraformutils.NewSimpleResource(
+			*subnet.ID,
+			*subnet.Name,
+			"azurerm_subnet",
+			"azurerm",
+			[]string{}))
+		if err := iter.NextWithContext(ctx); err != nil {
+			return nil, err
+		}
+	}
+	return resources, nil
+}
+
+func (g *SubnetGenerator) PostConvertHook() error {
+	for _, resource := range g.Resources {
+		if resource.InstanceInfo.Type != "azurerm_subnet" {
+			continue
+		}
+		delete(resource.Item, "address_prefix")
+	}
+	return nil
+}
+
+func (g *SubnetGenerator) InitResources() error {
+	ctx := context.Background()
+	client := network.NewSubnetsClient(g.Args["config"].(authentication.Config).SubscriptionID)
+	client.Authorizer = g.Args["authorizer"].(autorest.Authorizer)
+	vnetClient := network.NewVirtualNetworksClient(g.Args["config"].(authentication.Config).SubscriptionID)
+	vnetClient.Authorizer = g.Args["authorizer"].(autorest.Authorizer)
+	vnets, err := vnetClient.ListAllComplete(ctx)
+	if err != nil {
+		return err
+	}
+
+	var subnetResources []terraformutils.Resource
+	for vnets.NotDone() {
+		vnet := vnets.Value()
+
+		vnetID, err := ParseAzureResourceID(*vnet.ID)
+		if err != nil {
+			break
+		}
+		subnetIter, err := client.ListComplete(ctx, vnetID.ResourceGroup, *vnet.Name)
+		if err != nil {
+			return err
+		}
+		subnets, err := g.createResources(ctx, subnetIter)
+		if err != nil {
+			return err
+		}
+		subnetResources = append(subnetResources, subnets...)
+
+		if err := vnets.NextWithContext(ctx); err != nil {
+			return err
+		}
+	}
+	g.Resources = subnetResources
+	return nil
+}

--- a/providers/azure/virtual_network.go
+++ b/providers/azure/virtual_network.go
@@ -48,6 +48,16 @@ func (g VirtualNetworkGenerator) createResources(virtualNetworkListResultPage ne
 	return resources
 }
 
+func (g *VirtualNetworkGenerator) PostConvertHook() error {
+	for _, resource := range g.Resources {
+		if resource.InstanceInfo.Type != "azurerm_virtual_network" {
+			continue
+		}
+		delete(resource.Item, "subnet")
+	}
+	return nil
+}
+
 func (g *VirtualNetworkGenerator) InitResources() error {
 	ctx := context.Background()
 	virtualNetworkClient := network.NewVirtualNetworksClient(g.Args["config"].(authentication.Config).SubscriptionID)


### PR DESCRIPTION
Add support for `azurerm_subnet`.

## Local Test

Import `azurerm_resource_group`, `azurerm_virtual_network` and `azurerm_subnet` within a certain resource group.

```bash
$ rg_name="magodo-vnet-test"
$ terraformer import azure -C -p "{output}" -r resource_group,virtual_network,subnet -f "virtual_network;resource_group_name;$rg_name" -f "subnet;resource_group_name;$rg_name" -f "resource_group;name;$rg_name"
```

Run terraform plan against the generated config:

```bash
💤 tf plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

data.terraform_remote_state.local: Refreshing state...
azurerm_resource_group.tfer--magodo-002D-vnet-002D-test: Refreshing state... [id=/subscriptions/xxx/resourceGroups/magodo-vnet-test]
azurerm_subnet.tfer--subnet3: Refreshing state... [id=/subscriptions/xxx/resourceGroups/magodo-vnet-test/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/subnet3]
azurerm_subnet.tfer--subnet2: Refreshing state... [id=/subscriptions/xxx/resourceGroups/magodo-vnet-test/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/subnet2]
azurerm_subnet.tfer--subnet1: Refreshing state... [id=/subscriptions/xxx/resourceGroups/magodo-vnet-test/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/subnet1]
azurerm_virtual_network.tfer--virtualNetwork1: Refreshing state... [id=/subscriptions/xxx/resourceGroups/magodo-vnet-test/providers/Microsoft.Network/virtualNetworks/virtualNetwork1]

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```