### PR TITLE
Add support datadog cloud resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1408,6 +1408,18 @@ List of supported Datadog services:
     * `datadog_dashboard`
 *   `downtime`
     * `datadog_downtime`
+*   `integration_aws`
+    * `datadog_integration_aws`
+*   `integration_aws_lambda_arn`
+    * `datadog_integration_aws_lambda_arn`
+*   `integration_aws_log_collection`
+    * `datadog_integration_aws_log_collection`
+*   `integration_azure`
+    * `datadog_integration_azure`
+        * **_NOTE:_** Sensitive field `client_secret` is not generated and needs to be manually set
+*   `integration_gcp`
+    * `datadog_integration_gcp`
+        * **_NOTE:_** Sensitive fields `private_key, private_key_id, client_id` is not generated and needs to be manually set
 *   `monitor`
     * `datadog_monitor`
 *   `screenboard`

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -137,13 +137,18 @@ func (p *DatadogProvider) InitService(serviceName string, verbose bool) error {
 // GetSupportedService return map of support service for Datadog
 func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
 	return map[string]terraformutils.ServiceGenerator{
-		"dashboard":   &DashboardGenerator{},
-		"downtime":    &DowntimeGenerator{},
-		"monitor":     &MonitorGenerator{},
-		"screenboard": &ScreenboardGenerator{},
-		"synthetics":  &SyntheticsGenerator{},
-		"timeboard":   &TimeboardGenerator{},
-		"user":        &UserGenerator{},
+		"dashboard":                      &DashboardGenerator{},
+		"downtime":                       &DowntimeGenerator{},
+		"integration_aws":                &IntegrationAWSGenerator{},
+		"integration_aws_lambda_arn":     &IntegrationAWSLambdaARNGenerator{},
+		"integration_aws_log_collection": &IntegrationAWSLogCollectionGenerator{},
+		"integration_azure":              &IntegrationAzureGenerator{},
+		"integration_gcp":                &IntegrationGCPGenerator{},
+		"monitor":                        &MonitorGenerator{},
+		"screenboard":                    &ScreenboardGenerator{},
+		"synthetics":                     &SyntheticsGenerator{},
+		"timeboard":                      &TimeboardGenerator{},
+		"user":                           &UserGenerator{},
 	}
 }
 

--- a/providers/datadog/integration_aws.go
+++ b/providers/datadog/integration_aws.go
@@ -1,0 +1,69 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	datadogV1 "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+)
+
+var (
+	// IntegrationAWSAllowEmptyValues ...
+	IntegrationAWSAllowEmptyValues = []string{}
+)
+
+// IntegrationAWSGenerator ...
+type IntegrationAWSGenerator struct {
+	DatadogService
+}
+
+func (g *IntegrationAWSGenerator) createResources(AWSAccounts []datadogV1.AWSAccount) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, account := range AWSAccounts {
+		resourceID := fmt.Sprintf("%s:%s", account.GetAccountId(), account.GetRoleName())
+		resources = append(resources, g.createResource(resourceID))
+	}
+
+	return resources
+}
+
+func (g *IntegrationAWSGenerator) createResource(resourceID string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		resourceID,
+		fmt.Sprintf("integration_aws_%s", resourceID),
+		"datadog_integration_aws",
+		"datadog",
+		IntegrationAWSAllowEmptyValues,
+	)
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each monitor create 1 TerraformResource.
+// Need IntegrationAWS ID formatted as '<account_id>:<role_name>' as ID for terraform resource
+func (g *IntegrationAWSGenerator) InitResources() error {
+	datadogClientV1 := g.Args["datadogClientV1"].(*datadogV1.APIClient)
+	authV1 := g.Args["authV1"].(context.Context)
+
+	integrations, _, err := datadogClientV1.AWSIntegrationApi.ListAWSAccounts(authV1).Execute()
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(integrations.GetAccounts())
+	return nil
+}

--- a/providers/datadog/integration_aws_lambda_arn.go
+++ b/providers/datadog/integration_aws_lambda_arn.go
@@ -1,0 +1,73 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	datadogV1 "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+)
+
+var (
+	// IntegrationAWSLambdaARNAllowEmptyValues ...
+	IntegrationAWSLambdaARNAllowEmptyValues = []string{}
+)
+
+// IntegrationAWSLambdaARNGenerator ...
+type IntegrationAWSLambdaARNGenerator struct {
+	DatadogService
+}
+
+func (g *IntegrationAWSLambdaARNGenerator) createResources(logCollections []datadogV1.AWSLogsListResponse) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, logCollection := range logCollections {
+		for _, logCollectionLambdaArn := range logCollection.GetLambdas() {
+			accountID := logCollection.GetAccountId()
+			if v, ok := logCollectionLambdaArn.GetArnOk(); ok {
+				resourceID := fmt.Sprintf("%s %s", accountID, *v)
+				resources = append(resources, g.createResource(resourceID))
+			}
+		}
+	}
+	return resources
+}
+
+func (g *IntegrationAWSLambdaARNGenerator) createResource(resourceID string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		resourceID,
+		fmt.Sprintf("integration_aws_lambda_arn_%s", resourceID),
+		"datadog_integration_aws_lambda_arn",
+		"datadog",
+		IntegrationAWSLambdaARNAllowEmptyValues,
+	)
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each monitor create 1 TerraformResource.
+// Need IntegrationAWSLambdaARN ID formatted as '<account_id>:<role_name>' as ID for terraform resource
+func (g *IntegrationAWSLambdaARNGenerator) InitResources() error {
+	datadogClientV1 := g.Args["datadogClientV1"].(*datadogV1.APIClient)
+	authV1 := g.Args["authV1"].(context.Context)
+
+	logCollections, _, err := datadogClientV1.AWSLogsIntegrationApi.ListAWSLogsIntegrations(authV1).Execute()
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(logCollections)
+	return nil
+}

