### PR TITLE
Add missing terraformutils.TfSanitize

### DIFF
--- a/providers/openstack/compute.go
+++ b/providers/openstack/compute.go
@@ -88,7 +88,7 @@ func (g *ComputeGenerator) createResources(list *pagination.Pager, volclient *go
 							[]string{},
 							tv,
 						)
-						dependsOn = "openstack_compute_volume_attach_v2.tfer--" + name
+						dependsOn = "openstack_compute_volume_attach_v2."+terraformutils.TfSanitize(name)
 						tv["instance_name"] = terraformutils.TfSanitize(s.Name)
 						if v.Name == "" {
 							v.Name = v.ID

--- a/providers/openstack/compute.go
+++ b/providers/openstack/compute.go
@@ -88,7 +88,7 @@ func (g *ComputeGenerator) createResources(list *pagination.Pager, volclient *go
 							[]string{},
 							tv,
 						)
-						dependsOn = "openstack_compute_volume_attach_v2."+terraformutils.TfSanitize(name)
+						dependsOn = "openstack_compute_volume_attach_v2." + terraformutils.TfSanitize(name)
 						tv["instance_name"] = terraformutils.TfSanitize(s.Name)
 						if v.Name == "" {
 							v.Name = v.ID


### PR DESCRIPTION
When importing volume attachments from an instance, with
a name with special charaters such as a dot, and with multiple attachments,
the depends_on contained the literal dot.