### PR TITLE
Add PagerDuty Provider

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,8 +32,7 @@ jobs:
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: ${{ github.event.inputs.version }}
           prerelease: false
           files: |
             terraformer-*
-      - name: Create new tag
-        run: git tag ${{ github.event.inputs.version }}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A CLI tool that generates `tf`/`json` and `tfstate` files based on existing infr
     * Monitoring & System Management
         * [Datadog](/docs/datadog.md)
         * [New Relic](/docs/relic.md)
+        * [PagerDuty](/docs/pagerduty.md)
     * Community
         * [Keycloak](/docs/keycloak.md)
         * [Logz.io](/docs/logz.md)
@@ -118,9 +119,9 @@ To import resources from all services, use `--resources="*"` . If you want to ex
 
 Filters are a way to choose which resources `terraformer` imports. It's possible to filter resources by its identifiers or attributes. Multiple filtering values are separated by `:`. If an identifier contains this symbol, value should be wrapped in `'` e.g. `--filter=resource=id1:'project:dataset_id'`. Identifier based filters will be executed before Terraformer will try to refresh remote state.
 
-Use `Type` when you need to filter only one of several types of resources. Multiple filters can be combined when importing different resource types. An example would be importing all AWS security groups from a specific AWS VPC: 
+Use `Type` when you need to filter only one of several types of resources. Multiple filters can be combined when importing different resource types. An example would be importing all AWS security groups from a specific AWS VPC:
 ```
