### PR TITLE
format policy for aws sqs and sns resources as heredoc

### DIFF
--- a/providers/aws/sns.go
+++ b/providers/aws/sns.go
@@ -16,6 +16,7 @@ package aws
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 
@@ -81,4 +82,19 @@ func (g *SnsGenerator) InitResources() error {
 		}
 	}
 	return p.Err()
+}
+
+// PostConvertHook for add policy json as heredoc
+func (g *SnsGenerator) PostConvertHook() error {
+	for i, resource := range g.Resources {
+		if resource.InstanceInfo.Type == "aws_sns_topic" {
+			if val, ok := g.Resources[i].Item["policy"]; ok {
+				policy := g.escapeAwsInterpolation(val.(string))
+				g.Resources[i].Item["policy"] = fmt.Sprintf(`<<POLICY
+%s
+POLICY`, policy)
+			}
+		}
+	}
+	return nil
 }

--- a/providers/aws/sqs.go
+++ b/providers/aws/sqs.go
@@ -16,6 +16,7 @@ package aws
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -64,5 +65,20 @@ func (g *SqsGenerator) InitResources() error {
 		))
 	}
 
+	return nil
+}
+
+// PostConvertHook for add policy json as heredoc
+func (g *SqsGenerator) PostConvertHook() error {
+	for i, resource := range g.Resources {
+		if resource.InstanceInfo.Type == "aws_sqs_queue" {
+			if val, ok := g.Resources[i].Item["policy"]; ok {
+				policy := g.escapeAwsInterpolation(val.(string))
+				g.Resources[i].Item["policy"] = fmt.Sprintf(`<<POLICY
+%s
+POLICY`, policy)
+			}
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
if accepted this PR will format the `policy` field for `sqs` and `sns` resources in those that have this attribute configured