### PR TITLE
Issue #911. Add a --validate arg for the datadog provider

### DIFF
--- a/cmd/provider_cmd_datadog.go
+++ b/cmd/provider_cmd_datadog.go
@@ -20,14 +20,14 @@ import (
 )
 
 func newCmdDatadogImporter(options ImportOptions) *cobra.Command {
-	var apiKey, appKey, apiURL string
+	var apiKey, appKey, apiURL, validate string
 	cmd := &cobra.Command{
 		Use:   "datadog",
 		Short: "Import current state to Terraform configuration from Datadog",
 		Long:  "Import current state to Terraform configuration from Datadog",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			provider := newDataDogProvider()
-			err := Import(provider, options, []string{apiKey, appKey, apiURL})
+			err := Import(provider, options, []string{apiKey, appKey, apiURL, validate})
 			if err != nil {
 				return err
 			}
@@ -39,6 +39,7 @@ func newCmdDatadogImporter(options ImportOptions) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&apiKey, "api-key", "", "", "YOUR_DATADOG_API_KEY or env param DATADOG_API_KEY")
 	cmd.PersistentFlags().StringVarP(&appKey, "app-key", "", "", "YOUR_DATADOG_APP_KEY or env param DATADOG_APP_KEY")
 	cmd.PersistentFlags().StringVarP(&apiURL, "api-url", "", "", "YOUR_DATADOG_API_URL or env param DATADOG_HOST")
+	cmd.PersistentFlags().StringVar(&validate, "validate", "", "bool-parsable values only or env param DATADOG_VALIDATE. Enables validation of the provided API and APP keys during provider initialization. Default is true. When false, api_key and app_key won't be checked")
 	return cmd
 }
 

--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -3,8 +3,8 @@
 Example:
 
 ```
- ./terraformer import datadog --resources=monitor --api-key=YOUR_DATADOG_API_KEY // or DATADOG_API_KEY in env --app-key=YOUR_DATADOG_APP_KEY // or DATADOG_APP_KEY in env --api-url=DATADOG_API_URL // or DATADOG_HOST in env
- ./terraformer import datadog --resources=monitor --filter=monitor=id1:id2:id4 --api-key=YOUR_DATADOG_API_KEY // or DATADOG_API_KEY in env --app-key=YOUR_DATADOG_APP_KEY // or DATADOG_APP_KEY in env
+ ./terraformer import datadog --resources=monitor --api-key=YOUR_DATADOG_API_KEY // or DATADOG_API_KEY in env --app-key=YOUR_DATADOG_APP_KEY // or DATADOG_APP_KEY in env --api-url=DATADOG_API_URL // or DATADOG_HOST in env --validate=VALIDATE_BOOL // or DATADOG_VALIDATE in env
+ ./terraformer import datadog --resources=monitor --filter=monitor=id1:id2:id4 --api-key=YOUR_DATADOG_API_KEY // or DATADOG_API_KEY in env --app-key=YOUR_DATADOG_APP_KEY // or DATADOG_APP_KEY in env --validate=VALIDATE_BOOL // or DATADOG_VALIDATE in env
 ```
 
 List of supported Datadog services:


### PR DESCRIPTION
This complies with the corresponding [schema arg](https://registry.terraform.io/providers/DataDog/datadog/latest/docs#schema). It is passed as a string and parsed to a bool and complies with the existing convention of giving priority to the arg before the env var DATADOG_VALIDATE. It defaults to true to comply with the provider schema behavior

I didn't run the tests because I wasn't sure about this warning:
```
The script will create and destroy real resources. Never run this on a production Datadog organization.
```
How should I test this so it's safe? I built it locally and It works for what I am trying to accomplish