### PR TITLE
Remove filter requirement for Datadog SLO resource

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -63,7 +63,6 @@ List of supported Datadog services:
     * `datadog_security_monitoring_rule`
 *   `service_level_objective`
     * `datadog_service_level_objective`
-        * **_NOTE:_** Importing resource requires resource ID's to be passed via [Filter][1] option
 *   `synthetics`
     * `datadog_synthetics_test`
 *   `synthetics_global_variables`

--- a/providers/datadog/service_level_objective.go
+++ b/providers/datadog/service_level_objective.go
@@ -17,6 +17,7 @@ package datadog
 import (
 	"context"
 	"fmt"
+
 	datadogV1 "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"

--- a/providers/datadog/service_level_objective.go
+++ b/providers/datadog/service_level_objective.go
@@ -17,8 +17,6 @@ package datadog
 import (
 	"context"
 	"fmt"
-	"log"
-
 	datadogV1 "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
@@ -62,26 +60,12 @@ func (g *ServiceLevelObjectiveGenerator) InitResources() error {
 	authV1 := g.Args["authV1"].(context.Context)
 
 	var slos []datadogV1.ServiceLevelObjective
-	for _, filter := range g.Filter {
-		if filter.FieldPath == "id" && filter.IsApplicable("service_level_objective") {
-			for _, v := range filter.AcceptableValues {
-				resp, _, err := datadogClientV1.ServiceLevelObjectivesApi.GetSLO(authV1, v).Execute()
-				if err != nil {
-					log.Printf("error retrieving slo id:%s - %s", v, err)
-					continue
-				}
-
-				data := resp.GetData()
-				slos = append(slos, data)
-			}
-		}
+	resp, _, err := datadogClientV1.ServiceLevelObjectivesApi.ListSLOs(authV1).Execute()
+	if err != nil {
+		return err
 	}
 
-	if len(slos) == 0 {
-		log.Print("Filter(SLO IDs) is required for importing datadog_service_level_objective resource")
-		return nil
-	}
-
+	slos = append(slos, resp.GetData()...)
 	g.Resources = g.createResources(slos)
 	return nil
 }


### PR DESCRIPTION
It is now possible to list all SLO's for the datadog resource without having to manually specify an id. This PR removes the previous constraint set to require `id` to be passed.