### PR TITLE
Add support for AWS Batch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/apigateway v1.2.1
 	github.com/aws/aws-sdk-go-v2/service/appsync v1.2.1
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.3.1
+	github.com/aws/aws-sdk-go-v2/service/batch v1.3.1
 	github.com/aws/aws-sdk-go-v2/service/budgets v1.1.3
 	github.com/aws/aws-sdk-go-v2/service/cloud9 v1.1.3
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -191,6 +191,8 @@ github.com/aws/aws-sdk-go-v2/service/appsync v1.2.1 h1:qHxx2jl6nI6Sn5fuXtBQVWbha
 github.com/aws/aws-sdk-go-v2/service/appsync v1.2.1/go.mod h1:JkdNL71yKS0qmF+dFJJzxf1WJZWFGIhTepXHaxtKipE=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.3.1 h1:fQkypDE1Ll/W61tm8GoswgLjWfO8y1f50yXw5lA4uFo=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.3.1/go.mod h1:DVmOqpa3F7vhAuGfs2zse1f3N3mX64hCimRNSYiqnKE=
+github.com/aws/aws-sdk-go-v2/service/batch v1.3.1 h1:dZSRS8i4wL+lB87FCCHBynaD7BgrYyESuEzmx23/pOg=
+github.com/aws/aws-sdk-go-v2/service/batch v1.3.1/go.mod h1:sx7fSwDOWJhJ9Z/+SCHfisxlIXmPXqovaksLqQy/+w0=
 github.com/aws/aws-sdk-go-v2/service/budgets v1.1.3 h1:P2IXGUpF2t6gwy3QTPB82/wFarHkX6WVsHWs7nfaVWY=
 github.com/aws/aws-sdk-go-v2/service/budgets v1.1.3/go.mod h1:1NXNu5eiAZbLx6bK0Ir2X4MBXBO6JSMaPN3mdRaYZqo=
 github.com/aws/aws-sdk-go-v2/service/cloud9 v1.1.3 h1:I2V5IX5pwXq/+TL5QeDcoq4MIcFgzQ/yxbf5KTEqm4Q=

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -235,6 +235,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"api_gateway":       &AwsFacade{service: &APIGatewayGenerator{}},
 		"appsync":           &AwsFacade{service: &AppSyncGenerator{}},
 		"auto_scaling":      &AwsFacade{service: &AutoScalingGenerator{}},
+		"batch":             &AwsFacade{service: &BatchGenerator{}},
 		"budgets":           &AwsFacade{service: &BudgetsGenerator{}},
 		"cloud9":            &AwsFacade{service: &Cloud9Generator{}},
 		"cloudformation":    &AwsFacade{service: &CloudFormationGenerator{}},

--- a/providers/aws/batch.go
+++ b/providers/aws/batch.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
 
 	"github.com/aws/aws-sdk-go-v2/aws"

--- a/providers/aws/batch.go
+++ b/providers/aws/batch.go
@@ -1,0 +1,112 @@
+package aws
+
+import (
+	"context"
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/batch"
+)
+
+var BatchAllowEmptyValues = []string{"tags."}
+
+var BatchAdditionalFields = map[string]interface{}{}
+
+type BatchGenerator struct {
+	AWSService
+}
+
+func (g *BatchGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	batchClient := batch.NewFromConfig(config)
+
+	if err := g.loadComputeEnvironments(batchClient); err != nil {
+		return err
+	}
+	if err := g.loadJobDefinitions(batchClient); err != nil {
+		return err
+	}
+	if err := g.loadJobQueues(batchClient); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g *BatchGenerator) loadComputeEnvironments(batchClient *batch.Client) error {
+	p := batch.NewDescribeComputeEnvironmentsPaginator(batchClient, &batch.DescribeComputeEnvironmentsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, computeEnvironment := range page.ComputeEnvironments {
+			computeEnvironmentName := StringValue(computeEnvironment.ComputeEnvironmentName)
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				computeEnvironmentName,
+				computeEnvironmentName,
+				"aws_batch_compute_environment",
+				"aws",
+				map[string]string{
+					"compute_environment_name": computeEnvironmentName,
+				},
+				BatchAllowEmptyValues,
+				BatchAdditionalFields,
+			))
+		}
+	}
+	return nil
+}
+
+func (g *BatchGenerator) loadJobDefinitions(batchClient *batch.Client) error {
+	p := batch.NewDescribeJobDefinitionsPaginator(batchClient, &batch.DescribeJobDefinitionsInput{
+		Status: aws.String("ACTIVE"),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, jobDefinition := range page.JobDefinitions {
+			jobDefinitionName := StringValue(jobDefinition.JobDefinitionName)
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				jobDefinitionName,
+				jobDefinitionName,
+				"aws_batch_job_definition",
+				"aws",
+				map[string]string{
+					"arn": StringValue(jobDefinition.JobDefinitionArn),
+				},
+				BatchAllowEmptyValues,
+				BatchAdditionalFields,
+			))
+		}
+	}
+	return nil
+}
+
+func (g *BatchGenerator) loadJobQueues(batchClient *batch.Client) error {
+	p := batch.NewDescribeJobQueuesPaginator(batchClient, &batch.DescribeJobQueuesInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, jobQueue := range page.JobQueues {
+			jobQueueName := StringValue(jobQueue.JobQueueName)
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				jobQueueName,
+				jobQueueName,
+				"aws_batch_job_queue",
+				"aws",
+				map[string]string{},
+				BatchAllowEmptyValues,
+				BatchAdditionalFields,
+			))
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
# Goal
Add support for import AWS Batch related objects, concretely:
- Batch compute environment
- Job definition
- Job queues
see more on Terraform [aws provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/batch_compute_environment).

# Testing
Tested against account in eu-central-1 with multiple compute environments, job definition (with different revisions) and job queues. Worked for me without issues.