### PR TITLE
Add support for referencing dependent resources

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -35,25 +35,26 @@ import (
 )
 
 type ImportOptions struct {
-	Resources     []string
-	Excludes      []string
-	PathPattern   string
-	PathOutput    string
-	State         string
-	Bucket        string
-	Profile       string
-	Verbose       bool
-	Zone          string
-	Regions       []string
-	Projects      []string
-	ResourceGroup string
-	Connect       bool
-	Compact       bool
-	Filter        []string
-	Plan          bool `json:"-"`
-	Output        string
-	RetryCount    int
-	RetrySleepMs  int
+	Resources         []string
+	Excludes          []string
+	PathPattern       string
+	PathOutput        string
+	State             string
+	Bucket            string
+	Profile           string
+	Verbose           bool
+	Zone              string
+	Regions           []string
+	Projects          []string
+	ResourceGroup     string
+	Connect           bool
+	Compact           bool
+	Filter            []string
+	Plan              bool `json:"-"`
+	Output            string
+	RetryCount        int
+	RetrySleepMs      int
+	ShouldReferenceID bool
 }
 
 const DefaultPathPattern = "{output}/{provider}/{service}/"
@@ -206,6 +207,7 @@ func initServiceResources(service string, provider terraformutils.ProviderGenera
 		return err
 	}
 
+	provider.GetService().PopulateReferenceIDValues(options.ShouldReferenceID)
 	provider.GetService().PopulateIgnoreKeys(providerWrapper)
 	provider.GetService().InitialCleanup()
 	log.Println(provider.GetName() + " done importing " + service)
@@ -401,4 +403,5 @@ func baseProviderFlags(flag *pflag.FlagSet, options *ImportOptions, sampleRes, s
 	flag.StringVarP(&options.Output, "output", "O", "hcl", "output format hcl or json")
 	flag.IntVarP(&options.RetryCount, "retry-number", "n", 5, "number of retries to perform when refresh fails")
 	flag.IntVarP(&options.RetrySleepMs, "retry-sleep-ms", "m", 300, "time in ms to sleep between retries")
+	flag.BoolVarP(&options.ShouldReferenceID, "reference-id", "", false, "")
 }

--- a/providers/datadog/dashboard.go
+++ b/providers/datadog/dashboard.go
@@ -25,7 +25,7 @@ var (
 	// DashboardAllowEmptyValues ...
 	DashboardAllowEmptyValues  = []string{"tags."}
 	DashboardReferenceIDValues = map[string]string{
-		"slo_id": "datadog_service_level_objective",
+		"slo_id":   "datadog_service_level_objective",
 		"alert_id": "datadog_monitor",
 	}
 )

