### PR TITLE
Add filter support to datadog monitor

### DIFF
--- a/providers/datadog/monitor.go
+++ b/providers/datadog/monitor.go
@@ -85,10 +85,10 @@ func (g *MonitorGenerator) InitResources() error {
 		return nil
 	}
 
-	summary, _, err := datadogClientV1.MonitorsApi.ListMonitors(authV1).Execute()
+	monitors, _, err := datadogClientV1.MonitorsApi.ListMonitors(authV1).Execute()
 	if err != nil {
 		return err
 	}
-	g.Resources = g.createResources(summary)
+	g.Resources = g.createResources(monitors)
 	return nil
 }


### PR DESCRIPTION
This PR adds support for filtering datadog monitor by id and updates the api client to use the supported datadog go client.