-terraformer import aws -r sg,vpc --filter Type=sg;Name=vpc_id;Value=VPC_ID --filter Type=vpc;Name=id;Value=VPC_ID 
+terraformer import aws -r sg,vpc --filter Type=sg;Name=vpc_id;Value=VPC_ID --filter Type=vpc;Name=id;Value=VPC_ID
 ```
 Notice how the `Name` is different for `sg` than it is for `vpc`.
 
@@ -266,6 +267,7 @@ Links to download Terraform Providers:
 * Monitoring & System Management
     * Datadog provider >2.1.0 - [here](https://releases.hashicorp.com/terraform-provider-datadog/)
     * New Relic provider >2.0.0 - [here](https://releases.hashicorp.com/terraform-provider-newrelic/)
+    * Pagerduty >=1.9 - [here](https://releases.hashicorp.com/terraform-provider-pagerduty/)
 * Community
     * Keycloak provider >=1.19.0 - [here](https://github.com/mrparkers/terraform-provider-keycloak/)
     * Logz.io provider >=1.1.1 - [here](https://github.com/jonboydell/logzio_terraform_provider/)

--- a/cmd/provider_cmd_pagerduty.go
+++ b/cmd/provider_cmd_pagerduty.go
@@ -1,0 +1,47 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cmd
+
+import (
+	pagerduty_terraforming "github.com/GoogleCloudPlatform/terraformer/providers/pagerduty"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/spf13/cobra"
+)
+
+func newCmdPagerDutyImporter(options ImportOptions) *cobra.Command {
+	token := ""
+	cmd := &cobra.Command{
+		Use:   "pagerduty",
+		Short: "Import current state to Terraform configuration from PagerDuty",
+		Long:  "Import current state to Terraform configuration from PagerDuty",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			provider := newPagerDutyProvider()
+			err := Import(provider, options, []string{token})
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.AddCommand(listCmd(newPagerDutyProvider()))
+	cmd.PersistentFlags().StringVarP(&token, "token", "t", "", "env param PAGERDUTY_TOKEN")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "user", "user=id1:id2:id4")
+	return cmd
+}
+
+func newPagerDutyProvider() terraformutils.ProviderGenerator {
+	return &pagerduty_terraforming.PagerDutyProvider{}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,6 +67,7 @@ func providerImporterSubcommands() []func(options ImportOptions) *cobra.Command 
 		newCmdDatadogImporter,
 		newCmdNewRelicImporter,
 		newCmdGrafanaImporter,
+		newCmdPagerDutyImporter,
 		// Community
 		newCmdKeycloakImporter,
 		newCmdLogzioImporter,
@@ -107,6 +108,7 @@ func providerGenerators() map[string]func() terraformutils.ProviderGenerator {
 		// Monitoring & System Management
 		newDataDogProvider,
 		newNewRelicProvider,
+		newPagerDutyProvider,
 		// Community
 		newKeycloakProvider,
 		newLogzioProvider,

--- a/docs/pagerduty.md
+++ b/docs/pagerduty.md
@@ -1,0 +1,28 @@
+### Use with PagerDuty
+
+Example:
+
+```
+./terraformer import pagerduty -r team,schedule,user  -t YOUR_PAGERDUTY_TOKEN // or PAGERDUTY_TOKEN in env
+```
+Instructions to obtain a Auth Token: https://developer.pagerduty.com/docs/rest-api-v2/authentication/
+
+List of supported PagerDuty resources:
+
+* `business_service`
+  * `pagerduty_business_service`
+* `escalation_policy`
+  * `pagerduty_escalation_policy`
+* `ruleset`
+  * `pagerduty_ruleset`
+  * `pagerduty_ruleset_rule`
+* `schedule`
+  * `pagerduty_schedule`
+* `service`
+  * `pagerduty_service`
+  * `pagerduty_service_event_rule`
+* `team`
+  * `pagerduty_team`
+  * `pagerduty_team_membership`
+* `user`
+  * `pagerduty_user`

--- a/go.mod
+++ b/go.mod
@@ -110,6 +110,7 @@ require (
 	github.com/hashicorp/go-plugin v1.4.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/terraform v0.12.29
+	github.com/heimweh/go-pagerduty v0.0.0-20210412205347-cc0e5d3c14d4
 	github.com/heroku/heroku-go/v5 v5.1.0
 	github.com/hokaccha/go-prettyjson v0.0.0-20210113012101-fb4e108d2519 // indirect
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334

--- a/go.sum
+++ b/go.sum
@@ -689,6 +689,8 @@ github.com/hashicorp/vault v0.10.4/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bA
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/heimweh/go-pagerduty v0.0.0-20210412205347-cc0e5d3c14d4 h1:uyHgKwTluKHt2ctmyZfdVxECwSqYflYDo+RwyZZEdR0=
+github.com/heimweh/go-pagerduty v0.0.0-20210412205347-cc0e5d3c14d4/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/heroku/heroku-go/v5 v5.1.0 h1:3Qx1MxjzczSakhAZN4yRsvCI7kP0ldijK1XvfoYa4DE=
 github.com/heroku/heroku-go/v5 v5.1.0/go.mod h1:d+1QrZyjbnQJG1f8xIoVvMQRFLt3XRVZOdlm26Sr73U=
 github.com/hokaccha/go-prettyjson v0.0.0-20210113012101-fb4e108d2519 h1:nqAlWFEdqI0ClbTDrhDvE/8LeQ4pftrqKUX9w5k0j3s=

--- a/providers/pagerduty/business_service.go
+++ b/providers/pagerduty/business_service.go
@@ -1,0 +1,63 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pagerduty
+
+import (
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	pagerduty "github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+type BusinessServiceGenerator struct {
+	PagerDutyService
+}
+
+func (g *BusinessServiceGenerator) createBusinessServiceResources(client *pagerduty.Client) error {
+	resp, _, err := client.BusinessServices.List()
+	if err != nil {
+		return err
+	}
+
+	for _, service := range resp.BusinessServices {
+		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+			service.ID,
+			service.Name,
+			"pagerduty_business_service",
+			g.ProviderName,
+			[]string{},
+		))
+	}
+
+	return nil
+}
+
+func (g *BusinessServiceGenerator) InitResources() error {
+	client, err := g.Client()
+	if err != nil {
+		return err
+	}
+
+	funcs := []func(*pagerduty.Client) error{
+		g.createBusinessServiceResources,
+	}
+
+	for _, f := range funcs {
+		err := f(client)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/providers/pagerduty/escalation_policy.go
+++ b/providers/pagerduty/escalation_policy.go
@@ -1,0 +1,73 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pagerduty
+
+import (
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	pagerduty "github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+type EscalationPolicyGenerator struct {
+	PagerDutyService
+}
+
+func (g *EscalationPolicyGenerator) createEscalationPolicyResources(client *pagerduty.Client) error {
+	var offset = 0
+	options := pagerduty.ListEscalationPoliciesOptions{}
+	for {
+		options.Offset = offset
+		resp, _, err := client.EscalationPolicies.List(&options)
+		if err != nil {
+			return err
+		}
+
+		for _, policy := range resp.EscalationPolicies {
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				policy.ID,
+				policy.Name,
+				"pagerduty_escalation_policy",
+				g.ProviderName,
+				[]string{},
+			))
+		}
+
+		if resp.More != true {
+			break
+		}
+
+		offset += resp.Limit
+	}
+	return nil
+}
+
+func (g *EscalationPolicyGenerator) InitResources() error {
+	client, err := g.Client()
+	if err != nil {
+		return err
+	}
+
+	funcs := []func(*pagerduty.Client) error{
+		g.createEscalationPolicyResources,
+	}
+
+	for _, f := range funcs {
+		err := f(client)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/providers/pagerduty/pagerduty_provider.go
+++ b/providers/pagerduty/pagerduty_provider.go
@@ -1,0 +1,89 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pagerduty
+
+import (
+	"errors"
+	"os"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type PagerDutyProvider struct { //nolint
+	terraformutils.Provider
+	token string
+}
+
+func (p *PagerDutyProvider) Init(args []string) error {
+	if token := os.Getenv("PAGERDUTY_TOKEN"); token != "" {
+		p.token = os.Getenv("PAGERDUTY_TOKEN")
+	}
+	if len(args) > 0 {
+		p.token = args[0]
+	}
+	return nil
+}
+
+func (p *PagerDutyProvider) GetName() string {
+	return "pagerduty"
+}
+
+func (p *PagerDutyProvider) GetConfig() cty.Value {
+	return cty.ObjectVal(map[string]cty.Value{
+		"token": cty.StringVal(p.token),
+	})
+}
+
+func (p *PagerDutyProvider) GetProviderData(arg ...string) map[string]interface{} {
+	return map[string]interface{}{
+		"provider": map[string]interface{}{
+			"pagerduty": map[string]interface{}{
+				"token": p.token,
+			},
+		},
+	}
+}
+
+func (PagerDutyProvider) GetResourceConnections() map[string]map[string][]string {
+	return map[string]map[string][]string{}
+}
+
+func (p *PagerDutyProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
+	return map[string]terraformutils.ServiceGenerator{
+		"business_service":  &BusinessServiceGenerator{},
+		"escalation_policy": &EscalationPolicyGenerator{},
+		"ruleset":           &RulesetGenerator{},
+		"schedule":          &ScheduleGenerator{},
+		"service":           &ServiceGenerator{},
+		"team":              &TeamGenerator{},
+		"user":              &UserGenerator{},
+	}
+}
+
+func (p *PagerDutyProvider) InitService(serviceName string, verbose bool) error {
+	var isSupported bool
+	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
+	}
+	p.Service = p.GetSupportedService()[serviceName]
+	p.Service.SetName(serviceName)
+	p.Service.SetVerbose(verbose)
+	p.Service.SetProviderName(p.GetName())
+	p.Service.SetArgs(map[string]interface{}{
+		"token": p.token,
+	})
+	return nil
+}

--- a/providers/pagerduty/pagerduty_service.go
+++ b/providers/pagerduty/pagerduty_service.go
@@ -1,0 +1,32 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pagerduty
+
+import (
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	pagerduty "github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+type PagerDutyService struct { //nolint
+	terraformutils.Service
+}
+
+func (s *PagerDutyService) Client() (*pagerduty.Client, error) {
+	client, err := pagerduty.NewClient(&pagerduty.Config{Token: s.GetArgs()["token"].(string)})
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}

--- a/providers/pagerduty/ruleset.go
+++ b/providers/pagerduty/ruleset.go
@@ -1,0 +1,89 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pagerduty
+
+import (
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	pagerduty "github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+type RulesetGenerator struct {
+	PagerDutyService
+}
+
+func (g *RulesetGenerator) createRulesetResources(client *pagerduty.Client) error {
+	resp, _, err := client.Rulesets.List()
+	if err != nil {
+		return err
+	}
+
+	for _, ruleset := range resp.Rulesets {
+		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+			ruleset.ID,
+			ruleset.Name,
+			"pagerduty_ruleset",
+			g.ProviderName,
+			[]string{},
+		))
+	}
+
+	return nil
+}
+
+func (g *RulesetGenerator) createRulesetRuleResources(client *pagerduty.Client) error {
+	resp, _, err := client.Rulesets.List()
+	if err != nil {
+		return err
+	}
+
+	for _, ruleset := range resp.Rulesets {
+		rules, _, err := client.Rulesets.ListRules(ruleset.ID)
+		if err != nil {
+			return err
+		}
+
+		for _, rule := range rules.Rules {
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				rule.ID,
+				rule.ID,
+				"pagerduty_ruleset_rule",
+				g.ProviderName,
+				[]string{},
+			))
+		}
+	}
+
+	return nil
+}
+
+func (g *RulesetGenerator) InitResources() error {
+	client, err := g.Client()
+	if err != nil {
+		return err
+	}
+
+	funcs := []func(*pagerduty.Client) error{
+		g.createRulesetResources,
+	}
+
+	for _, f := range funcs {
+		err := f(client)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/providers/pagerduty/schedule.go
+++ b/providers/pagerduty/schedule.go
@@ -1,0 +1,75 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pagerduty
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	pagerduty "github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+type ScheduleGenerator struct {
+	PagerDutyService
+}
+
+func (g *ScheduleGenerator) createScheduleResources(client *pagerduty.Client) error {
+	var offset = 0
+	options := pagerduty.ListSchedulesOptions{}
+	for {
+		options.Offset = offset
+		resp, _, err := client.Schedules.List(&options)
+		if err != nil {
+			return err
+		}
+
+		for _, schedule := range resp.Schedules {
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				schedule.ID,
+				fmt.Sprintf("schedule_%s", schedule.Name),
+				"pagerduty_schedule",
+				g.ProviderName,
+				[]string{},
+			))
+		}
+		if resp.More != true {
+			break
+		}
+
+		offset += resp.Limit
+	}
+
+	return nil
+}
+
+func (g *ScheduleGenerator) InitResources() error {
+	client, err := g.Client()
+	if err != nil {
+		return err
+	}
+
+	funcs := []func(*pagerduty.Client) error{
+		g.createScheduleResources,
+	}
+
+	for _, f := range funcs {
+		err := f(client)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/providers/pagerduty/service.go
+++ b/providers/pagerduty/service.go
@@ -1,0 +1,104 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pagerduty
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	pagerduty "github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+type ServiceGenerator struct {
+	PagerDutyService
+}
+
+func (g *ServiceGenerator) createServiceResources(client *pagerduty.Client) error {
+	var offset = 0
+	options := pagerduty.ListServicesOptions{}
+	for {
+		options.Offset = offset
+		resp, _, err := client.Services.List(&pagerduty.ListServicesOptions{})
+		if err != nil {
+			return err
+		}
+
+		for _, service := range resp.Services {
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				service.ID,
+				fmt.Sprintf("service_%s", service.Name),
+				"pagerduty_service",
+				g.ProviderName,
+				[]string{},
+			))
+		}
+
+		if resp.More != true {
+			break
+		}
+
+		offset += resp.Limit
+	}
+
+	return nil
+}
+
+func (g *ServiceGenerator) createServiceEventRuleResources(client *pagerduty.Client) error {
+	resp, _, err := client.Services.List(&pagerduty.ListServicesOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, service := range resp.Services {
+		rules, _, err := client.Services.ListEventRules(service.ID, &pagerduty.ListServiceEventRuleOptions{})
+
+		if err != nil {
+			return err
+		}
+
+		for _, rule := range rules.EventRules {
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				fmt.Sprintf("%s.%s", service.ID, rule.ID),
+				fmt.Sprintf("%s_%s", service.Name, rule.ID),
+				"pagerduty_service_event_rule",
+				g.ProviderName,
+				[]string{},
+			))
+		}
+	}
+
+	return nil
+}
+
+func (g *ServiceGenerator) InitResources() error {
+	client, err := g.Client()
+	if err != nil {
+		return err
+	}
+
+	funcs := []func(*pagerduty.Client) error{
+		g.createServiceResources,
+		g.createServiceEventRuleResources,
+	}
+
+	for _, f := range funcs {
+		err := f(client)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/providers/pagerduty/team.go
+++ b/providers/pagerduty/team.go
@@ -1,0 +1,116 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pagerduty
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	pagerduty "github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+type TeamGenerator struct {
+	PagerDutyService
+}
+
+func (g *TeamGenerator) createTeamResources(client *pagerduty.Client) error {
+	var offset = 0
+	options := pagerduty.ListTeamsOptions{}
+	for {
+		options.Offset = offset
+		resp, _, err := client.Teams.List(&options)
+		if err != nil {
+			return err
+		}
+
+		for _, team := range resp.Teams {
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				team.ID,
+				fmt.Sprintf("Team_%s", team.Name),
+				"pagerduty_team",
+				g.ProviderName,
+				[]string{},
+			))
+		}
+		if resp.More != true {
+			break
+		}
+
+		offset += resp.Limit
+	}
+
+	return nil
+}
+
+func (g *TeamGenerator) createTeamMembershipResources(client *pagerduty.Client) error {
+	var teamOffset = 0
+	teamOptions := pagerduty.ListTeamsOptions{}
+
+	for {
+		teamOptions.Offset = teamOffset
+		resp, _, err := client.Teams.List(&teamOptions)
+		if err != nil {
+			return err
+		}
+
+		memberOptions := pagerduty.GetMembersOptions{}
+		for _, team := range resp.Teams {
+			members, _, err := client.Teams.GetMembers(team.ID, &memberOptions)
+
+			if err != nil {
+				return err
+			}
+
+			for _, member := range members.Members {
+				g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+					fmt.Sprintf("%s:%s", member.User.ID, team.ID),
+					fmt.Sprintf("%s_%s", member.User.ID, team.Name),
+					"pagerduty_team_membership",
+					g.ProviderName,
+					[]string{},
+				))
+			}
+		}
+
+		if resp.More != true {
+			break
+		}
+
+		teamOffset += resp.Limit
+	}
+
+	return nil
+}
+
+func (g *TeamGenerator) InitResources() error {
+	client, err := g.Client()
+	if err != nil {
+		return err
+	}
+
+	funcs := []func(*pagerduty.Client) error{
+		g.createTeamResources,
+		g.createTeamMembershipResources,
+	}
+
+	for _, f := range funcs {
+		err := f(client)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/providers/pagerduty/user.go
+++ b/providers/pagerduty/user.go
@@ -1,0 +1,76 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pagerduty
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	pagerduty "github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+type UserGenerator struct {
+	PagerDutyService
+}
+
+func (g *UserGenerator) createUserResources(client *pagerduty.Client) error {
+	var offset = 0
+	options := pagerduty.ListUsersOptions{}
+	for {
+		options.Offset = offset
+		resp, _, err := client.Users.List(&options)
+		if err != nil {
+			return err
+		}
+
+		for _, user := range resp.Users {
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				user.ID,
+				fmt.Sprintf("user_%s", user.ID),
+				"pagerduty_user",
+				g.ProviderName,
+				[]string{},
+			))
+		}
+
+		if resp.More != true {
+			break
+		}
+
+		offset += resp.Limit
+	}
+
+	return nil
+}
+
+func (g *UserGenerator) InitResources() error {
+	client, err := g.Client()
+	if err != nil {
+		return err
+	}
+
+	funcs := []func(*pagerduty.Client) error{
+		g.createUserResources,
+	}
+
+	for _, f := range funcs {
+		err := f(client)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds a provider for PagerDuty that is able to collect business_services, escalation_policy, ruleset, shcedule, service, team and users from the PagerDuty API.