### PR TITLE
Import AWS EC2 instance volumes

### DIFF
--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -64,6 +64,7 @@ func (p AWSProvider) GetResourceConnections() map[string]map[string][]string {
 		"ec2_instance": {
 			"sg":     []string{"vpc_security_group_ids", "id"},
 			"subnet": []string{"subnet_id", "id"},
+			"ebs":    []string{"ebs_block_device", "id"},
 		},
 		"elasticache": {
 			"vpc":    []string{"vpc_id", "id"},

--- a/providers/aws/ec2.go
+++ b/providers/aws/ec2.go
@@ -77,7 +77,6 @@ func (g *Ec2Generator) InitResources() error {
 					ec2AllowEmptyValues,
 					map[string]interface{}{},
 				)
-				r.IgnoreKeys = append(r.IgnoreKeys, "^ebs_block_device.(.*)")
 				g.Resources = append(g.Resources, r)
 			}
 		}


### PR DESCRIPTION
When importing an AWS EC2 instance do not leave out the secondary EBS volumes that are attached to it.
This is different from importing an EBS volume and trying to figure out what is attached.