### PR TITLE
Update Datadog api client and various fixes

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -11,6 +11,8 @@ List of supported Datadog services:
 
 *   `dashboard`
     * `datadog_dashboard`
+*   `dashboard_json`
+    * `datadog_dashboard_json`
 *   `dashboard_list`
     * `datadog_dashboard_list`
 *   `downtime`
@@ -63,7 +65,7 @@ List of supported Datadog services:
     * `datadog_security_monitoring_rule`
 *   `service_level_objective`
     * `datadog_service_level_objective`
-*   `synthetics`
+*   `synthetics_test`
     * `datadog_synthetics_test`
 *   `synthetics_global_variables`
     * `datadog_synthetics_global_variables`

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v42.3.0+incompatible
 	github.com/Azure/azure-storage-blob-go v0.10.0
 	github.com/Azure/go-autorest/autorest v0.11.12
-	github.com/DataDog/datadog-api-client-go v1.0.0-beta.18
+	github.com/DataDog/datadog-api-client-go v1.0.0-beta.20
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20210203095940-db28d5e07b55
 	github.com/IBM/go-sdk-core/v3 v3.3.1
 	github.com/IBM/go-sdk-core/v4 v4.9.0

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,11 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
 github.com/DataDog/datadog-api-client-go v1.0.0-beta.18 h1:4i51yRTWm8SEuc9iRxxFicm59jQcAo70v+3ddZhEq8Q=
 github.com/DataDog/datadog-api-client-go v1.0.0-beta.18/go.mod h1:Gn0fZwIOBbSidO0OaPEh9nO5EmIPsxJrHfHvfVXEaoU=
+github.com/DataDog/datadog-api-client-go v1.0.0-beta.20 h1:VwdZv6Mm4d7Jx9qawTNM6FlShdlE1d/J+64X3Izd574=
+github.com/DataDog/datadog-api-client-go v1.0.0-beta.20/go.mod h1:T4YUFSUXoBbhxY5qq5V/1llk5U1o6vTjYFS3dk3uH74=
 github.com/DataDog/datadog-go v4.4.0+incompatible h1:R7WqXWP4fIOAqWJtUKmSfuc7eDsBT58k9AY5WSHVosk=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/DataDog/gostackparse v0.5.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
 github.com/IBM-Cloud/bluemix-go v0.0.0-20210203095940-db28d5e07b55 h1:sUpBb2/GC8L6UOKDnbEZLRTxQB2RQgMv1mxbnOHOQW4=
 github.com/IBM-Cloud/bluemix-go v0.0.0-20210203095940-db28d5e07b55/go.mod h1:kqTYO0mts71aa8PVwviaKlCKYud/NbEkFIqU8aHH3/g=
 github.com/IBM/go-sdk-core v1.1.0 h1:pV73lZqr9r1xKb3h08c1uNG3AphwoV5KzUzhS+pfEqY=
@@ -429,6 +432,7 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/go-bdd/assert v0.0.0-20190820124234-20d47a68475d/go.mod h1:dOoqt7g2I/fpR7/Pyz0P19J3xjDj5lsHn3v9EaFLRjM=
 github.com/go-bdd/gobdd v1.1.3-0.20210205100305-4910f932a786 h1:upeQpV8AFGWxWvlu2LpJojgvWOU2SyiG+XvYerMGaCw=
 github.com/go-bdd/gobdd v1.1.3-0.20210205100305-4910f932a786/go.mod h1:Q3mXpW/Qm9GJCPLxFCTXdTtRBdHzcTfrbeLlaqAPtXM=
+github.com/go-bdd/gobdd v1.1.3/go.mod h1:Q3mXpW/Qm9GJCPLxFCTXdTtRBdHzcTfrbeLlaqAPtXM=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -1440,6 +1444,7 @@ google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/DataDog/dd-trace-go.v1 v1.29.0-rc.1.0.20210226170446-a8dc39ec3484 h1:gv8e5qO2QJPaYAcGrgu4jex1zo4IlxKxzmUSQ++sufQ=
 gopkg.in/DataDog/dd-trace-go.v1 v1.29.0-rc.1.0.20210226170446-a8dc39ec3484/go.mod h1:H9vSLD4Qlnl3rH2fUT6jyP9qwq1lDo0ikaDqSJo8t/U=
