### PR TITLE
Add support for datadog security resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1412,6 +1412,10 @@ List of supported Datadog services:
     * `datadog_monitor`
 *   `screenboard`
     * `datadog_screenboard`
+*   `security_monitoring_default_rule`
+    * `datadog_security_monitoring_default_rule`
+*   `security_monitoring_rule`
+    * `datadog_security_monitoring_rule`
 *   `synthetics`
     * `datadog_synthetics_test`
 *   `timeboard`

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -180,13 +180,15 @@ func (p *DatadogProvider) InitService(serviceName string, verbose bool) error {
 // GetSupportedService return map of support service for Datadog
 func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
 	return map[string]terraformutils.ServiceGenerator{
-		"dashboard":   &DashboardGenerator{},
-		"downtime":    &DowntimeGenerator{},
-		"monitor":     &MonitorGenerator{},
-		"screenboard": &ScreenboardGenerator{},
-		"synthetics":  &SyntheticsGenerator{},
-		"timeboard":   &TimeboardGenerator{},
-		"user":        &UserGenerator{},
+		"dashboard":                        &DashboardGenerator{},
+		"downtime":                         &DowntimeGenerator{},
+		"monitor":                          &MonitorGenerator{},
+		"screenboard":                      &ScreenboardGenerator{},
+		"security_monitoring_default_rule": &SecurityMonitoringDefaultRuleGenerator{},
+		"security_monitoring_rule":         &SecurityMonitoringRuleGenerator{},
+		"synthetics":                       &SyntheticsGenerator{},
+		"timeboard":                        &TimeboardGenerator{},
+		"user":                             &UserGenerator{},
 	}
 }
 

--- a/providers/datadog/security_monitoring_default_rule.go
+++ b/providers/datadog/security_monitoring_default_rule.go
@@ -1,0 +1,72 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	datadogV2 "github.com/DataDog/datadog-api-client-go/api/v2/datadog"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+)
+
+var (
+	// SecurityMonitoringDefaultRuleAllowEmptyValues ...
+	SecurityMonitoringDefaultRuleAllowEmptyValues = []string{"tags."}
+)
+
+// SecurityMonitoringDefaultRuleGenerator ...
+type SecurityMonitoringDefaultRuleGenerator struct {
+	DatadogService
+}
+
+func (g *SecurityMonitoringDefaultRuleGenerator) createResources(rulesResponse []datadogV2.SecurityMonitoringRuleResponse) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, rule := range rulesResponse {
+		if rule.GetIsDefault() {
+			resourceName := rule.GetId()
+			resources = append(resources, g.createResource(resourceName))
+		}
+	}
+
+	return resources
+}
+
+func (g *SecurityMonitoringDefaultRuleGenerator) createResource(ruleID string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		ruleID,
+		fmt.Sprintf("security_monitoring_default_rule_%s", ruleID),
+		"datadog_security_monitoring_default_rule",
+		"datadog",
+		SecurityMonitoringDefaultRuleAllowEmptyValues,
+	)
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each SecurityMonitoringDefaultRule create 1 TerraformResource.
+// Need SecurityMonitoringDefaultRule ID as ID for terraform resource
+func (g *SecurityMonitoringDefaultRuleGenerator) InitResources() error {
+	datadogClientV2 := g.Args["datadogClientV2"].(*datadogV2.APIClient)
+	authV2 := g.Args["authV2"].(context.Context)
+
+	pageSize := int64(999)
+	resp, _, err := datadogClientV2.SecurityMonitoringApi.ListSecurityMonitoringRules(authV2).PageSize(pageSize).Execute()
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(resp.GetData())
+	return nil
+}

--- a/providers/datadog/security_monitoring_rule.go
+++ b/providers/datadog/security_monitoring_rule.go
@@ -1,0 +1,77 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	datadogV2 "github.com/DataDog/datadog-api-client-go/api/v2/datadog"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+)
+
+var (
+	// SecurityMonitoringRuleAllowEmptyValues ...
+	SecurityMonitoringRuleAllowEmptyValues = []string{"tags."}
+)
+
+// SecurityMonitoringRuleGenerator ...
+type SecurityMonitoringRuleGenerator struct {
+	DatadogService
+}
+
+func (g *SecurityMonitoringRuleGenerator) createResources(rulesResponse []datadogV2.SecurityMonitoringRuleResponse) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, rule := range rulesResponse {
+		if !rule.GetIsDefault() {
+			resourceName := rule.GetId()
+			resources = append(resources, g.createResource(resourceName, rule.GetIsEnabled()))
+		}
+	}
+
+	return resources
+}
+
+func (g *SecurityMonitoringRuleGenerator) createResource(ruleID string, ruleEnabled bool) terraformutils.Resource {
+	return terraformutils.NewResource(
+		ruleID,
+		fmt.Sprintf("security_monitoring_rule_%s", ruleID),
+		"datadog_security_monitoring_rule",
+		"datadog",
+		map[string]string{
+			"enabled": strconv.FormatBool(ruleEnabled),
+		},
+		SecurityMonitoringRuleAllowEmptyValues,
+		map[string]interface{}{},
+	)
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each SecurityMonitoringRule create 1 TerraformResource.
+// Need SecurityMonitoringRule ID as ID for terraform resource
+func (g *SecurityMonitoringRuleGenerator) InitResources() error {
+	datadogClientV2 := g.Args["datadogClientV2"].(*datadogV2.APIClient)
+	authV2 := g.Args["authV2"].(context.Context)
+
+	pageSize := int64(1000)
+	resp, _, err := datadogClientV2.SecurityMonitoringApi.ListSecurityMonitoringRules(authV2).PageSize(pageSize).Execute()
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(resp.GetData())
+	return nil
+}


### PR DESCRIPTION
This PR adds support for the following Datadog resources:

- datadog_security_monitoring_default_rule
- datadog_security_monitoring_rule
