### PR TITLE
Fix all golangci-lint errors

### DIFF
--- a/build/main.go
+++ b/build/main.go
@@ -25,8 +25,8 @@ func main() {
 	for _, f := range files {
 		if strings.HasPrefix(f.Name(), filePrefix) {
 			if !strings.HasPrefix(f.Name(), filePrefix+provider+fileSuffix) {
-				providerName := strings.Replace(f.Name(), filePrefix, "", -1)
-				providerName = strings.Replace(providerName, fileSuffix, "", -1)
+				providerName := strings.ReplaceAll(f.Name(), filePrefix, "")
+				providerName = strings.ReplaceAll(providerName, fileSuffix, "")
 				deletedProvider = append(deletedProvider, providerName)
 			}
 		}
@@ -77,7 +77,7 @@ func main() {
 	}
 	fmt.Println(outb.String())
 
-	//revert code and files
+	// revert code and files
 	err = ioutil.WriteFile(packageCmdPath+"/root.go", rootCode, os.ModePerm)
 	if err != nil {
 		log.Println(err)

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -223,7 +223,7 @@ func printService(provider terraformutils.ProviderGenerator, serviceName string,
 					}
 					variables["data"]["terraform_remote_state"][k] = map[string]interface{}{
 						"backend": "gcs",
-						"config":  bucket.BucketGetTfData(strings.Replace(path, serviceName, k, -1)),
+						"config":  bucket.BucketGetTfData(strings.ReplaceAll(path, serviceName, k)),
 					}
 				}
 			} else {
@@ -234,7 +234,7 @@ func printService(provider terraformutils.ProviderGenerator, serviceName string,
 					variables["data"]["terraform_remote_state"][k] = map[string]interface{}{
 						"backend": "local",
 						"config": [1]interface{}{map[string]interface{}{
-							"path": strings.Repeat("../", strings.Count(path, "/")) + strings.Replace(path, serviceName, k, -1) + "terraform.tfstate",
+							"path": strings.Repeat("../", strings.Count(path, "/")) + strings.ReplaceAll(path, serviceName, k) + "terraform.tfstate",
 						}},
 					}
 				}

--- a/cmd/provider_cmd_github.go
+++ b/cmd/provider_cmd_github.go
@@ -34,7 +34,7 @@ func newCmdGithubImporter(options ImportOptions) *cobra.Command {
 			for _, organization := range organizations {
 				provider := newGitHubProvider()
 				options.PathPattern = originalPathPattern
-				options.PathPattern = strings.Replace(options.PathPattern, "{provider}", "{provider}/"+organization, -1)
+				options.PathPattern = strings.ReplaceAll(options.PathPattern, "{provider}", "{provider}/"+organization)
 				log.Println(provider.GetName() + " importing organization " + organization)
 				err := Import(provider, options, []string{organization, token})
 				if err != nil {

--- a/cmd/provider_cmd_google.go
+++ b/cmd/provider_cmd_google.go
@@ -33,7 +33,7 @@ func newCmdGoogleImporter(options ImportOptions) *cobra.Command {
 				for _, region := range options.Regions {
 					provider := newGoogleProvider()
 					options.PathPattern = originalPathPattern
-					options.PathPattern = strings.Replace(options.PathPattern, "{provider}/{service}", "{provider}/"+project+"/{service}/"+region, -1)
+					options.PathPattern = strings.ReplaceAll(options.PathPattern, "{provider}/{service}", "{provider}/"+project+"/{service}/"+region)
 					log.Println(provider.GetName() + " importing project " + project + " region " + region)
 					err := Import(provider, options, []string{region, project})
 					if err != nil {

--- a/cmd/provider_cmd_keycloak.go
+++ b/cmd/provider_cmd_keycloak.go
@@ -68,7 +68,7 @@ func newCmdKeycloakImporter(options ImportOptions) *cobra.Command {
 					provider := newKeycloakProvider()
 					log.Println(provider.GetName() + " importing realm " + target)
 					options.PathPattern = originalPathPattern
-					options.PathPattern = strings.Replace(options.PathPattern, "{provider}", "{provider}/"+target, -1)
+					options.PathPattern = strings.ReplaceAll(options.PathPattern, "{provider}", "{provider}/"+target)
 					err := Import(provider, options, []string{url, clientID, clientSecret, realm, strconv.FormatInt(clientTimeout, 10), caCert, strconv.FormatBool(tlsInsecureSkipVerify), target})
 					if err != nil {
 						return err

--- a/cmd/provider_cmd_yandex.go
+++ b/cmd/provider_cmd_yandex.go
@@ -36,7 +36,7 @@ func newCmdYandexImporter(options ImportOptions) *cobra.Command {
 			for _, folderID := range options.Projects {
 				provider := newYandexProvider()
 				options.PathPattern = originalPathPattern
-				options.PathPattern = strings.Replace(options.PathPattern, "{provider}/{service}", "{provider}/"+folderID+"/{service}", -1)
+				options.PathPattern = strings.ReplaceAll(options.PathPattern, "{provider}/{service}", "{provider}/"+folderID+"/{service}")
 				log.Println(provider.GetName() + " importing folder id " + folderID)
 				err := Import(provider, options, []string{folderID})
 				if err != nil {

--- a/providers/alicloud/connectivity/endpoint.go
+++ b/providers/alicloud/connectivity/endpoint.go
@@ -50,7 +50,7 @@ const (
 	DDOSBGPCode       = ServiceCode("DDOSBGP")
 )
 
-//xml
+// xml
 type Endpoints struct {
 	Endpoint []Endpoint `xml:"Endpoint"`
 }

--- a/providers/aws/autoscaling.go
+++ b/providers/aws/autoscaling.go
@@ -62,7 +62,7 @@ func (g *AutoScalingGenerator) loadLaunchConfigurations(svc *autoscaling.Client)
 			attributes := map[string]string{}
 			// only for LaunchConfigurations with userdata, we want get user_data_base64
 			if aws.StringValue(lc.UserData) != "" {
-				attributes["user_data_base64"] = "=" //need set not empty string to get user_data_base64 from provider
+				attributes["user_data_base64"] = "=" // need set not empty string to get user_data_base64 from provider
 			}
 			g.Resources = append(g.Resources, terraformutils.NewResource(
 				resourceName,

--- a/providers/aws/iam.go
+++ b/providers/aws/iam.go
@@ -183,7 +183,7 @@ func (g *IamGenerator) getUserPolices(svc *iam.Client, userName *string) error {
 	for p.Next(context.Background()) {
 		for _, policy := range p.CurrentPage().PolicyNames {
 			resourceName := aws.StringValue(userName) + "_" + policy
-			resourceName = strings.Replace(resourceName, "@", "", -1)
+			resourceName = strings.ReplaceAll(resourceName, "@", "")
 			policyID := aws.StringValue(userName) + ":" + policy
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 				policyID,

--- a/providers/datadog/user.go
+++ b/providers/datadog/user.go
@@ -17,6 +17,7 @@ package datadog
 import (
 	"context"
 	"fmt"
+
 	datadogV1 "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"

--- a/providers/gcp/clouddns.go
+++ b/providers/gcp/clouddns.go
@@ -118,7 +118,7 @@ func (g *CloudDNSGenerator) PostConvertHook() error {
 			if zoneID == resourceZone.InstanceState.ID {
 				g.Resources[i].Item["managed_zone"] = "${google_dns_managed_zone." + resourceZone.ResourceName + ".name}"
 				name := g.Resources[i].Item["name"].(string)
-				name = strings.Replace(name, resourceZone.Item["dns_name"].(string), "", -1)
+				name = strings.ReplaceAll(name, resourceZone.Item["dns_name"].(string), "")
 				g.Resources[i].Item["name"] = name + "${google_dns_managed_zone." + resourceZone.ResourceName + ".dns_name}"
 			}
 		}

--- a/providers/gcp/dataproc.go
+++ b/providers/gcp/dataproc.go
@@ -100,8 +100,8 @@ func (g *DataprocGenerator) InitResources() error {
 	clusterList := dataprocService.Projects.Regions.Clusters.List(g.GetArgs()["project"].(string), g.GetArgs()["region"].(compute.Region).Name)
 	g.Resources = g.createClusterResources(ctx, clusterList)
 
-	//jobList := dataprocService.Projects.Regions.Jobs.List(g.GetArgs()["project"].(string), g.GetArgs()["region"])
-	//g.Resources = append(g.Resources, g.createJobResources(jobList, ctx)...)
+	// jobList := dataprocService.Projects.Regions.Jobs.List(g.GetArgs()["project"].(string), g.GetArgs()["region"])
+	// g.Resources = append(g.Resources, g.createJobResources(jobList, ctx)...)
 
 	return nil
 }

--- a/providers/gcp/gcp_compute_code_generator/main.go
+++ b/providers/gcp/gcp_compute_code_generator/main.go
@@ -152,7 +152,7 @@ var ComputeServices = map[string]terraformutils.ServiceGenerator{
 `
 
 func main() {
-	computeAPIData, err := ioutil.ReadFile(os.Getenv("GOPATH") + "/src/google.golang.org/api/compute/v1/compute-api.json") //TODO delete this hack
+	computeAPIData, err := ioutil.ReadFile(os.Getenv("GOPATH") + "/src/google.golang.org/api/compute/v1/compute-api.json") // TODO delete this hack
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/providers/gcp/gcp_compute_code_generator/resources.go
+++ b/providers/gcp/gcp_compute_code_generator/resources.go
@@ -50,9 +50,9 @@ var terraformResources = map[string]gcpResourceRenderable{
 			terraformName: "google_compute_global_forwarding_rule",
 		},
 	},
-	//"globalNetworkEndpointGroups": basicGCPResource{
-	//	terraformName: "google_compute_global_network_endpoint",
-	//},
+	// "globalNetworkEndpointGroups": basicGCPResource{
+	// 	terraformName: "google_compute_global_network_endpoint",
+	// },
 	"healthChecks": basicGCPResource{
 		terraformName: "google_compute_health_check",
 	},

--- a/providers/gcp/gcs.go
+++ b/providers/gcp/gcs.go
@@ -178,12 +178,12 @@ func (g *GcsGenerator) InitResources() error {
 	g.Resources = g.createBucketsResources(ctx, gcsService)
 
 	// TODO find bug with storageTransferService.TransferJobs.List().Pages
-	//storageTransferService, err := storagetransfer.NewService(ctx)
-	//if err != nil {
-	//	log.Print(err)
-	//		return err
-	//	}
-	//g.Resources = append(g.Resources, g.createTransferJobsResources(ctx, storageTransferService)...)
+	// storageTransferService, err := storagetransfer.NewService(ctx)
+	// if err != nil {
+	// 	log.Print(err)
+	// 		return err
+	// 	}
+	// g.Resources = append(g.Resources, g.createTransferJobsResources(ctx, storageTransferService)...)
 	return nil
 }
 

--- a/providers/gcp/gke.go
+++ b/providers/gcp/gke.go
@@ -60,7 +60,7 @@ func (g *GkeGenerator) initClusters(clusters *container.ListClustersResponse) []
 			"^node_config\\.(.*)", // delete node_config config from google_container_cluster
 			"^ip_allocation_policy\\.[0-9]\\.cluster_secondary_range_name$",  // conflict with cluster_ipv4_cidr_block
 			"^ip_allocation_policy\\.[0-9]\\.services_secondary_range_name$", // conflict with services_ipv4_cidr_block
-			"^ip_allocation_policy\\.[0-9]\\.create_subnetwork")              //only for create new cluster conflict with others ip_allocation_policy fields
+			"^ip_allocation_policy\\.[0-9]\\.create_subnetwork")              // only for create new cluster conflict with others ip_allocation_policy fields
 		resources = append(resources, resource)
 		resources = append(resources, g.initNodePools(cluster.NodePools, cluster.Name, cluster.Location)...)
 	}

--- a/providers/gcp/instances.go
+++ b/providers/gcp/instances.go
@@ -37,7 +37,7 @@ func (g InstancesGenerator) createResources(ctx context.Context, instancesList *
 	resources := []terraformutils.Resource{}
 	if err := instancesList.Pages(ctx, func(page *compute.InstanceList) error {
 		for _, obj := range page.Items {
-			if strings.HasPrefix("gke-", obj.Name) {
+			if strings.HasPrefix(obj.Name, "gke-") {
 				continue
 			}
 			resources = append(resources, terraformutils.NewResource(

--- a/providers/github/repositories.go
+++ b/providers/github/repositories.go
@@ -41,7 +41,7 @@ func (g *RepositoriesGenerator) InitResources() error {
 	opt := &githubAPI.RepositoryListByOrgOptions{
 		ListOptions: githubAPI.ListOptions{PerPage: 100},
 	}
-	//list all repositories for the authenticated user
+	// list all repositories for the authenticated user
 	for {
 		repos, resp, err := client.Repositories.ListByOrg(ctx, g.GetArgs()["organization"].(string), opt)
 		if err != nil {

--- a/providers/gmailfilter/label.go
+++ b/providers/gmailfilter/label.go
@@ -34,7 +34,7 @@ func (g LabelGenerator) createResources(labels []*gmail.Label) []terraformutils.
 		}
 		resources = append(resources, terraformutils.NewResource(
 			l.Id,
-			strings.Replace(l.Name, "/", "_", -1),
+			strings.ReplaceAll(l.Name, "/", "_"),
 			"gmailfilter_label",
 			"gmailfilter",
 			map[string]string{},

--- a/providers/keycloak/openid_client.go
+++ b/providers/keycloak/openid_client.go
@@ -114,23 +114,23 @@ func (g RealmGenerator) createOpenIDProtocolMapperResources(clientID string, ope
 			resources = append(resources, g.createOpenIDGenericProtocolMapperResource("user_session_note", protocolMapper.Id, protocolMapper.Name, openidClient.RealmId, openidClient.ClientId, clientID))
 		case "oidc-address-mapper":
 			// Not supported for the moment
-			//resources = append(resources, g.createOpenIDGenericProtocolMapperResource("address", protocolMapper.Id, protocolMapper.Name, openidClient.RealmId, openidClient.ClientId, clientID))
+			// resources = append(resources, g.createOpenIDGenericProtocolMapperResource("address", protocolMapper.Id, protocolMapper.Name, openidClient.RealmId, openidClient.ClientId, clientID))
 			continue
 		case "oidc-role-name-mapper":
 			// Not supported for the moment
-			//resources = append(resources, g.createOpenIDGenericProtocolMapperResource("role_name", protocolMapper.Id, protocolMapper.Name, openidClient.RealmId, openidClient.ClientId, clientID))
+			// resources = append(resources, g.createOpenIDGenericProtocolMapperResource("role_name", protocolMapper.Id, protocolMapper.Name, openidClient.RealmId, openidClient.ClientId, clientID))
 			continue
 		case "oidc-sha256-pairwise-sub-mapper":
 			// Not supported for the moment
-			//resources = append(resources, g.createOpenIDGenericProtocolMapperResource("pairwise_subject_identifier", protocolMapper.Id, protocolMapper.Name, openidClient.RealmId, openidClient.ClientId, clientID))
+			// resources = append(resources, g.createOpenIDGenericProtocolMapperResource("pairwise_subject_identifier", protocolMapper.Id, protocolMapper.Name, openidClient.RealmId, openidClient.ClientId, clientID))
 			continue
 		case "oidc-allowed-origins-mapper":
 			// Not supported for the moment
-			//resources = append(resources, g.createOpenIDGenericProtocolMapperResource("allowed_web_origins", protocolMapper.Id, protocolMapper.Name, openidClient.RealmId, openidClient.ClientId, clientID))
+			// resources = append(resources, g.createOpenIDGenericProtocolMapperResource("allowed_web_origins", protocolMapper.Id, protocolMapper.Name, openidClient.RealmId, openidClient.ClientId, clientID))
 			continue
 		case "oidc-audience-resolve-mapper":
 			// Not supported for the moment
-			//resources = append(resources, g.createOpenIDGenericProtocolMapperResource("audience_resolve", protocolMapper.Id, protocolMapper.Name, openidClient.RealmId, openidClient.ClientId, clientID))
+			// resources = append(resources, g.createOpenIDGenericProtocolMapperResource("audience_resolve", protocolMapper.Id, protocolMapper.Name, openidClient.RealmId, openidClient.ClientId, clientID))
 			continue
 		}
 	}

--- a/providers/openstack/compute.go
+++ b/providers/openstack/compute.go
@@ -77,7 +77,7 @@ func (g *ComputeGenerator) createResources(list *pagination.Pager, volclient *go
 							tv["depends_on"] = []string{dependsOn}
 						}
 
-						name := s.Name + strings.Replace(v.Attachments[0].Device, "/dev/", "", -1)
+						name := s.Name + strings.ReplaceAll(v.Attachments[0].Device, "/dev/", "")
 						rid := s.ID + "/" + v.ID
 						resource := terraformutils.NewResource(
 							rid,

--- a/terraformutils/json.go
+++ b/terraformutils/json.go
@@ -18,9 +18,9 @@ func jsonPrint(data interface{}) ([]byte, error) {
 		return []byte{}, fmt.Errorf("error marshalling terraform data to json: %v", err)
 	}
 	// We don't need to escape > or <
-	s := strings.Replace(string(dataJSONBytes), "\\u003c", "<", -1)
+	s := strings.ReplaceAll(string(dataJSONBytes), "\\u003c", "<")
 	s = OpeningBracketRegexp.ReplaceAllStringFunc(s, escapingBackslashReplacer("<"))
-	s = strings.Replace(s, "\\u003e", ">", -1)
+	s = strings.ReplaceAll(s, "\\u003e", ">")
 	s = ClosingBracketRegexp.ReplaceAllStringFunc(s, escapingBackslashReplacer(">"))
 	return []byte(s), nil
 }

--- a/terraformutils/terraformoutput/bucket.go
+++ b/terraformutils/terraformoutput/bucket.go
@@ -26,7 +26,7 @@ type BucketState struct {
 }
 
 func (b BucketState) BucketGetTfData(path string) interface{} {
-	name := strings.Replace(b.Name, "gs://", "", -1)
+	name := strings.ReplaceAll(b.Name, "gs://", "")
 	bucketStateData := map[string]interface{}{
 		"terraform": map[string]interface{}{
 			"backend": []map[string]interface{}{
@@ -52,7 +52,7 @@ func (b BucketState) BucketUpload(path string, file []byte) error {
 	if err != nil {
 		log.Fatalf("Failed to create client: %v", err)
 	}
-	name := strings.Replace(b.Name, "gs://", "", -1)
+	name := strings.ReplaceAll(b.Name, "gs://", "")
 	wc := client.Bucket(name).Object(b.BucketPrefix(path) + "/default.tfstate").NewWriter(ctx)
 	if _, err = wc.Write(file); err != nil {
 		return err

--- a/terraformutils/terraformoutput/hcl.go
+++ b/terraformutils/terraformoutput/hcl.go
@@ -101,7 +101,7 @@ func OutputHclFiles(resources []terraformutils.Resource, provider terraformutils
 		}
 	} else {
 		for k, v := range typeOfServices {
-			fileName := strings.Replace(k, strings.Split(k, "_")[0]+"_", "", -1)
+			fileName := strings.ReplaceAll(k, strings.Split(k, "_")[0]+"_", "")
 			err := printFile(v, fileName, path, output)
 			if err != nil {
 				return err


### PR DESCRIPTION
# Issues reported by `golangci-lint`


Command: `golangci-lint run  --out-format=tab  ./...`
## Before

<details>
  <summary>Issues reported</summary>
  
  | File| REPORTER | DESCRIPTION |
  | --- | ----- | ----- |
  | providers/aws/autoscaling.go:65:42                          | gocritic |   commentFormatting: put a space between `//` and comment text |
  | providers/aws/iam.go:186:19                                 | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(resourceName, "@", "", -1)` |
  | providers/gmailfilter/label.go:37:4                         | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(l.Name, "/", "_", -1)` |
  | cmd/import.go:226:41                                        | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(path, serviceName, k, -1)` |
  | cmd/import.go:237:66                                        | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(path, serviceName, k, -1)` |
  | cmd/provider_cmd_github.go:37:27                            | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(options.PathPattern, "{provider}", "{provider}/"+organization, -1)` |
  | cmd/provider_cmd_google.go:36:28                            | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(options.PathPattern, "{provider}/{service}", "{provider}/"+project+"/{service}/"+region, -1)` |
  | cmd/provider_cmd_keycloak.go:71:28                          | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(options.PathPattern, "{provider}", "{provider}/"+target, -1)` |
  | cmd/provider_cmd_yandex.go:39:27                            | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(options.PathPattern, "{provider}/{service}", "{provider}/"+folderID+"/{service}", -1)` |
  | providers/github/repositories.go:44:2                       | gocritic |   commentFormatting: put a space between `//` and comment text |
  | providers/gcp/clouddns.go:121:12                            | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(name, resourceZone.Item["dns_name"].(string), "", -1)` |
  | providers/gcp/dataproc.go:103:2                             | gocritic |   commentFormatting: put a space between `//` and comment text |
  | providers/gcp/gcs.go:180:2                                  | gocritic |   commentFormatting: put a space between `//` and comment text |
  | providers/gcp/gke.go:63:70                                  | gocritic |   commentFormatting: put a space between `//` and comment text |
  | providers/gcp/instances.go:40:7                             | gocritic |   argOrder: probably meant `strings.HasPrefix(obj.Name, "gke-")` |
  | terraformutils/hcl.go:89:19                                 | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(t.Token.Text, `\n`, "\n", -1)` |
  | terraformutils/hcl.go:90:19                                 | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(t.Token.Text, `\t`, "", -1)` |
  | terraformutils/hcl.go:97:15                                 | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(jsonTest, "\\\"", "\"", -1)` |
  | terraformutils/hcl.go:157:6                                 | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(s, "}\nresource", "}\n\nresource", -1)` |
  | terraformutils/hcl.go:154:6                                 | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(s, "\n\n", "\n", -1)` |
  | terraformutils/json.go:23:6                                 | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(s, "\\u003e", ">", -1)` |
  | terraformutils/json.go:21:7                                 | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(string(dataJSONBytes), "\\u003c", "<", -1)` |
  | terraformutils/terraformoutput/bucket.go:55:10              | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(b.Name, "gs://", "", -1)` |
  | terraformutils/terraformoutput/bucket.go:29:10              | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(b.Name, "gs://", "", -1)` |
  | build/main.go:80:2                                          | gocritic |   commentFormatting: put a space between `//` and comment text |
  | terraformutils/terraformoutput/hcl.go:104:16                | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(k, strings.Split(k, "_")[0]+"_", "", -1)` |
  | build/main.go:29:20                                         | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(providerName, fileSuffix, "", -1)` |
  | build/main.go:28:21                                         | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(f.Name(), filePrefix, "", -1)` |
  | providers/gcp/gcp_compute_code_generator/resources.go:53:2  | gocritic |   commentFormatting: put a space between `//` and comment text |
  | providers/gcp/gcp_compute_code_generator/main.go:155:121    | gocritic |   commentFormatting: put a space between `//` and comment text |
  | providers/keycloak/openid_client.go:116:4                   | gocritic |   commentFormatting: put a space between `//` and comment text |
  | providers/datadog/user.go:19                                | goimports |  File is not `goimports`-ed |
  | providers/keycloak/openid_client.go:124:4                   | gocritic |   commentFormatting: put a space between `//` and comment text |
  | providers/keycloak/openid_client.go:120:4                   | gocritic |   commentFormatting: put a space between `//` and comment text |
  | providers/keycloak/openid_client.go:132:4                   | gocritic |   commentFormatting: put a space between `//` and comment text |
  | providers/keycloak/openid_client.go:128:4                   | gocritic |   commentFormatting: put a space between `//` and comment text |
  | providers/alicloud/connectivity/endpoint.go:53:1            | gocritic |   commentFormatting: put a space between `//` and comment text |
  | providers/openstack/compute.go:80:24                        | gocritic |   wrapperFunc: use strings.ReplaceAll method in `strings.Replace(v.Attachments[0].Device, "/dev/", "", -1)` |
</details>

## After

No more issues left
```
golangci-lint run  --out-format=tab  ./... | wc -l
       0
```