### PR TITLE
Escape period characters and fix output values

### DIFF
--- a/terraformutils/providerwrapper/provider.go
+++ b/terraformutils/providerwrapper/provider.go
@@ -106,7 +106,7 @@ func (p *ProviderWrapper) GetReadOnlyAttributes(resourceTypes []string) (map[str
 			for k, v := range obj.Block.Attributes {
 				if !v.Optional && !v.Required {
 					if v.Type.IsListType() || v.Type.IsSetType() {
-						readOnlyAttributes[resourceName] = append(readOnlyAttributes[resourceName], "^"+k+".(.*)")
+						readOnlyAttributes[resourceName] = append(readOnlyAttributes[resourceName], "^"+k+"\\.(.*)")
 					} else {
 						readOnlyAttributes[resourceName] = append(readOnlyAttributes[resourceName], "^"+k+"$")
 					}
@@ -124,7 +124,7 @@ func (p *ProviderWrapper) readObjBlocks(block map[string]*configschema.NestedBlo
 			if parent == "-1" {
 				readOnlyAttributes = p.readObjBlocks(v.BlockTypes, readOnlyAttributes, k)
 			} else {
-				readOnlyAttributes = p.readObjBlocks(v.BlockTypes, readOnlyAttributes, parent+".[0-9]+."+k)
+				readOnlyAttributes = p.readObjBlocks(v.BlockTypes, readOnlyAttributes, parent+"\\.[0-9]+\\."+k)
 			}
 		}
 		fieldCount := 0
@@ -134,20 +134,20 @@ func (p *ProviderWrapper) readObjBlocks(block map[string]*configschema.NestedBlo
 				switch v.Nesting {
 				case configschema.NestingList:
 					if parent == "-1" {
-						readOnlyAttributes = append(readOnlyAttributes, "^"+k+".[0-9]+."+key+"($|\\.[0-9]+|\\.#)")
+						readOnlyAttributes = append(readOnlyAttributes, "^"+k+"\\.[0-9]+\\."+key+"($|\\.[0-9]+|\\.#)")
 					} else {
-						readOnlyAttributes = append(readOnlyAttributes, "^"+parent+".(.*)."+key+"$")
+						readOnlyAttributes = append(readOnlyAttributes, "^"+parent+"\\.(.*)\\."+key+"$")
 					}
 				case configschema.NestingSet:
 					if parent == "-1" {
-						readOnlyAttributes = append(readOnlyAttributes, "^"+k+".[0-9]+."+key+"$")
+						readOnlyAttributes = append(readOnlyAttributes, "^"+k+"\\.[0-9]+\\."+key+"$")
 					} else {
-						readOnlyAttributes = append(readOnlyAttributes, "^"+parent+".(.*)."+key+"($|\\.(.*))")
+						readOnlyAttributes = append(readOnlyAttributes, "^"+parent+"\\.(.*)\\."+key+"($|\\.(.*))")
 					}
 				case configschema.NestingMap:
-					readOnlyAttributes = append(readOnlyAttributes, parent+"."+key)
+					readOnlyAttributes = append(readOnlyAttributes, parent+"\\."+key)
 				default:
-					readOnlyAttributes = append(readOnlyAttributes, parent+"."+key+"$")
+					readOnlyAttributes = append(readOnlyAttributes, parent+"\\."+key+"$")
 				}
 			}
 		}

--- a/terraformutils/terraformoutput/hcl.go
+++ b/terraformutils/terraformoutput/hcl.go
@@ -52,7 +52,7 @@ func OutputHclFiles(resources []terraformutils.Resource, provider terraformutils
 	for i, r := range resources {
 		outputState := map[string]*terraform.OutputState{}
 		outputsByResource[r.InstanceInfo.Type+"_"+r.ResourceName+"_"+r.GetIDKey()] = map[string]interface{}{
-			"value": r.InstanceInfo.Type + "." + r.ResourceName + "." + r.GetIDKey(),
+			"value": "${" + r.InstanceInfo.Type + "." + r.ResourceName + "." + r.GetIDKey() + "}",
 		}
 		outputState[r.InstanceInfo.Type+"_"+r.ResourceName+"_"+r.GetIDKey()] = &terraform.OutputState{
 			Type:  "string",
@@ -68,7 +68,7 @@ func OutputHclFiles(resources []terraformutils.Resource, provider terraformutils
 						}
 						linkKey := r.InstanceInfo.Type + "_" + r.ResourceName + "_" + key
 						outputsByResource[linkKey] = map[string]interface{}{
-							"value": r.InstanceInfo.Type + "." + r.ResourceName + "." + key,
+							"value": "${" + r.InstanceInfo.Type + "." + r.ResourceName + "." + key + "}",
 						}
 						outputState[linkKey] = &terraform.OutputState{
 							Type:  "string",


### PR DESCRIPTION
This PR includes 2 fixes:

1) Escape period (".") characters in the generated exclude regexes. 

2) Fix output values. Current behavior is the generated output is interpreted as a string rather than an interpolated value:
```
output "datadog_dashboard_tfer--dashboard_aat-002D-zsc-002D-rag_id" {
  value = "datadog_dashboard.tfer--dashboard_aat-002D-zsc-002D-rag.id"
}

$ terraform apply
> Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
Outputs:
datadog_dashboard_tfer--dashboard_aat-002D-zsc-002D-rag_id = datadog_dashboard.tfer--dashboard_aat-002D-zsc-002D-rag.id
```