### PR TITLE
Handle nested maps in terraform12Adjustments

### DIFF
--- a/terraformutils/hcl.go
+++ b/terraformutils/hcl.go
@@ -237,6 +237,7 @@ func TfSanitize(name string) string {
 func HclPrintResource(resources []Resource, providerData map[string]interface{}, output string) ([]byte, error) {
 	resourcesByType := map[string]map[string]interface{}{}
 	mapsObjects := map[string]struct{}{}
+	indexRe := regexp.MustCompile(`\.[0-9]+`)
 	for _, res := range resources {
 		r := resourcesByType[res.InstanceInfo.Type]
 		if r == nil {
@@ -254,7 +255,7 @@ func HclPrintResource(resources []Resource, providerData map[string]interface{},
 		for k := range res.InstanceState.Attributes {
 			if strings.HasSuffix(k, ".%") {
 				key := strings.TrimSuffix(k, ".%")
-				mapsObjects[key] = struct{}{}
+				mapsObjects[indexRe.ReplaceAllString(key, "")] = struct{}{}
 			}
 		}
 	}

--- a/terraformutils/hcl.go
+++ b/terraformutils/hcl.go
@@ -188,7 +188,7 @@ func terraform12Adjustments(formatted []byte, mapsObjects map[string]struct{}) [
 	prefix := make([]string, 0)
 	for i, line := range lines {
 		if singletonListFixEnd.MatchString(line) && len(prefix) > 0 {
-			prefix = prefix[:len(prefix) - 1]
+			prefix = prefix[:len(prefix)-1]
 			continue
 		}
 		if !singletonListFix.MatchString(line) {

--- a/terraformutils/hcl_test.go
+++ b/terraformutils/hcl_test.go
@@ -28,12 +28,18 @@ func TestPrintResource(t *testing.T) {
 			"type1": "ID2",
 			"map1.%": "1",
 			"map1.foo": "bar",
-			"nested.map1.#": "1",
-			"nested.map1.0.field1": "egg",
+			"nested.#": "1",
+			"nested.0.map1.#": "1",
+			"nested.0.map1.0.field1": "egg",
+			"nested2.#": "1",
+			"nested2.0.field1": "spam",
+			"nested2.0.map2.%": "1",
+			"nested2.0.map2.foo": "bar",
 		}, map[string]interface{}{
 			"type1": "ID2",
 			"map1": mapI("foo", "bar"),
 			"nested": mapI("map1", nested),
+			"nested2": map[string]interface{}{"map2": mapI("bar", "foo"), "field1": "egg"},
 		})
 	resources = append(resources, importResource)
 	providerData := map[string]interface{}{}
@@ -41,6 +47,9 @@ func TestPrintResource(t *testing.T) {
 	data, _ := HclPrintResource(resources, providerData, output)
 
 	if strings.Count(string(data), "map1 = ") != 1 {
+		t.Errorf("failed to parse data %s", string(data))
+	}
+	if strings.Count(string(data), "map2 = ") != 1 {
 		t.Errorf("failed to parse data %s", string(data))
 	}
 }

--- a/terraformutils/hcl_test.go
+++ b/terraformutils/hcl_test.go
@@ -1,0 +1,46 @@
+// Copyright 2020 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package terraformutils
+
+import (
+	"testing"
+	"strings"
+)
+
+
+func TestPrintResource(t *testing.T) {
+	var resources []Resource
+	var nested []map[string]interface{}
+	nested = append(nested, mapI("field1", "egg"))
+	importResource := prepare("ID1", "type1", map[string]string{
+			"type1": "ID2",
+			"map1.%": "1",
+			"map1.foo": "bar",
+			"nested.map1.#": "1",
+			"nested.map1.0.field1": "egg",
+		}, map[string]interface{}{
+			"type1": "ID2",
+			"map1": mapI("foo", "bar"),
+			"nested": mapI("map1", nested),
+		})
+	resources = append(resources, importResource)
+	providerData := map[string]interface{}{}
+	output := "hcl"
+	data, _ := HclPrintResource(resources, providerData, output)
+
+	if strings.Count(string(data), "map1 = ") != 1 {
+		t.Errorf("failed to parse data %s", string(data))
+	}
+}

--- a/terraformutils/hcl_test.go
+++ b/terraformutils/hcl_test.go
@@ -15,32 +15,31 @@
 package terraformutils
 
 import (
-	"testing"
 	"strings"
+	"testing"
 )
-
 
 func TestPrintResource(t *testing.T) {
 	var resources []Resource
 	var nested []map[string]interface{}
 	nested = append(nested, mapI("field1", "egg"))
 	importResource := prepare("ID1", "type1", map[string]string{
-			"type1": "ID2",
-			"map1.%": "1",
-			"map1.foo": "bar",
-			"nested.#": "1",
-			"nested.0.map1.#": "1",
-			"nested.0.map1.0.field1": "egg",
-			"nested2.#": "1",
-			"nested2.0.field1": "spam",
-			"nested2.0.map2.%": "1",
-			"nested2.0.map2.foo": "bar",
-		}, map[string]interface{}{
-			"type1": "ID2",
-			"map1": mapI("foo", "bar"),
-			"nested": mapI("map1", nested),
-			"nested2": map[string]interface{}{"map2": mapI("bar", "foo"), "field1": "egg"},
-		})
+		"type1":                  "ID2",
+		"map1.%":                 "1",
+		"map1.foo":               "bar",
+		"nested.#":               "1",
+		"nested.0.map1.#":        "1",
+		"nested.0.map1.0.field1": "egg",
+		"nested2.#":              "1",
+		"nested2.0.field1":       "spam",
+		"nested2.0.map2.%":       "1",
+		"nested2.0.map2.foo":     "bar",
+	}, map[string]interface{}{
+		"type1":   "ID2",
+		"map1":    mapI("foo", "bar"),
+		"nested":  mapI("map1", nested),
+		"nested2": map[string]interface{}{"map2": mapI("bar", "foo"), "field1": "egg"},
+	})
 	resources = append(resources, importResource)
 	providerData := map[string]interface{}{}
 	output := "hcl"


### PR DESCRIPTION
This tries to handle the case where a field has the same name under different subschemas in the same resource, one of them being a map. Currently, it replaces all occurrences to the map version, but we can properly detect where we are in the hierarchy.