--- a/providers/datadog/integration_aws_log_collection.go
+++ b/providers/datadog/integration_aws_log_collection.go
@@ -1,0 +1,77 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	datadogV1 "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+)
+
+var (
+	// IntegrationAWSLogCollectionAllowEmptyValues ...
+	IntegrationAWSLogCollectionAllowEmptyValues = []string{"services"}
+)
+
+// IntegrationAWSLogCollectionGenerator ...
+type IntegrationAWSLogCollectionGenerator struct {
+	DatadogService
+}
+
+func (g *IntegrationAWSLogCollectionGenerator) createResources(logCollections []datadogV1.AWSLogsListResponse) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, logCollection := range logCollections {
+		resourceID := logCollection.GetAccountId()
+		resources = append(resources, g.createResource(resourceID))
+	}
+	return resources
+}
+
+func (g *IntegrationAWSLogCollectionGenerator) createResource(resourceID string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		resourceID,
+		fmt.Sprintf("integration_aws_log_collection_%s", resourceID),
+		"datadog_integration_aws_log_collection",
+		"datadog",
+		IntegrationAWSLogCollectionAllowEmptyValues,
+	)
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each monitor create 1 TerraformResource.
+// Need IntegrationAWSLogCollection ID formatted as '<account_id>:<role_name>' as ID for terraform resource
+func (g *IntegrationAWSLogCollectionGenerator) InitResources() error {
+	datadogClientV1 := g.Args["datadogClientV1"].(*datadogV1.APIClient)
+	authV1 := g.Args["authV1"].(context.Context)
+
+	logCollections, _, err := datadogClientV1.AWSLogsIntegrationApi.ListAWSLogsIntegrations(authV1).Execute()
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(logCollections)
+	return nil
+}
+
+func (g *IntegrationAWSLogCollectionGenerator) PostConvertHook() error {
+	for _, r := range g.Resources {
+		// services is a required attribute but can be empty. This ensures we append an empty list
+		if r.Item["services"] == nil {
+			r.Item["services"] = []string{}
+		}
+	}
+	return nil
+}

--- a/providers/datadog/integration_azure.go
+++ b/providers/datadog/integration_azure.go
@@ -1,0 +1,68 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	datadogV1 "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+)
+
+var (
+	// IntegrationAzureAllowEmptyValues ...
+	IntegrationAzureAllowEmptyValues = []string{}
+)
+
+// IntegrationAzureGenerator ...
+type IntegrationAzureGenerator struct {
+	DatadogService
+}
+
+func (g *IntegrationAzureGenerator) createResources(AzureAccounts []datadogV1.AzureAccount) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, account := range AzureAccounts {
+		resourceID := fmt.Sprintf("%s:%s", account.GetTenantName(), account.GetClientId())
+		resources = append(resources, g.createResource(resourceID))
+	}
+
+	return resources
+}
+
+func (g *IntegrationAzureGenerator) createResource(resourceID string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		resourceID,
+		fmt.Sprintf("integration_azure_%s", resourceID),
+		"datadog_integration_azure",
+		"datadog",
+		IntegrationAzureAllowEmptyValues,
+	)
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each monitor create 1 TerraformResource.
+// Need IntegrationAzure ID formatted as '<tenant_name>:<client_id>' as ID for terraform resource
+func (g *IntegrationAzureGenerator) InitResources() error {
+	datadogClientV1 := g.Args["datadogClientV1"].(*datadogV1.APIClient)
+	authV1 := g.Args["authV1"].(context.Context)
+
+	integrations, _, err := datadogClientV1.AzureIntegrationApi.ListAzureIntegration(authV1).Execute()
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(integrations)
+	return nil
+}

--- a/providers/datadog/integration_gcp.go
+++ b/providers/datadog/integration_gcp.go
@@ -1,0 +1,68 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	datadogV1 "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+)
+
+var (
+	// IntegrationGCPAllowEmptyValues ...
+	IntegrationGCPAllowEmptyValues = []string{}
+)
+
+// IntegrationGCPGenerator ...
+type IntegrationGCPGenerator struct {
+	DatadogService
+}
+
+func (g *IntegrationGCPGenerator) createResources(GCPAccounts []datadogV1.GCPAccount) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, account := range GCPAccounts {
+		resourceID := account.GetProjectId()
+		resources = append(resources, g.createResource(resourceID))
+	}
+
+	return resources
+}
+
+func (g *IntegrationGCPGenerator) createResource(resourceID string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		resourceID,
+		fmt.Sprintf("integration_gcp_%s", resourceID),
+		"datadog_integration_gcp",
+		"datadog",
+		IntegrationGCPAllowEmptyValues,
+	)
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each monitor create 1 TerraformResource.
+// Need IntegrationGCP ID formatted as '<tenant_name>:<client_id>' as ID for terraform resource
+func (g *IntegrationGCPGenerator) InitResources() error {
+	datadogClientV1 := g.Args["datadogClientV1"].(*datadogV1.APIClient)
+	authV1 := g.Args["authV1"].(context.Context)
+
+	integrations, _, err := datadogClientV1.GCPIntegrationApi.ListGCPIntegration(authV1).Execute()
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(integrations)
+	return nil
+}


### PR DESCRIPTION
This PR adds support for the following Datadog resources:

- datadog_integration_aws
- datadog_integration_aws_lambda_arn
- datadog_integration_aws_log_collection
- datadog_integration_azure
- datadog_integration_gcp