### PR TITLE
Print out errors when wrong region selected

### DIFF
--- a/providers/gcp/gcp_provider.go
+++ b/providers/gcp/gcp_provider.go
@@ -17,6 +17,7 @@ package gcp
 import (
 	"context"
 	"errors"
+	"log"
 	"os"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
@@ -49,10 +50,12 @@ func GetRegions(project string) []string {
 func getRegion(project, regionName string) *compute.Region {
 	computeService, err := compute.NewService(context.Background())
 	if err != nil {
+		log.Println(err)
 		return &compute.Region{}
 	}
 	region, err := computeService.Regions.Get(project, regionName).Do()
 	if err != nil {
+		log.Println(err)
 		return &compute.Region{}
 	}
 	return region


### PR DESCRIPTION
Print out errors when the wrong region selected otherwise some resources silently will not be generated.