### PR TITLE
Fix typo on Azure public IP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,7 +810,7 @@ List of supported Azure resources:
     * `azurerm_private_dns_txt_record`
     * `azurerm_private_dns_zone`
     * `azurerm_private_dns_zone_virtual_network_link`
-*   `pubilc_ip`
+*   `public_ip`
     * `azurerm_public_ip`
     * `azurerm_public_ip_prefix`
 *   `resource_group`


### PR DESCRIPTION
Fix typo on README for the Azure `public_ip` section