### PR TITLE
providers/alicloud: shouldn't access p.Service in GetConfig()

### DIFF
--- a/providers/alicloud/alicloud_provider.go
+++ b/providers/alicloud/alicloud_provider.go
@@ -31,8 +31,7 @@ type AliCloudProvider struct { //nolint
 
 // GetConfig Converts json config to go-cty
 func (p *AliCloudProvider) GetConfig() cty.Value {
-	args := p.Service.GetArgs()
-	profile := args["profile"].(string)
+	profile := p.profile
 	config, err := LoadConfigFromProfile(profile)
 	if err != nil {
 		fmt.Println("ERROR:", err)


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/terraformer/issues/681

### why

`p.Service` is not initialized when we call `GetConfig` here:

https://github.com/GoogleCloudPlatform/terraformer/blob/master/cmd/import.go#L113-L116

and it's better to use `p.profile` field which is initialized in `Init()`:

https://github.com/GoogleCloudPlatform/terraformer/blob/b9a6ae6e7de30c81d62649ce4b47c657cb19986c/providers/alicloud/alicloud_provider.go#L112-L116

```
$ terraformer import alicloud --resources=* --profile=<xxx> --regions cn-hangzhou
2020/12/01 20:17:17 alicloud importing region cn-hangzhou
2020/12/01 20:17:17 Attempting an import of ALL resources in alicloud
2020/12/01 20:17:17 provider name: alicloud
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1998da1]

goroutine 1 [running]:
github.com/GoogleCloudPlatform/terraformer/providers/alicloud.(*AliCloudProvider).GetConfig(0xc000786730, 0x7471d77, 0x8, 0x1, 0x1)
	/data/go/src/github.com/GoogleCloudPlatform/terraformer/providers/alicloud/alicloud_provider.go:34 +0x41
github.com/GoogleCloudPlatform/terraformer/cmd.Import(0x7ce8ce0, 0xc000786730, 0xc000b3f700, 0xb, 0x10, 0xc0000787b0, 0x2a, 0x7474e4b, 0x9, 0x746c083, ...)
	/data/go/src/github.com/GoogleCloudPlatform/terraformer/cmd/import.go:97 +0x2e7
...
```