+gopkg.in/DataDog/dd-trace-go.v1 v1.30.0-rc.1.0.20210420124628-f63633f38e8f/go.mod h1:I3nUNop4UZaHSj2C2OBCHezmsQIHczbUps8nHgw/HXs=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/providers/datadog/dashboard.go
+++ b/providers/datadog/dashboard.go
@@ -64,7 +64,7 @@ func (g *DashboardGenerator) InitResources() error {
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "id" && filter.IsApplicable("dashboard") {
 			for _, value := range filter.AcceptableValues {
-				dashboard, _, err := datadogClientV1.DashboardsApi.GetDashboard(authV1, value).Execute()
+				dashboard, _, err := datadogClientV1.DashboardsApi.GetDashboard(authV1, value)
 				if err != nil {
 					return err
 				}
@@ -79,7 +79,7 @@ func (g *DashboardGenerator) InitResources() error {
 		return nil
 	}
 
-	summary, _, err := datadogClientV1.DashboardsApi.ListDashboards(authV1).Execute()
+	summary, _, err := datadogClientV1.DashboardsApi.ListDashboards(authV1)
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/dashboard_json.go
+++ b/providers/datadog/dashboard_json.go
@@ -24,52 +24,52 @@ import (
 )
 
 var (
-	// SyntheticsAllowEmptyValues ...
-	SyntheticsAllowEmptyValues = []string{"tags."}
+	// DashboardJsonAllowEmptyValues ...
+	DashboardJsonAllowEmptyValues = []string{"tags."}
 )
 
-// SyntheticsGenerator ...
-type SyntheticsGenerator struct {
+// DashboardJsonGenerator ...
+type DashboardJsonGenerator struct {
 	DatadogService
 }
 
-func (g *SyntheticsGenerator) createResources(syntheticsList []datadogV1.SyntheticsTestDetails) []terraformutils.Resource {
+func (g *DashboardJsonGenerator) createResources(dashboards []datadogV1.DashboardSummaryDefinition) []terraformutils.Resource {
 	resources := []terraformutils.Resource{}
-	for _, synthetics := range syntheticsList {
-		resourceName := synthetics.GetPublicId()
+	for _, dashboard := range dashboards {
+		resourceName := dashboard.GetId()
 		resources = append(resources, g.createResource(resourceName))
 	}
 
 	return resources
 }
 
-func (g *SyntheticsGenerator) createResource(syntheticsID string) terraformutils.Resource {
+func (g *DashboardJsonGenerator) createResource(dashboard_jsonID string) terraformutils.Resource {
 	return terraformutils.NewSimpleResource(
-		syntheticsID,
-		fmt.Sprintf("synthetics_%s", syntheticsID),
-		"datadog_synthetics_test",
+		dashboard_jsonID,
+		fmt.Sprintf("dashboard_json_%s", dashboard_jsonID),
+		"datadog_dashboard_json",
 		"datadog",
-		SyntheticsAllowEmptyValues,
+		DashboardJsonAllowEmptyValues,
 	)
 }
 
 // InitResources Generate TerraformResources from Datadog API,
-// from each synthetics create 1 TerraformResource.
-// Need Synthetics ID as ID for terraform resource
-func (g *SyntheticsGenerator) InitResources() error {
+// from each dashboard_json create 1 TerraformResource.
+// Need Dashboard ID as ID for terraform resource
+func (g *DashboardJsonGenerator) InitResources() error {
 	datadogClientV1 := g.Args["datadogClientV1"].(*datadogV1.APIClient)
 	authV1 := g.Args["authV1"].(context.Context)
 
 	resources := []terraformutils.Resource{}
 	for _, filter := range g.Filter {
-		if filter.FieldPath == "id" && filter.IsApplicable("synthetics") {
+		if filter.FieldPath == "id" && filter.IsApplicable("dashboard_json") {
 			for _, value := range filter.AcceptableValues {
-				syntheticsTest, _, err := datadogClientV1.SyntheticsApi.GetTest(authV1, value)
+				dashboard, _, err := datadogClientV1.DashboardsApi.GetDashboard(authV1, value)
 				if err != nil {
 					return err
 				}
 
-				resources = append(resources, g.createResource(syntheticsTest.GetPublicId()))
+				resources = append(resources, g.createResource(dashboard.GetId()))
 			}
 		}
 	}
@@ -79,10 +79,10 @@ func (g *SyntheticsGenerator) InitResources() error {
 		return nil
 	}
 
-	syntheticsTests, _, err := datadogClientV1.SyntheticsApi.ListTests(authV1)
+	summary, _, err := datadogClientV1.DashboardsApi.ListDashboards(authV1)
 	if err != nil {
 		return err
 	}
-	g.Resources = g.createResources(syntheticsTests.GetTests())
+	g.Resources = g.createResources(summary.GetDashboards())
 	return nil
 }

--- a/providers/datadog/dashboard_json.go
+++ b/providers/datadog/dashboard_json.go
@@ -24,16 +24,16 @@ import (
 )
 
 var (
-	// DashboardJsonAllowEmptyValues ...
-	DashboardJsonAllowEmptyValues = []string{"tags."}
+	// DashboardJSONAllowEmptyValues ...
+	DashboardJSONAllowEmptyValues = []string{"tags."}
 )
 
-// DashboardJsonGenerator ...
-type DashboardJsonGenerator struct {
+// DashboardJSONGenerator ...
+type DashboardJSONGenerator struct {
 	DatadogService
 }
 
-func (g *DashboardJsonGenerator) createResources(dashboards []datadogV1.DashboardSummaryDefinition) []terraformutils.Resource {
+func (g *DashboardJSONGenerator) createResources(dashboards []datadogV1.DashboardSummaryDefinition) []terraformutils.Resource {
 	resources := []terraformutils.Resource{}
 	for _, dashboard := range dashboards {
 		resourceName := dashboard.GetId()
@@ -43,20 +43,20 @@ func (g *DashboardJsonGenerator) createResources(dashboards []datadogV1.Dashboar
 	return resources
 }
 
-func (g *DashboardJsonGenerator) createResource(dashboard_jsonID string) terraformutils.Resource {
+func (g *DashboardJSONGenerator) createResource(dashboardID string) terraformutils.Resource {
 	return terraformutils.NewSimpleResource(
-		dashboard_jsonID,
-		fmt.Sprintf("dashboard_json_%s", dashboard_jsonID),
+		dashboardID,
+		fmt.Sprintf("dashboard_json_%s", dashboardID),
 		"datadog_dashboard_json",
 		"datadog",
-		DashboardJsonAllowEmptyValues,
+		DashboardJSONAllowEmptyValues,
 	)
 }
 
 // InitResources Generate TerraformResources from Datadog API,
 // from each dashboard_json create 1 TerraformResource.
 // Need Dashboard ID as ID for terraform resource
-func (g *DashboardJsonGenerator) InitResources() error {
+func (g *DashboardJSONGenerator) InitResources() error {
 	datadogClientV1 := g.Args["datadogClientV1"].(*datadogV1.APIClient)
 	authV1 := g.Args["authV1"].(context.Context)
 

--- a/providers/datadog/dashboard_list.go
+++ b/providers/datadog/dashboard_list.go
@@ -61,7 +61,7 @@ func (g *DashboardListGenerator) InitResources() error {
 	datadogClientV1 := g.Args["datadogClientV1"].(*datadogV1.APIClient)
 	authV1 := g.Args["authV1"].(context.Context)
 
-	dlResponse, _, err := datadogClientV1.DashboardListsApi.ListDashboardLists(authV1).Execute()
+	dlResponse, _, err := datadogClientV1.DashboardListsApi.ListDashboardLists(authV1)
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -177,6 +177,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 	return map[string]terraformutils.ServiceGenerator{
 		"dashboard_list":                       &DashboardListGenerator{},
 		"dashboard":                            &DashboardGenerator{},
+		"dashboard_json":                       &DashboardJsonGenerator{},
 		"downtime":                             &DowntimeGenerator{},
 		"logs_archive":                         &LogsArchiveGenerator{},
 		"logs_archive_order":                   &LogsArchiveOrderGenerator{},
@@ -199,7 +200,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"security_monitoring_default_rule":     &SecurityMonitoringDefaultRuleGenerator{},
 		"security_monitoring_rule":             &SecurityMonitoringRuleGenerator{},
 		"service_level_objective":              &ServiceLevelObjectiveGenerator{},
-		"synthetics":                           &SyntheticsGenerator{},
+		"synthetics_test":                      &SyntheticsTestGenerator{},
 		"synthetics_global_variable":           &SyntheticsGlobalVariableGenerator{},
 		"synthetics_private_location":          &SyntheticsPrivateLocationGenerator{},
 		"timeboard":                            &TimeboardGenerator{},
@@ -291,13 +292,13 @@ func (p DatadogProvider) GetResourceConnections() map[string]map[string][]string
 				"monitor_ids", "id",
 			},
 		},
-		"synthetics": {
+		"synthetics_test": {
 			"synthetics_private_location": {
 				"locations", "id",
 			},
 		},
 		"synthetics_global_variable": {
-			"synthetics": {
+			"synthetics_test": {
 				"parse_test_id", "id",
 			},
 		},

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -177,7 +177,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 	return map[string]terraformutils.ServiceGenerator{
 		"dashboard_list":                       &DashboardListGenerator{},
 		"dashboard":                            &DashboardGenerator{},
-		"dashboard_json":                       &DashboardJsonGenerator{},
+		"dashboard_json":                       &DashboardJSONGenerator{},
 		"downtime":                             &DowntimeGenerator{},
 		"logs_archive":                         &LogsArchiveGenerator{},
 		"logs_archive_order":                   &LogsArchiveOrderGenerator{},

--- a/providers/datadog/downtime.go
+++ b/providers/datadog/downtime.go
@@ -70,7 +70,7 @@ func (g *DowntimeGenerator) InitResources() error {
 					return err
 				}
 
-				monitor, _, err := datadogClientV1.DowntimesApi.GetDowntime(authV1, i).Execute()
+				monitor, _, err := datadogClientV1.DowntimesApi.GetDowntime(authV1, i)
 				if err != nil {
 					return err
 				}
@@ -85,7 +85,7 @@ func (g *DowntimeGenerator) InitResources() error {
 		return nil
 	}
 
-	downtimes, _, err := datadogClientV1.DowntimesApi.ListDowntimes(authV1).Execute()
+	downtimes, _, err := datadogClientV1.DowntimesApi.ListDowntimes(authV1)
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/integration_aws.go
+++ b/providers/datadog/integration_aws.go
@@ -60,7 +60,7 @@ func (g *IntegrationAWSGenerator) InitResources() error {
 	datadogClientV1 := g.Args["datadogClientV1"].(*datadogV1.APIClient)
 	authV1 := g.Args["authV1"].(context.Context)
 
-	integrations, _, err := datadogClientV1.AWSIntegrationApi.ListAWSAccounts(authV1).Execute()
+	integrations, _, err := datadogClientV1.AWSIntegrationApi.ListAWSAccounts(authV1)
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/integration_aws_lambda_arn.go
+++ b/providers/datadog/integration_aws_lambda_arn.go
@@ -64,7 +64,7 @@ func (g *IntegrationAWSLambdaARNGenerator) InitResources() error {
 	datadogClientV1 := g.Args["datadogClientV1"].(*datadogV1.APIClient)
 	authV1 := g.Args["authV1"].(context.Context)
 
-	logCollections, _, err := datadogClientV1.AWSLogsIntegrationApi.ListAWSLogsIntegrations(authV1).Execute()
+	logCollections, _, err := datadogClientV1.AWSLogsIntegrationApi.ListAWSLogsIntegrations(authV1)
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/integration_aws_log_collection.go
+++ b/providers/datadog/integration_aws_log_collection.go
@@ -59,7 +59,7 @@ func (g *IntegrationAWSLogCollectionGenerator) InitResources() error {
 	datadogClientV1 := g.Args["datadogClientV1"].(*datadogV1.APIClient)
 	authV1 := g.Args["authV1"].(context.Context)
 
-	logCollections, _, err := datadogClientV1.AWSLogsIntegrationApi.ListAWSLogsIntegrations(authV1).Execute()
+	logCollections, _, err := datadogClientV1.AWSLogsIntegrationApi.ListAWSLogsIntegrations(authV1)
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/integration_azure.go
+++ b/providers/datadog/integration_azure.go
@@ -60,7 +60,7 @@ func (g *IntegrationAzureGenerator) InitResources() error {
 	datadogClientV1 := g.Args["datadogClientV1"].(*datadogV1.APIClient)
 	authV1 := g.Args["authV1"].(context.Context)
 
-	integrations, _, err := datadogClientV1.AzureIntegrationApi.ListAzureIntegration(authV1).Execute()
+	integrations, _, err := datadogClientV1.AzureIntegrationApi.ListAzureIntegration(authV1)
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/integration_gcp.go
+++ b/providers/datadog/integration_gcp.go
@@ -60,7 +60,7 @@ func (g *IntegrationGCPGenerator) InitResources() error {
 	datadogClientV1 := g.Args["datadogClientV1"].(*datadogV1.APIClient)
 	authV1 := g.Args["authV1"].(context.Context)
 
-	integrations, _, err := datadogClientV1.GCPIntegrationApi.ListGCPIntegration(authV1).Execute()
+	integrations, _, err := datadogClientV1.GCPIntegrationApi.ListGCPIntegration(authV1)
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/integration_slack_channel.go
+++ b/providers/datadog/integration_slack_channel.go
@@ -64,7 +64,7 @@ func (g *IntegrationSlackChannelGenerator) InitResources() error {
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "account_name" && filter.IsApplicable("integration_slack_channel") {
 			for _, value := range filter.AcceptableValues {
-				slackChannels, _, err := datadogClientV1.SlackIntegrationApi.GetSlackIntegrationChannels(authV1, value).Execute()
+				slackChannels, _, err := datadogClientV1.SlackIntegrationApi.GetSlackIntegrationChannels(authV1, value)
 				if err != nil {
 					return err
 				}

--- a/providers/datadog/logs_archive.go
+++ b/providers/datadog/logs_archive.go
@@ -64,7 +64,7 @@ func (g *LogsArchiveGenerator) InitResources() error {
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "id" && filter.IsApplicable("logs_archive") {
 			for _, value := range filter.AcceptableValues {
-				resp, _, err := datadogClientV2.LogsArchivesApi.GetLogsArchive(authV2, value).Execute()
+				resp, _, err := datadogClientV2.LogsArchivesApi.GetLogsArchive(authV2, value)
 				if err != nil {
 					return err
 				}
@@ -79,7 +79,7 @@ func (g *LogsArchiveGenerator) InitResources() error {
 		return nil
 	}
 
-	logsArchiveListResp, _, err := datadogClientV2.LogsArchivesApi.ListLogsArchives(authV2).Execute()
+	logsArchiveListResp, _, err := datadogClientV2.LogsArchivesApi.ListLogsArchives(authV2)
 	logsArchiveList := logsArchiveListResp.GetData()
 	if err != nil {
 		return err

--- a/providers/datadog/logs_custom_pipeline.go
+++ b/providers/datadog/logs_custom_pipeline.go
@@ -69,7 +69,7 @@ func (g *LogsCustomPipelineGenerator) InitResources() error {
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "id" && filter.IsApplicable("logs_custom_pipeline") {
 			for _, value := range filter.AcceptableValues {
-				logsCustomPipeline, _, err := datadogClientV1.LogsPipelinesApi.GetLogsPipeline(authV1, value).Execute()
+				logsCustomPipeline, _, err := datadogClientV1.LogsPipelinesApi.GetLogsPipeline(authV1, value)
 				if err != nil {
 					return err
 				}
@@ -84,7 +84,7 @@ func (g *LogsCustomPipelineGenerator) InitResources() error {
 		return nil
 	}
 
-	logsCustomPipelines, _, err := datadogClientV1.LogsPipelinesApi.ListLogsPipelines(authV1).Execute()
+	logsCustomPipelines, _, err := datadogClientV1.LogsPipelinesApi.ListLogsPipelines(authV1)
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/logs_index.go
+++ b/providers/datadog/logs_index.go
@@ -64,7 +64,7 @@ func (g *LogsIndexGenerator) InitResources() error {
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "id" && filter.IsApplicable("logs_index") {
 			for _, value := range filter.AcceptableValues {
-				logsIndex, _, err := datadogClientV1.LogsIndexesApi.GetLogsIndex(authV1, value).Execute()
+				logsIndex, _, err := datadogClientV1.LogsIndexesApi.GetLogsIndex(authV1, value)
 				if err != nil {
 					return err
 				}
@@ -79,7 +79,7 @@ func (g *LogsIndexGenerator) InitResources() error {
 		return nil
 	}
 
-	logsIndexList, _, err := datadogClientV1.LogsIndexesApi.ListLogIndexes(authV1).Execute()
+	logsIndexList, _, err := datadogClientV1.LogsIndexesApi.ListLogIndexes(authV1)
 	logsIndex := logsIndexList.GetIndexes()
 	if err != nil {
 		return err

--- a/providers/datadog/logs_integration_pipeline.go
+++ b/providers/datadog/logs_integration_pipeline.go
@@ -62,7 +62,7 @@ func (g *LogsIntegrationPipelineGenerator) InitResources() error {
 	datadogClientV1 := g.Args["datadogClientV1"].(*datadogV1.APIClient)
 	authV1 := g.Args["authV1"].(context.Context)
 
-	logsIntegrationPipelines, _, err := datadogClientV1.LogsPipelinesApi.ListLogsPipelines(authV1).Execute()
+	logsIntegrationPipelines, _, err := datadogClientV1.LogsPipelinesApi.ListLogsPipelines(authV1)
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/monitor.go
+++ b/providers/datadog/monitor.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	// MonitorAllowEmptyValues ...
-	MonitorAllowEmptyValues = []string{"tags."}
+	MonitorAllowEmptyValues = []string{"tags.", "message"}
 )
 
 // MonitorGenerator ...

--- a/providers/datadog/monitor.go
+++ b/providers/datadog/monitor.go
@@ -64,8 +64,8 @@ func (g *MonitorGenerator) createResource(monitorID string) terraformutils.Resou
 func (g *MonitorGenerator) InitResources() error {
 	datadogClientV1 := g.Args["datadogClientV1"].(*datadogV1.APIClient)
 	authV1 := g.Args["authV1"].(context.Context)
-	dclient := datadogClientV1.MonitorsApi.ListMonitors(authV1)
 
+	optionalParams := datadogV1.NewListMonitorsOptionalParameters()
 	resources := []terraformutils.Resource{}
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "id" && filter.IsApplicable("monitor") {
@@ -75,7 +75,7 @@ func (g *MonitorGenerator) InitResources() error {
 					return err
 				}
 
-				monitor, _, err := datadogClientV1.MonitorsApi.GetMonitor(authV1, i).Execute()
+				monitor, _, err := datadogClientV1.MonitorsApi.GetMonitor(authV1, i)
 				if err != nil {
 					return err
 				}
@@ -84,7 +84,7 @@ func (g *MonitorGenerator) InitResources() error {
 			}
 		}
 		if filter.FieldPath == "tags" && filter.IsApplicable("monitor") {
-			dclient = dclient.MonitorTags(strings.Join(filter.AcceptableValues, ","))
+			optionalParams.WithMonitorTags(strings.Join(filter.AcceptableValues, ","))
 		}
 	}
 
@@ -97,7 +97,9 @@ func (g *MonitorGenerator) InitResources() error {
 	pageSize := int32(1000)
 	pageNumber := int64(0)
 	for {
-		resp, _, err := dclient.PageSize(pageSize).Page(pageNumber).Execute()
+		resp, _, err := datadogClientV1.MonitorsApi.ListMonitors(authV1, *optionalParams.
+			WithPageSize(pageSize).
+			WithPage(pageNumber))
 		if err != nil {
 			return err
 		}

--- a/providers/datadog/role.go
+++ b/providers/datadog/role.go
@@ -68,7 +68,9 @@ func (g *RoleGenerator) InitResources() error {
 
 	var roles []datadogV2.Role
 	for remaining > int64(0) {
-		resp, _, err := datadogClientV2.RolesApi.ListRoles(authV2).PageSize(pageSize).PageNumber(pageNumber).Execute()
+		resp, _, err := datadogClientV2.RolesApi.ListRoles(authV2, *datadogV2.NewListRolesOptionalParameters().
+			WithPageSize(pageSize).
+			WithPageNumber(pageNumber))
 		if err != nil {
 			return err
 		}

--- a/providers/datadog/security_monitoring_default_rule.go
+++ b/providers/datadog/security_monitoring_default_rule.go
@@ -69,7 +69,10 @@ func (g *SecurityMonitoringDefaultRuleGenerator) InitResources() error {
 	remaining := int64(1)
 
 	for remaining > int64(0) {
-		resp, _, err := datadogClientV2.SecurityMonitoringApi.ListSecurityMonitoringRules(authV2).PageSize(pageSize).PageNumber(pageNumber).Execute()
+		resp, _, err := datadogClientV2.SecurityMonitoringApi.ListSecurityMonitoringRules(authV2,
+			*datadogV2.NewListSecurityMonitoringRulesOptionalParameters().
+			WithPageSize(pageSize).
+			WithPageNumber(pageNumber))
 		if err != nil {
 			return err
 		}

--- a/providers/datadog/security_monitoring_default_rule.go
+++ b/providers/datadog/security_monitoring_default_rule.go
@@ -71,8 +71,8 @@ func (g *SecurityMonitoringDefaultRuleGenerator) InitResources() error {
 	for remaining > int64(0) {
 		resp, _, err := datadogClientV2.SecurityMonitoringApi.ListSecurityMonitoringRules(authV2,
 			*datadogV2.NewListSecurityMonitoringRulesOptionalParameters().
-			WithPageSize(pageSize).
-			WithPageNumber(pageNumber))
+				WithPageSize(pageSize).
+				WithPageNumber(pageNumber))
 		if err != nil {
 			return err
 		}

--- a/providers/datadog/security_monitoring_rule.go
+++ b/providers/datadog/security_monitoring_rule.go
@@ -76,8 +76,8 @@ func (g *SecurityMonitoringRuleGenerator) InitResources() error {
 	for remaining > int64(0) {
 		resp, _, err := datadogClientV2.SecurityMonitoringApi.ListSecurityMonitoringRules(authV2,
 			*datadogV2.NewListSecurityMonitoringRulesOptionalParameters().
-			WithPageNumber(pageNumber).
-			WithPageSize(pageSize))
+				WithPageNumber(pageNumber).
+				WithPageSize(pageSize))
 		if err != nil {
 			return err
 		}

--- a/providers/datadog/security_monitoring_rule.go
+++ b/providers/datadog/security_monitoring_rule.go
@@ -74,7 +74,10 @@ func (g *SecurityMonitoringRuleGenerator) InitResources() error {
 	remaining := int64(1)
 
 	for remaining > int64(0) {
-		resp, _, err := datadogClientV2.SecurityMonitoringApi.ListSecurityMonitoringRules(authV2).PageSize(pageSize).PageNumber(pageNumber).Execute()
+		resp, _, err := datadogClientV2.SecurityMonitoringApi.ListSecurityMonitoringRules(authV2,
+			*datadogV2.NewListSecurityMonitoringRulesOptionalParameters().
+			WithPageNumber(pageNumber).
+			WithPageSize(pageSize))
 		if err != nil {
 			return err
 		}

--- a/providers/datadog/service_level_objective.go
+++ b/providers/datadog/service_level_objective.go
@@ -61,7 +61,7 @@ func (g *ServiceLevelObjectiveGenerator) InitResources() error {
 	authV1 := g.Args["authV1"].(context.Context)
 
 	var slos []datadogV1.ServiceLevelObjective
-	resp, _, err := datadogClientV1.ServiceLevelObjectivesApi.ListSLOs(authV1).Execute()
+	resp, _, err := datadogClientV1.ServiceLevelObjectivesApi.ListSLOs(authV1)
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/synthetics.go
+++ b/providers/datadog/synthetics.go
@@ -64,7 +64,7 @@ func (g *SyntheticsGenerator) InitResources() error {
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "id" && filter.IsApplicable("synthetics") {
 			for _, value := range filter.AcceptableValues {
-				syntheticsTest, _, err := datadogClientV1.SyntheticsApi.GetTest(authV1, value).Execute()
+				syntheticsTest, _, err := datadogClientV1.SyntheticsApi.GetTest(authV1, value)
 				if err != nil {
 					return err
 				}
@@ -79,7 +79,7 @@ func (g *SyntheticsGenerator) InitResources() error {
 		return nil
 	}
 
-	syntheticsTests, _, err := datadogClientV1.SyntheticsApi.ListTests(authV1).Execute()
+	syntheticsTests, _, err := datadogClientV1.SyntheticsApi.ListTests(authV1)
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/synthetics_global_variable.go
+++ b/providers/datadog/synthetics_global_variable.go
@@ -65,7 +65,7 @@ func (g *SyntheticsGlobalVariableGenerator) InitResources() error {
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "id" && filter.IsApplicable("synthetics_global_variable") {
 			for _, v := range filter.AcceptableValues {
-				resp, _, err := datadogClientV1.SyntheticsApi.GetGlobalVariable(authV1, v).Execute()
+				resp, _, err := datadogClientV1.SyntheticsApi.GetGlobalVariable(authV1, v)
 				if err != nil {
 					log.Printf("error retrieving synthetics gloval variable with id:%s - %s", v, err)
 					continue

--- a/providers/datadog/synthetics_private_location.go
+++ b/providers/datadog/synthetics_private_location.go
@@ -63,7 +63,7 @@ func (g *SyntheticsPrivateLocationGenerator) InitResources() error {
 	datadogClientV1 := g.Args["datadogClientV1"].(*datadogV1.APIClient)
 	authV1 := g.Args["authV1"].(context.Context)
 
-	data, _, err := datadogClientV1.SyntheticsApi.ListLocations(authV1).Execute()
+	data, _, err := datadogClientV1.SyntheticsApi.ListLocations(authV1)
 	if err != nil {
 		return err
 	}

--- a/providers/datadog/synthetics_test_.go
+++ b/providers/datadog/synthetics_test_.go
@@ -1,0 +1,88 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	datadogV1 "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+)
+
+var (
+	// SyntheticsAllowEmptyValues ...
+	SyntheticsAllowEmptyValues = []string{"tags."}
+)
+
+// SyntheticsTestGenerator ...
+type SyntheticsTestGenerator struct {
+	DatadogService
+}
+
+func (g *SyntheticsTestGenerator) createResources(syntheticsList []datadogV1.SyntheticsTestDetails) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, synthetics := range syntheticsList {
+		resourceName := synthetics.GetPublicId()
+		resources = append(resources, g.createResource(resourceName))
+	}
+
+	return resources
+}
+
+func (g *SyntheticsTestGenerator) createResource(syntheticsID string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		syntheticsID,
+		fmt.Sprintf("synthetics_%s", syntheticsID),
+		"datadog_synthetics_test",
+		"datadog",
+		SyntheticsAllowEmptyValues,
+	)
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each synthetics create 1 TerraformResource.
+// Need Synthetics ID as ID for terraform resource
+func (g *SyntheticsTestGenerator) InitResources() error {
+	datadogClientV1 := g.Args["datadogClientV1"].(*datadogV1.APIClient)
+	authV1 := g.Args["authV1"].(context.Context)
+
+	resources := []terraformutils.Resource{}
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("synthetics_test") {
+			for _, value := range filter.AcceptableValues {
+				syntheticsTest, _, err := datadogClientV1.SyntheticsApi.GetTest(authV1, value)
+				if err != nil {
+					return err
+				}
+
+				resources = append(resources, g.createResource(syntheticsTest.GetPublicId()))
+			}
+		}
+	}
+
+	if len(resources) > 0 {
+		g.Resources = resources
+		return nil
+	}
+
+	syntheticsTests, _, err := datadogClientV1.SyntheticsApi.ListTests(authV1)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(syntheticsTests.GetTests())
+	return nil
+}

--- a/providers/datadog/user.go
+++ b/providers/datadog/user.go
@@ -17,6 +17,8 @@ package datadog
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
 
 	datadogV2 "github.com/DataDog/datadog-api-client-go/api/v2/datadog"
@@ -72,6 +74,13 @@ func (g *UserGenerator) InitResources() error {
 	pageNumber := int64(0)
 	remaining := int64(1)
 	optionalParams := datadogV2.NewListUsersOptionalParameters()
+	for _, filter := range g.Filter {
+		if filter.IsApplicable("user") && filter.FieldPath == "disabled" {
+			if len(filter.AcceptableValues) == 1 && strings.ToLower(filter.AcceptableValues[0]) == "false" {
+				optionalParams = optionalParams.WithFilterStatus("Active,Pending")
+			}
+		}
+	}
 
 	for remaining > int64(0) {
 		resp, _, err := datadogClientV2.UsersApi.ListUsers(authV2, *optionalParams.

--- a/providers/datadog/user.go
+++ b/providers/datadog/user.go
@@ -68,16 +68,11 @@ func (g *UserGenerator) InitResources() error {
 	datadogClientV2 := g.Args["datadogClientV2"].(*datadogV2.APIClient)
 	authV2 := g.Args["authV2"].(context.Context)
 
-	optionalParams := datadogV2.NewListUsersOptionalParameters()
-	for _, filter := range g.Filter {
-		if filter.FieldPath == "status" && filter.IsApplicable("user") {
-			optionalParams = optionalParams.WithFilterStatus(filter.AcceptableValues[0])
-		}
-	}
-
 	pageSize := int64(1000)
 	pageNumber := int64(0)
 	remaining := int64(1)
+	optionalParams := datadogV2.NewListUsersOptionalParameters()
+
 	for remaining > int64(0) {
 		resp, _, err := datadogClientV2.UsersApi.ListUsers(authV2, *optionalParams.
 			WithPageSize(pageSize).


### PR DESCRIPTION
This PR does several things:

- Updates the DD API Client to latest
- Renames synthetics -> synthetics_test to keep it on par with datadog terraform provider
- Adds new DashboardJSON resource
- Add support for filtering users by their `status`
- Allow setting empty `message` attribute for monitors

Thanks!