### PR TITLE
Add support for passing Datadog api url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1291,7 +1291,7 @@ Notes:
 Example:
 
 ```
- ./terraformer import datadog --resources=monitor --api-key=YOUR_DATADOG_API_KEY // or DATADOG_API_KEY in env --app-key=YOUR_DATADOG_APP_KEY // or DATADOG_APP_KEY in env
+ ./terraformer import datadog --resources=monitor --api-key=YOUR_DATADOG_API_KEY // or DATADOG_API_KEY in env --app-key=YOUR_DATADOG_APP_KEY // or DATADOG_APP_KEY in env --api-url=DATADOG_API_URL // or DATADOG_HOST in env
  ./terraformer import datadog --resources=monitor --filter=monitor=id1:id2:id4 --api-key=YOUR_DATADOG_API_KEY // or DATADOG_API_KEY in env --app-key=YOUR_DATADOG_APP_KEY // or DATADOG_APP_KEY in env
 ```
 

--- a/cmd/provider_cmd_datadog.go
+++ b/cmd/provider_cmd_datadog.go
@@ -20,14 +20,14 @@ import (
 )
 
 func newCmdDatadogImporter(options ImportOptions) *cobra.Command {
-	var apiKey, appKey string
+	var apiKey, appKey, apiUrl string
 	cmd := &cobra.Command{
 		Use:   "datadog",
 		Short: "Import current state to Terraform configuration from Datadog",
 		Long:  "Import current state to Terraform configuration from Datadog",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			provider := newDataDogProvider()
-			err := Import(provider, options, []string{apiKey, appKey})
+			err := Import(provider, options, []string{apiKey, appKey, apiUrl})
 			if err != nil {
 				return err
 			}
@@ -38,6 +38,7 @@ func newCmdDatadogImporter(options ImportOptions) *cobra.Command {
 	baseProviderFlags(cmd.PersistentFlags(), &options, "monitors,users", "monitor=id1:id2:id4")
 	cmd.PersistentFlags().StringVarP(&apiKey, "api-key", "", "", "YOUR_DATADOG_API_KEY or env param DATADOG_API_KEY")
 	cmd.PersistentFlags().StringVarP(&appKey, "app-key", "", "", "YOUR_DATADOG_APP_KEY or env param DATADOG_APP_KEY")
+	cmd.PersistentFlags().StringVarP(&apiUrl, "api-url", "", "", "YOUR_DATADOG_API_URL or env param DATADOG_HOST")
 	return cmd
 }
 

--- a/cmd/provider_cmd_datadog.go
+++ b/cmd/provider_cmd_datadog.go
@@ -20,14 +20,14 @@ import (
 )
 
 func newCmdDatadogImporter(options ImportOptions) *cobra.Command {
-	var apiKey, appKey, apiUrl string
+	var apiKey, appKey, apiURL string
 	cmd := &cobra.Command{
 		Use:   "datadog",
 		Short: "Import current state to Terraform configuration from Datadog",
 		Long:  "Import current state to Terraform configuration from Datadog",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			provider := newDataDogProvider()
-			err := Import(provider, options, []string{apiKey, appKey, apiUrl})
+			err := Import(provider, options, []string{apiKey, appKey, apiURL})
 			if err != nil {
 				return err
 			}
@@ -38,7 +38,7 @@ func newCmdDatadogImporter(options ImportOptions) *cobra.Command {
 	baseProviderFlags(cmd.PersistentFlags(), &options, "monitors,users", "monitor=id1:id2:id4")
 	cmd.PersistentFlags().StringVarP(&apiKey, "api-key", "", "", "YOUR_DATADOG_API_KEY or env param DATADOG_API_KEY")
 	cmd.PersistentFlags().StringVarP(&appKey, "app-key", "", "", "YOUR_DATADOG_APP_KEY or env param DATADOG_APP_KEY")
-	cmd.PersistentFlags().StringVarP(&apiUrl, "api-url", "", "", "YOUR_DATADOG_API_URL or env param DATADOG_HOST")
+	cmd.PersistentFlags().StringVarP(&apiURL, "api-url", "", "", "YOUR_DATADOG_API_URL or env param DATADOG_HOST")
 	return cmd
 }
 

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -28,10 +28,10 @@ import (
 
 type DatadogProvider struct { //nolint
 	terraformutils.Provider
-	apiKey string
-	appKey string
-	apiURL string
-	authV1 context.Context
+	apiKey          string
+	appKey          string
+	apiURL          string
+	authV1          context.Context
 	datadogClientV1 *datadogV1.APIClient
 }
 
@@ -76,7 +76,7 @@ func (p *DatadogProvider) Init(args []string) error {
 			},
 		},
 	)
-	if  p.apiURL != "" {
+	if p.apiURL != "" {
 		parsedAPIURL, parseErr := url.Parse(p.apiURL)
 		if parseErr != nil {
 			return fmt.Errorf(`invalid API Url : %v`, parseErr)
@@ -125,10 +125,10 @@ func (p *DatadogProvider) InitService(serviceName string, verbose bool) error {
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
-		"api-key": p.apiKey,
-		"app-key": p.appKey,
-		"api-url": p.apiURL,
-		"authV1": p.authV1,
+		"api-key":         p.apiKey,
+		"app-key":         p.appKey,
+		"api-url":         p.apiURL,
+		"authV1":          p.authV1,
 		"datadogClientV1": p.datadogClientV1,
 	})
 	return nil

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -30,7 +30,7 @@ type DatadogProvider struct { //nolint
 	terraformutils.Provider
 	apiKey string
 	appKey string
-	apiUrl string
+	apiURL string
 	authV1 context.Context
 	datadogClientV1 *datadogV1.APIClient
 }
@@ -58,9 +58,9 @@ func (p *DatadogProvider) Init(args []string) error {
 	}
 
 	if args[2] != "" {
-		p.apiUrl = args[2]
+		p.apiURL = args[2]
 	} else if v := os.Getenv("DATADOG_HOST"); v != "" {
-		p.apiUrl = v
+		p.apiURL = v
 	}
 
 	// Initialize the Datadog API client
@@ -76,19 +76,19 @@ func (p *DatadogProvider) Init(args []string) error {
 			},
 		},
 	)
-	if  p.apiUrl != "" {
-		parsedApiUrl, parseErr := url.Parse(p.apiUrl)
+	if  p.apiURL != "" {
+		parsedAPIURL, parseErr := url.Parse(p.apiURL)
 		if parseErr != nil {
 			return fmt.Errorf(`invalid API Url : %v`, parseErr)
 		}
-		if parsedApiUrl.Host == "" || parsedApiUrl.Scheme == "" {
-			return fmt.Errorf(`missing protocol or host : %v`, p.apiUrl)
+		if parsedAPIURL.Host == "" || parsedAPIURL.Scheme == "" {
+			return fmt.Errorf(`missing protocol or host : %v`, p.apiURL)
 		}
 		// If api url is passed, set and use the api name and protocol on ServerIndex{1}
 		authV1 = context.WithValue(authV1, datadogV1.ContextServerIndex, 1)
 		authV1 = context.WithValue(authV1, datadogV1.ContextServerVariables, map[string]string{
-			"name":     parsedApiUrl.Host,
-			"protocol": parsedApiUrl.Scheme,
+			"name":     parsedAPIURL.Host,
+			"protocol": parsedAPIURL.Scheme,
 		})
 	}
 	p.authV1 = authV1
@@ -110,7 +110,7 @@ func (p *DatadogProvider) GetConfig() cty.Value {
 	return cty.ObjectVal(map[string]cty.Value{
 		"api_key": cty.StringVal(p.apiKey),
 		"app_key": cty.StringVal(p.appKey),
-		"api_url": cty.StringVal(p.apiUrl),
+		"api_url": cty.StringVal(p.apiURL),
 	})
 }
 
@@ -127,7 +127,7 @@ func (p *DatadogProvider) InitService(serviceName string, verbose bool) error {
 	p.Service.SetArgs(map[string]interface{}{
 		"api-key": p.apiKey,
 		"app-key": p.appKey,
-		"api-url": p.apiUrl,
+		"api-url": p.apiURL,
 		"authV1": p.authV1,
 		"datadogClientV1": p.datadogClientV1,
 	})

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -17,6 +17,8 @@ package datadog
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/url"
 	"os"
 
 	datadogV1 "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
@@ -30,6 +32,7 @@ type DatadogProvider struct { //nolint
 	appKey string
 	authV1 context.Context
 	datadogClientV1 *datadogV1.APIClient
+	apiUrl string
 }
 
 // Init check env params and initialize API Client
@@ -54,6 +57,12 @@ func (p *DatadogProvider) Init(args []string) error {
 		}
 	}
 
+	if args[2] != "" {
+		p.apiUrl = args[2]
+	} else if v := os.Getenv("DATADOG_HOST"); v != "" {
+		p.apiUrl = v
+	}
+
 	// Initialize the Datadog API client
 	authV1 := context.WithValue(
 		context.Background(),
@@ -67,6 +76,21 @@ func (p *DatadogProvider) Init(args []string) error {
 			},
 		},
 	)
+	if  p.apiUrl != "" {
+		parsedApiUrl, parseErr := url.Parse(p.apiUrl)
+		if parseErr != nil {
+			return fmt.Errorf(`invalid API Url : %v`, parseErr)
+		}
+		if parsedApiUrl.Host == "" || parsedApiUrl.Scheme == "" {
+			return fmt.Errorf(`missing protocol or host : %v`, p.apiUrl)
+		}
+		// If api url is passed, set and use the api name and protocol on ServerIndex{1}
+		authV1 = context.WithValue(authV1, datadogV1.ContextServerIndex, 1)
+		authV1 = context.WithValue(authV1, datadogV1.ContextServerVariables, map[string]string{
+			"name":     parsedApiUrl.Host,
+			"protocol": parsedApiUrl.Scheme,
+		})
+	}
 	p.authV1 = authV1
 
 	configV1 := datadogV1.NewConfiguration()
@@ -86,6 +110,7 @@ func (p *DatadogProvider) GetConfig() cty.Value {
 	return cty.ObjectVal(map[string]cty.Value{
 		"api_key": cty.StringVal(p.apiKey),
 		"app_key": cty.StringVal(p.appKey),
+		"api_url": cty.StringVal(p.apiUrl),
 	})
 }
 
@@ -102,6 +127,7 @@ func (p *DatadogProvider) InitService(serviceName string, verbose bool) error {
 	p.Service.SetArgs(map[string]interface{}{
 		"api-key": p.apiKey,
 		"app-key": p.appKey,
+		"api-url": p.apiUrl,
 		"authV1": p.authV1,
 		"datadogClientV1": p.datadogClientV1,
 	})

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -30,9 +30,9 @@ type DatadogProvider struct { //nolint
 	terraformutils.Provider
 	apiKey string
 	appKey string
+	apiUrl string
 	authV1 context.Context
 	datadogClientV1 *datadogV1.APIClient
-	apiUrl string
 }
 
 // Init check env params and initialize API Client


### PR DESCRIPTION
This PR adds support for passing custom Datadog api url allowing users from different regions such as EU to use the tool as well by setting the flag: `--api-url=https://api.datadoghq.eu` or env variable `DATADOG_HOST=https://api.datadoghq.eu` 