--- a/providers/datadog/dashboard.go
+++ b/providers/datadog/dashboard.go
@@ -16,8 +16,6 @@ package datadog
 
 import (
 	"context"
-	"fmt"
-
 	datadogV1 "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
@@ -25,7 +23,11 @@ import (
 
 var (
 	// DashboardAllowEmptyValues ...
-	DashboardAllowEmptyValues = []string{"tags."}
+	DashboardAllowEmptyValues  = []string{"tags."}
+	DashboardReferenceIDValues = map[string]string{
+		"slo_id": "datadog_service_level_objective",
+		"alert_id": "datadog_monitor",
+	}
 )
 
 // DashboardGenerator ...
@@ -37,7 +39,9 @@ func (g *DashboardGenerator) createResources(dashboards []datadogV1.DashboardSum
 	resources := []terraformutils.Resource{}
 	for _, dashboard := range dashboards {
 		resourceName := dashboard.GetId()
-		resources = append(resources, g.createResource(resourceName))
+		resource := g.createResource(resourceName)
+		resource.ReferenceIDValues = DashboardReferenceIDValues
+		resources = append(resources, resource)
 	}
 
 	return resources
@@ -46,7 +50,7 @@ func (g *DashboardGenerator) createResources(dashboards []datadogV1.DashboardSum
 func (g *DashboardGenerator) createResource(dashboardID string) terraformutils.Resource {
 	return terraformutils.NewSimpleResource(
 		dashboardID,
-		fmt.Sprintf("dashboard_%s", dashboardID),
+		dashboardID,
 		"datadog_dashboard",
 		"datadog",
 		DashboardAllowEmptyValues,

--- a/providers/datadog/monitor.go
+++ b/providers/datadog/monitor.go
@@ -16,7 +16,6 @@ package datadog
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -51,7 +50,7 @@ func (g *MonitorGenerator) createResources(monitors []datadogV1.Monitor) []terra
 func (g *MonitorGenerator) createResource(monitorID string) terraformutils.Resource {
 	return terraformutils.NewSimpleResource(
 		monitorID,
-		fmt.Sprintf("monitor_%s", monitorID),
+		monitorID,
 		"datadog_monitor",
 		"datadog",
 		MonitorAllowEmptyValues,

--- a/providers/datadog/service_level_objective.go
+++ b/providers/datadog/service_level_objective.go
@@ -16,7 +16,6 @@ package datadog
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	datadogV1 "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
@@ -47,7 +46,7 @@ func (g *ServiceLevelObjectiveGenerator) createResources(sloList []datadogV1.Ser
 func (g *ServiceLevelObjectiveGenerator) createResource(sloID string) terraformutils.Resource {
 	return terraformutils.NewSimpleResource(
 		sloID,
-		fmt.Sprintf("service_level_objective_%s", sloID),
+		sloID,
 		"datadog_service_level_objective",
 		"datadog",
 		ServiceLevelObjectiveAllowEmptyValues,

--- a/terraformutils/flatmap_test.go
+++ b/terraformutils/flatmap_test.go
@@ -16,7 +16,7 @@ func TestNestedAttributeFiltering(t *testing.T) {
 	ignoreKeys := []*regexp.Regexp{
 		regexp.MustCompile(`^attribute$`),
 	}
-	parser := NewFlatmapParser(attributes, ignoreKeys, []*regexp.Regexp{})
+	parser := NewFlatmapParser(attributes, ignoreKeys, []*regexp.Regexp{}, map[*regexp.Regexp]string{})
 
 	attributesType := cty.Object(map[string]cty.Type{
 		"attribute": cty.String,

--- a/terraformutils/providerwrapper/provider.go
+++ b/terraformutils/providerwrapper/provider.go
@@ -106,7 +106,7 @@ func (p *ProviderWrapper) GetReadOnlyAttributes(resourceTypes []string) (map[str
 			for k, v := range obj.Block.Attributes {
 				if !v.Optional && !v.Required {
 					if v.Type.IsListType() || v.Type.IsSetType() {
-						readOnlyAttributes[resourceName] = append(readOnlyAttributes[resourceName], "^"+k+".(.*)")
+						readOnlyAttributes[resourceName] = append(readOnlyAttributes[resourceName], "^"+k+"\\.(.*)")
 					} else {
 						readOnlyAttributes[resourceName] = append(readOnlyAttributes[resourceName], "^"+k+"$")
 					}
@@ -124,7 +124,7 @@ func (p *ProviderWrapper) readObjBlocks(block map[string]*configschema.NestedBlo
 			if parent == "-1" {
 				readOnlyAttributes = p.readObjBlocks(v.BlockTypes, readOnlyAttributes, k)
 			} else {
-				readOnlyAttributes = p.readObjBlocks(v.BlockTypes, readOnlyAttributes, parent+".[0-9]+."+k)
+				readOnlyAttributes = p.readObjBlocks(v.BlockTypes, readOnlyAttributes, parent+"\\.[0-9]+\\."+k)
 			}
 		}
 		fieldCount := 0
@@ -134,20 +134,20 @@ func (p *ProviderWrapper) readObjBlocks(block map[string]*configschema.NestedBlo
 				switch v.Nesting {
 				case configschema.NestingList:
 					if parent == "-1" {
-						readOnlyAttributes = append(readOnlyAttributes, "^"+k+".[0-9]+."+key+"($|\\.[0-9]+|\\.#)")
+						readOnlyAttributes = append(readOnlyAttributes, "^"+k+"\\.[0-9]+\\."+key+"($|\\.[0-9]+|\\.#)")
 					} else {
-						readOnlyAttributes = append(readOnlyAttributes, "^"+parent+".(.*)."+key+"$")
+						readOnlyAttributes = append(readOnlyAttributes, "^"+parent+"\\.(.*)\\."+key+"$")
 					}
 				case configschema.NestingSet:
 					if parent == "-1" {
-						readOnlyAttributes = append(readOnlyAttributes, "^"+k+".[0-9]+."+key+"$")
+						readOnlyAttributes = append(readOnlyAttributes, "^"+k+"\\.[0-9]+\\."+key+"$")
 					} else {
-						readOnlyAttributes = append(readOnlyAttributes, "^"+parent+".(.*)."+key+"($|\\.(.*))")
+						readOnlyAttributes = append(readOnlyAttributes, "^"+parent+"\\.(.*)\\."+key+"($|\\.(.*))")
 					}
 				case configschema.NestingMap:
-					readOnlyAttributes = append(readOnlyAttributes, parent+"."+key)
+					readOnlyAttributes = append(readOnlyAttributes, parent+"\\."+key)
 				default:
-					readOnlyAttributes = append(readOnlyAttributes, parent+"."+key+"$")
+					readOnlyAttributes = append(readOnlyAttributes, parent+"\\."+key+"$")
 				}
 			}
 		}

--- a/terraformutils/resource.go
+++ b/terraformutils/resource.go
@@ -37,6 +37,7 @@ type Resource struct {
 	AllowEmptyValues  []string               `json:",omitempty"`
 	AdditionalFields  map[string]interface{} `json:",omitempty"`
 	SlowQueryRequired bool
+	ReferenceIDValues map[string]string
 }
 
 type ApplicableFilter interface {
@@ -168,7 +169,13 @@ func (r *Resource) ConvertTFstate(provider *providerwrapper.ProviderWrapper) err
 			allowEmptyValues = append(allowEmptyValues, regexp.MustCompile(pattern))
 		}
 	}
-	parser := NewFlatmapParser(r.InstanceState.Attributes, ignoreKeys, allowEmptyValues)
+	referenceIDValues := map[*regexp.Regexp]string{}
+	for k, v := range r.ReferenceIDValues {
+		re := regexp.MustCompile(k)
+		referenceIDValues[re] = v
+	}
+
+	parser := NewFlatmapParser(r.InstanceState.Attributes, ignoreKeys, allowEmptyValues, referenceIDValues)
 	schema := provider.GetSchema()
 	impliedType := schema.ResourceTypes[r.InstanceInfo.Type].Block.ImpliedType()
 	return r.ParseTFstate(parser, impliedType)

--- a/terraformutils/service.go
+++ b/terraformutils/service.go
@@ -38,6 +38,7 @@ type ServiceGenerator interface {
 	InitialCleanup()
 	PopulateIgnoreKeys(*providerwrapper.ProviderWrapper)
 	PostRefreshCleanup()
+	PopulateReferenceIDValues(bool)
 }
 
 type Service struct {
@@ -162,6 +163,15 @@ func (s *Service) PopulateIgnoreKeys(providerWrapper *providerwrapper.ProviderWr
 			if s.Resources[i].InstanceInfo.Type == k {
 				s.Resources[i].IgnoreKeys = append(s.Resources[i].IgnoreKeys, v...)
 			}
+		}
+	}
+}
+
+// PopulateReferenceIDValues set ReferenceIDValues to nil if ShouldReferenceID is false
+func (s *Service) PopulateReferenceIDValues(v bool) {
+	if !v {
+		for i := range s.Resources {
+			s.Resources[i].ReferenceIDValues = map[string]string{}
 		}
 	}
 }


### PR DESCRIPTION
We have a use-case at Datadog where we would like to avoid referencing dependent resources by ID directly. Rather we would like to have an option to reference the resources e.g. `datadog_dashboard.test-dashboard.id`. For example:
```
...
  widget {
    alert_graph_definition {
      alert_id    = "1234567"
    }
  }
....
```
Would become:
```
...
  widget {
    alert_graph_definition {
      alert_id    = "${datadog_monitor.tfer--33212605.id}"
    }
  }
....
```

This option is hidden behind the flag `--reference-id` and should not effect any existing resources or workflows. 

The idea behind this feature is to be able to re-create resources that are interdependent without having to manually update ID's.

See the example usage for the datadog dashboard resource in this PR.  

Additionally, we have thought about using `PostConvertHooks()` to achieve the same behavior but this can get quite messy especially with nested attributes.

Thanks!
