### PR TITLE
Properly ignore nested attributes 

### DIFF
--- a/terraformutils/providerwrapper/provider.go
+++ b/terraformutils/providerwrapper/provider.go
@@ -107,7 +107,11 @@ func (p *ProviderWrapper) GetReadOnlyAttributes(resourceTypes []string) (map[str
 func (p *ProviderWrapper) readObjBlocks(block map[string]*configschema.NestedBlock, readOnlyAttributes []string, parent string) []string {
 	for k, v := range block {
 		if len(v.BlockTypes) > 0 {
-			readOnlyAttributes = p.readObjBlocks(v.BlockTypes, readOnlyAttributes, k)
+			if parent == "-1" {
+				readOnlyAttributes = p.readObjBlocks(v.BlockTypes, readOnlyAttributes, k)
+			} else {
+				readOnlyAttributes = p.readObjBlocks(v.BlockTypes, readOnlyAttributes, parent+".[0-9]+."+k)
+			}
 		}
 		fieldCount := 0
 		for key, l := range v.Attributes {
@@ -116,13 +120,13 @@ func (p *ProviderWrapper) readObjBlocks(block map[string]*configschema.NestedBlo
 				switch v.Nesting {
 				case configschema.NestingList:
 					if parent == "-1" {
-						readOnlyAttributes = append(readOnlyAttributes, "^"+k+".[0-9]."+key+"($|\\.[0-9]|\\.#)")
+						readOnlyAttributes = append(readOnlyAttributes, "^"+k+".[0-9]+."+key+"($|\\.[0-9]+|\\.#)")
 					} else {
 						readOnlyAttributes = append(readOnlyAttributes, "^"+parent+".(.*)."+key+"$")
 					}
 				case configschema.NestingSet:
 					if parent == "-1" {
-						readOnlyAttributes = append(readOnlyAttributes, "^"+k+".[0-9]."+key+"$")
+						readOnlyAttributes = append(readOnlyAttributes, "^"+k+".[0-9]+."+key+"$")
 					} else {
 						readOnlyAttributes = append(readOnlyAttributes, "^"+parent+".(.*)."+key+"($|\\.(.*))")
 					}

--- a/terraformutils/providerwrapper/provider_test.go
+++ b/terraformutils/providerwrapper/provider_test.go
@@ -21,8 +21,8 @@ func TestAuthenticationValidate(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		block             map[string]*configschema.NestedBlock
-		ignoredAttributes []string
+		block                map[string]*configschema.NestedBlock
+		ignoredAttributes    []string
 		notIgnoredAttributes []string
 	}{
 		"nesting_set": {map[string]*configschema.NestedBlock{
@@ -50,7 +50,7 @@ func TestAuthenticationValidate(t *testing.T) {
 				Nesting: configschema.NestingList,
 			},
 		}, []string{"nesting_list.0.attribute_one.0.attribute_two_nested.computed_attribute"},
-		[]string{"nesting_list.0.attribute_one.0.attribute_two_nested.required_attribute"}},
+			[]string{"nesting_list.0.attribute_one.0.attribute_two_nested.required_attribute"}},
 	}
 
 	for key, tc := range testCases {

--- a/terraformutils/providerwrapper/provider_test.go
+++ b/terraformutils/providerwrapper/provider_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func TestAuthenticationValidate(t *testing.T) {
-	attribute := map[string]*configschema.Attribute{
+func TestIgnoredAttributes(t *testing.T) {
+	attributes := map[string]*configschema.Attribute{
 		"computed_attribute": {
 			Type:     cty.Number,
 			Computed: true,
@@ -28,7 +28,7 @@ func TestAuthenticationValidate(t *testing.T) {
 		"nesting_set": {map[string]*configschema.NestedBlock{
 			"attribute_one": {
 				Block: configschema.Block{
-					Attributes: attribute,
+					Attributes: attributes,
 				},
 				Nesting: configschema.NestingSet,
 			},
@@ -42,7 +42,7 @@ func TestAuthenticationValidate(t *testing.T) {
 						"attribute_two_nested": {
 							Nesting: configschema.NestingList,
 							Block: configschema.Block{
-								Attributes: attribute,
+								Attributes: attributes,
 							},
 						},
 					},

--- a/terraformutils/providerwrapper/provider_test.go
+++ b/terraformutils/providerwrapper/provider_test.go
@@ -1,0 +1,84 @@
+package providerwrapper //nolint
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/configs/configschema"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestAuthenticationValidate(t *testing.T) {
+	attribute := map[string]*configschema.Attribute{
+		"computed_attribute": {
+			Type:     cty.Number,
+			Computed: true,
+		},
+		"required_attribute": {
+			Type:     cty.String,
+			Required: true,
+		},
+	}
+
+	testCases := map[string]struct {
+		block             map[string]*configschema.NestedBlock
+		ignoredAttributes []string
+		notIgnoredAttributes []string
+	}{
+		"nesting_set": {map[string]*configschema.NestedBlock{
+			"attribute_one": {
+				Block: configschema.Block{
+					Attributes: attribute,
+				},
+				Nesting: configschema.NestingSet,
+			},
+		}, []string{"nesting_set.attribute_one.computed_attribute"},
+			[]string{"nesting_set.attribute_one.required_attribute"}},
+		"nesting_list": {map[string]*configschema.NestedBlock{
+			"attribute_one": {
+				Block: configschema.Block{
+					Attributes: map[string]*configschema.Attribute{},
+					BlockTypes: map[string]*configschema.NestedBlock{
+						"attribute_two_nested": {
+							Nesting: configschema.NestingList,
+							Block: configschema.Block{
+								Attributes: attribute,
+							},
+						},
+					},
+				},
+				Nesting: configschema.NestingList,
+			},
+		}, []string{"nesting_list.0.attribute_one.0.attribute_two_nested.computed_attribute"},
+		[]string{"nesting_list.0.attribute_one.0.attribute_two_nested.required_attribute"}},
+	}
+
+	for key, tc := range testCases {
+		t.Run(key, func(t *testing.T) {
+			provider := ProviderWrapper{}
+			readOnlyAttributes := provider.readObjBlocks(tc.block, []string{}, key)
+			for _, attr := range tc.ignoredAttributes {
+				if ignored := isAttributeIgnored(attr, readOnlyAttributes); !ignored {
+					t.Errorf("attribute \"%s\" was not ignored. Pattern list: %s", attr, readOnlyAttributes)
+				}
+			}
+
+			for _, attr := range tc.notIgnoredAttributes {
+				if ignored := isAttributeIgnored(attr, readOnlyAttributes); ignored {
+					t.Errorf("attribute \"%s\" was ignored. Pattern list: %s", attr, readOnlyAttributes)
+				}
+			}
+		})
+	}
+}
+
+func isAttributeIgnored(name string, patterns []string) bool {
+	ignored := false
+	for _, pattern := range patterns {
+		if match, _ := regexp.MatchString(pattern, name); match {
+			ignored = true
+			break
+		}
+	}
+	return ignored
+}


### PR DESCRIPTION
This PR fixes regex generation for nested attributes. For example, in datadog dashboards the following is possible. The widget attribute has an `ID` field which is `computed`:

```
  widget {
    group_definition {
      widget {
      ...
      }
    }
  }

### attributes
# "widget.0.id"
# "widget.0.group_definition.0.widget.0.id"
```

Resulting rule generations for the above were previously:
```
^group_definition.(.*).id$ 
^widget.[0-9].id($|\.[0-9]|\.#)
```

With the changes in this PR:
```
^widget.[0-9]+.group_definition.(.*).id$ 
^widget.[0-9]+.id($|\.[0-9]+|\.#)
```

-------------------------
The PR also ensures we properly handle nested attributes with `len(attributes) > 9`
