### PR TITLE
Add Datadog API client to DatadogProvider struct

### DIFF
--- a/providers/datadog/dashboard.go
+++ b/providers/datadog/dashboard.go
@@ -57,26 +57,14 @@ func (g *DashboardGenerator) createResource(dashboardID string) terraformutils.R
 // from each dashboard create 1 TerraformResource.
 // Need Dashboard ID as ID for terraform resource
 func (g *DashboardGenerator) InitResources() error {
-	authV1 := context.WithValue(
-		context.Background(),
-		datadogV1.ContextAPIKeys,
-		map[string]datadogV1.APIKey{
-			"apiKeyAuth": {
-				Key: g.Args["api-key"].(string),
-			},
-			"appKeyAuth": {
-				Key: g.Args["app-key"].(string),
-			},
-		},
-	)
-	config := datadogV1.NewConfiguration()
-	client := datadogV1.NewAPIClient(config)
+	datadogClientV1 := g.Args["datadogClientV1"].(*datadogV1.APIClient)
+	authV1 := g.Args["authV1"].(context.Context)
 
 	resources := []terraformutils.Resource{}
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "id" && filter.IsApplicable("dashboard") {
 			for _, value := range filter.AcceptableValues {
-				dashboard, _, err := client.DashboardsApi.GetDashboard(authV1, value).Execute()
+				dashboard, _, err := datadogClientV1.DashboardsApi.GetDashboard(authV1, value).Execute()
 				if err != nil {
 					return err
 				}
@@ -91,7 +79,7 @@ func (g *DashboardGenerator) InitResources() error {
 		return nil
 	}
 
-	summary, _, err := client.DashboardsApi.ListDashboards(authV1).Execute()
+	summary, _, err := datadogClientV1.DashboardsApi.ListDashboards(authV1).Execute()
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -29,8 +29,8 @@ type DatadogProvider struct { //nolint
 	terraformutils.Provider
 	apiKey string
 	appKey string
-	AuthV1 context.Context
-	DatadogClientV1 *datadogV1.APIClient
+	authV1 context.Context
+	datadogClientV1 *datadogV1.APIClient
 }
 
 // Init check env params and initialize API Client
@@ -68,11 +68,11 @@ func (p *DatadogProvider) Init(args []string) error {
 			},
 		},
 	)
-	p.AuthV1 = authV1
+	p.authV1 = authV1
 
 	configV1 := datadogV1.NewConfiguration()
 	datadogClientV1 := datadogV1.NewAPIClient(configV1)
-	p.DatadogClientV1 = datadogClientV1
+	p.datadogClientV1 = datadogClientV1
 
 	return nil
 }
@@ -103,8 +103,8 @@ func (p *DatadogProvider) InitService(serviceName string, verbose bool) error {
 	p.Service.SetArgs(map[string]interface{}{
 		"api-key": p.apiKey,
 		"app-key": p.appKey,
-		"AuthV1": p.AuthV1,
-		"DatadogClientV1": p.DatadogClientV1,
+		"authV1": p.authV1,
+		"datadogClientV1": p.datadogClientV1,
 	})
 	return nil
 }


### PR DESCRIPTION
This adds the official Datadog client and auth context to the DatadogProvider struct avoiding code duplication in resources when the official Datadog client is used.