### PR TITLE
Update datadog-api-go-client library version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v42.0.0+incompatible
 	github.com/Azure/azure-storage-blob-go v0.10.0
 	github.com/Azure/go-autorest/autorest v0.11.12
-	github.com/DataDog/datadog-api-client-go v1.0.0-beta.9
+	github.com/DataDog/datadog-api-client-go v1.0.0-beta.14
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20201210085054-cdf09378fdd9
 	github.com/IBM/go-sdk-core/v3 v3.3.1
 	github.com/IBM/go-sdk-core/v4 v4.9.0

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
 github.com/DataDog/datadog-api-client-go v1.0.0-beta.9 h1:TsOhRZ1r0WptlynSSBp8EuBT4vPRWNzYwbXrMGV0Eto=
 github.com/DataDog/datadog-api-client-go v1.0.0-beta.9/go.mod h1:/bMeu+q33QzX2JuO5PkGkhU1VYOXIXKEPF6Ck4yR06M=
+github.com/DataDog/datadog-api-client-go v1.0.0-beta.14 h1:NbJeCxYBhThksWgk6Z9QpaFc/z2k0mcs7ZVnCRREeZU=
+github.com/DataDog/datadog-api-client-go v1.0.0-beta.14/go.mod h1:/bMeu+q33QzX2JuO5PkGkhU1VYOXIXKEPF6Ck4yR06M=
 github.com/DataDog/datadog-go v3.6.0+incompatible h1:ILg7c5Y1KvZFDOaVS0higGmJ5Fal5O1KQrkrT9j6dSM=
 github.com/DataDog/datadog-go v3.6.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/IBM-Cloud/bluemix-go v0.0.0-20201210085054-cdf09378fdd9 h1:CQEiiiSY2KD3U3WnBpYo6Bh6/VD6+LlL6+Hd3AH+utY=


### PR DESCRIPTION
This PR bumps the datadog-api-go-client version and also introduces support for datadog v2 api.