### PR TITLE
Add filter support to datadog downtime

### DIFF
--- a/providers/datadog/downtime.go
+++ b/providers/datadog/downtime.go
@@ -15,10 +15,11 @@
 package datadog
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
-	datadog "github.com/zorkian/go-datadog-api"
+	datadogV1 "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
 )
@@ -33,32 +34,58 @@ type DowntimeGenerator struct {
 	DatadogService
 }
 
-func (DowntimeGenerator) createResources(downtimes []datadog.Downtime) []terraformutils.Resource {
+func (g *DowntimeGenerator) createResources(downtimes []datadogV1.Downtime) []terraformutils.Resource {
 	resources := []terraformutils.Resource{}
 	for _, downtime := range downtimes {
-		resourceName := strconv.Itoa(downtime.GetId())
-		resources = append(resources, terraformutils.NewSimpleResource(
-			resourceName,
-			fmt.Sprintf("downtime_%s", resourceName),
-			"datadog_downtime",
-			"datadog",
-			DowntimeAllowEmptyValues,
-		))
+		resourceName := strconv.FormatInt(downtime.GetId(), 10)
+		resources = append(resources, g.createResource(resourceName))
 	}
 
 	return resources
+}
+
+func (g *DowntimeGenerator) createResource(downtimeID string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		downtimeID,
+		fmt.Sprintf("downtime_%s", downtimeID),
+		"datadog_downtime",
+		"datadog",
+		DowntimeAllowEmptyValues,
+	)
 }
 
 // InitResources Generate TerraformResources from Datadog API,
 // from each downtime create 1 TerraformResource.
 // Need Downtime ID as ID for terraform resource
 func (g *DowntimeGenerator) InitResources() error {
-	client := datadog.NewClient(g.Args["api-key"].(string), g.Args["app-key"].(string))
-	_, err := client.Validate()
-	if err != nil {
-		return err
+	datadogClientV1 := g.Args["datadogClientV1"].(*datadogV1.APIClient)
+	authV1 := g.Args["authV1"].(context.Context)
+
+	resources := []terraformutils.Resource{}
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("downtime") {
+			for _, value := range filter.AcceptableValues {
+				i, err := strconv.ParseInt(value, 10, 64)
+				if err != nil {
+					return err
+				}
+
+				monitor, _, err := datadogClientV1.DowntimesApi.GetDowntime(authV1, i).Execute()
+				if err != nil {
+					return err
+				}
+
+				resources = append(resources, g.createResource(strconv.FormatInt(monitor.GetId(), 10)))
+			}
+		}
 	}
-	downtimes, err := client.GetDowntimes()
+
+	if len(resources) > 0 {
+		g.Resources = resources
+		return nil
+	}
+
+	downtimes, _, err := datadogClientV1.DowntimesApi.ListDowntimes(authV1).Execute()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds support for filtering datadog downtimes by id and updates the api client to use the supported datadog go client.