### PR TITLE
add support for rabbitmq shovels

### DIFF
--- a/providers/rabbitmq/rabbitmq_provider.go
+++ b/providers/rabbitmq/rabbitmq_provider.go
@@ -81,6 +81,7 @@ func (p *RBTProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"queues":      &QueueGenerator{},
 		"users":       &UserGenerator{},
 		"vhosts":      &VhostGenerator{},
+		"shovels":     &ShovelGenerator{},
 	}
 }
 
@@ -92,6 +93,9 @@ func (RBTProvider) GetResourceConnections() map[string]map[string][]string {
 			"vhosts":    []string{"vhost", "self_link"},
 		},
 		"exchanges": {
+			"vhosts": []string{"vhost", "self_link"},
+		},
+		"shovels": {
 			"vhosts": []string{"vhost", "self_link"},
 		},
 		"permissions": {

--- a/providers/rabbitmq/shovel.go
+++ b/providers/rabbitmq/shovel.go
@@ -1,0 +1,72 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rabbitmq
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+)
+
+type ShovelGenerator struct {
+	RBTService
+}
+
+type Shovel struct {
+	Name  string `json:"name"`
+	Vhost string `json:"vhost"`
+}
+
+type Shovels []Shovel
+
+var ShovelAllowEmptyValues = []string{}
+var ShovelAdditionalFields = map[string]interface{}{}
+
+func (g ShovelGenerator) createResources(shovels Shovels) []terraformutils.Resource {
+	var resources []terraformutils.Resource
+	for _, shovel := range shovels {
+		if len(shovel.Name) == 0 {
+			continue
+		}
+		resources = append(resources, terraformutils.NewResource(
+			fmt.Sprintf("%s@%s", shovel.Name, shovel.Vhost),
+			fmt.Sprintf("shovel_%s_%s", normalizeResourceName(shovel.Vhost), normalizeResourceName(shovel.Name)),
+			"rabbitmq_shovel",
+			"rabbitmq",
+			map[string]string{
+				"name":  shovel.Name,
+				"vhost": shovel.Vhost,
+			},
+			ShovelAllowEmptyValues,
+			ShovelAdditionalFields,
+		))
+	}
+	return resources
+}
+
+func (g *ShovelGenerator) InitResources() error {
+	body, err := g.generateRequest("/api/shovels?columns=name,vhost")
+	if err != nil {
+		return err
+	}
+	var shovels Shovels
+	err = json.Unmarshal(body, &shovels)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(shovels)
+	return nil
+}


### PR DESCRIPTION
Hey there! thank you for making terraformer opensource. This afternoon I tried to add shovel support for rabbitmq provider however I'm missing something. This pull request is almost completed except for that part.

```
+ ../terraformer import rabbitmq -v -p '{output}/{provider}/' --resources=shovels                                                                                                                                                                              
2020-12-27T21:56:04.769+0100 [INFO]  plugin: configuring client automatic mTLS                                                                                                                                                                                 
2020-12-27T21:56:04.798+0100 [DEBUG] plugin: starting plugin: path=.terraform/plugins/registry.terraform.io/cyrilgdn/rabbitmq/1.5.1/linux_amd64/terraform-provider-rabbitmq_v1.5.1 args=[.terraform/plugins/registry.terraform.io/cyrilgdn/rabbitmq/1.5.1/linux_amd64/terraform-provider-rabbitmq_v1.5.1]                                                                                                                                                                                                                     
2020-12-27T21:56:04.798+0100 [DEBUG] plugin: plugin started: path=.terraform/plugins/registry.terraform.io/cyrilgdn/rabbitmq/1.5.1/linux_amd64/terraform-provider-rabbitmq_v1.5.1 pid=10977                                                                    
2020-12-27T21:56:04.798+0100 [DEBUG] plugin: waiting for RPC address: path=.terraform/plugins/registry.terraform.io/cyrilgdn/rabbitmq/1.5.1/linux_amd64/terraform-provider-rabbitmq_v1.5.1                                                                     
2020-12-27T21:56:04.810+0100 [INFO]  plugin.terraform-provider-rabbitmq_v1.5.1: configuring server automatic mTLS: timestamp=2020-12-27T21:56:04.810+0100                                                                                                      
2020-12-27T21:56:04.837+0100 [DEBUG] plugin: using plugin: version=5                                                                                                                                                                                           
2020-12-27T21:56:04.837+0100 [DEBUG] plugin.terraform-provider-rabbitmq_v1.5.1: plugin address: address=/tmp/plugin928573766 network=unix timestamp=2020-12-27T21:56:04.837+0100                                                                               
2020-12-27T21:56:04.887+0100 [TRACE] plugin.stdio: waiting for stdio data                                                                                                                                                                                      
2020-12-27T21:56:04.888+0100 [DEBUG] plugin.stdio: received EOF, stopping recv loop: err="rpc error: code = Unimplemented desc = unknown service plugin.GRPCStdio"
2020/12/27 21:56:04 rabbitmq importing... shovels
2020/12/27 21:56:04 [{0xc0012f4960 ID = someshovel@someVhost
name = someshovel
vhost = someVhost
Tainted = false
2020/12/27 21:56:04 Refreshing state... rabbitmq_shovel.tfer--someshovel
2020-12-27T21:56:04.896+0100 [DEBUG] plugin.terraform-provider-rabbitmq_v1.5.1: 2020/12/27 21:56:04 [DEBUG] RabbitMQ: Shovel retrieved: Vhost: "someVhost", Name: "someshovel"
2020/12/27 21:56:04 rabbitmq Connecting.... 
2020/12/27 21:56:04 rabbitmq save 
2020/12/27 21:56:04 rabbitmq save tfstate
2020-12-27T21:56:04.900+0100 [DEBUG] plugin: plugin process exited: path=.terraform/plugins/registry.terraform.io/cyrilgdn/rabbitmq/1.5.1/linux_amd64/terraform-provider-rabbitmq_v1.5.1 pid=10977
2020-12-27T21:56:04.900+0100 [DEBUG] plugin: plugin exited
+ cat generated/rabbitmq/shovel.tf
resource "rabbitmq_shovel" "tfer--someshovel" {
  name  = "someshovel"
  vhost = "someVhost"
}
```

Clearly its missing info definition for shovel but I cannot seem to find where it should be done :( 