### PR TITLE
feat(panos): improve authentication, fix panos_telemetry

### DIFF
--- a/cmd/provider_cmd_panos.go
+++ b/cmd/provider_cmd_panos.go
@@ -16,18 +16,11 @@ package cmd
 
 import (
 	"log"
-	"os"
 	"strings"
 
 	panos_terraforming "github.com/GoogleCloudPlatform/terraformer/providers/panos"
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
 	"github.com/spf13/cobra"
-)
-
-const (
-	defaultPanosHostname = "192.168.1.1"
-	defaultPanosUsername = "admin"
-	defaultPanosPassword = "admin"
 )
 
 func newCmdPanosImporter(options ImportOptions) *cobra.Command {
@@ -37,25 +30,10 @@ func newCmdPanosImporter(options ImportOptions) *cobra.Command {
 		Short: "Import current state to Terraform configuration from a PAN-OS",
 		Long:  "Import current state to Terraform configuration from a PAN-OS",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			hostname := os.Getenv("PANOS_HOSTNAME")
-			if len(hostname) == 0 {
-				hostname = defaultPanosHostname
-			}
-
-			username := os.Getenv("PANOS_USERNAME")
-			if len(username) == 0 {
-				username = defaultPanosUsername
-			}
-
-			password := os.Getenv("PANOS_PASSWORD")
-			if len(password) == 0 {
-				password = defaultPanosPassword
-			}
-
 			if len(vsys) == 0 {
 				var err error
 
-				vsys, err = panos_terraforming.GetVsysList(hostname, username, password)
+				vsys, err = panos_terraforming.GetVsysList()
 				if err != nil {
 					return err
 				}
@@ -68,7 +46,7 @@ func newCmdPanosImporter(options ImportOptions) *cobra.Command {
 				options.PathPattern = originalPathPattern
 				options.PathPattern = strings.ReplaceAll(options.PathPattern, "{provider}", "{provider}/"+v)
 
-				err := Import(provider, options, []string{hostname, username, password, v})
+				err := Import(provider, options, []string{v})
 				if err != nil {
 					return err
 				}

--- a/docs/panos.md
+++ b/docs/panos.md
@@ -9,6 +9,19 @@ Example:
 
  terraformer import panos --resources=device_config,firewall_networking,firewall_objects,firewall_policy
 ```
+The list of usable environment variables is the same as the [pango go-client](https://github.com/PaloAltoNetworks/pango):
+*  `PANOS_HOSTNAME`
+*  `PANOS_USERNAME`
+*  `PANOS_PASSWORD`
+*  `PANOS_API_KEY`
+*  `PANOS_PROTOCOL`
+*  `PANOS_PORT`
+*  `PANOS_TIMEOUT`
+*  `PANOS_TARGET`
+*  `PANOS_HEADERS`
+*  `PANOS_VERIFY_CERTIFICATE`
+*  `PANOS_LOGGING`
+
 Here is the list of resources which are currently supported:
 
 *   `device_config`

--- a/providers/panos/device_config.go
+++ b/providers/panos/device_config.go
@@ -16,6 +16,7 @@ package panos
 
 import (
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/PaloAltoNetworks/pango/dev/general"
 )
 
 type DeviceConfigGenerator struct {
@@ -50,6 +51,14 @@ func (g *DeviceConfigGenerator) createResourcesFromList(o getGeneric, idPrefix, 
 	}
 
 	return resources
+}
+
+func (g *DeviceConfigGenerator) createGeneralSettingsResource(generalConfig general.Config) terraformutils.Resource {
+	return g.createSimpleResource(generalConfig.Hostname, "panos_general_settings")
+}
+
+func (g *DeviceConfigGenerator) createTelemetryResource(generalConfig general.Config) terraformutils.Resource {
+	return g.createSimpleResource(generalConfig.IpAddress, "panos_telemetry")
 }
 
 func (g *DeviceConfigGenerator) createEmailServerProfileResources() []terraformutils.Resource {
@@ -90,8 +99,8 @@ func (g *DeviceConfigGenerator) InitResources() error {
 		return err
 	}
 
-	g.Resources = append(g.Resources, g.createSimpleResource(generalConfig.Hostname, "panos_general_settings"))
-	g.Resources = append(g.Resources, g.createSimpleResource(generalConfig.Hostname, "panos_telemetry"))
+	g.Resources = append(g.Resources, g.createGeneralSettingsResource(generalConfig))
+	g.Resources = append(g.Resources, g.createTelemetryResource(generalConfig))
 	g.Resources = append(g.Resources, g.createEmailServerProfileResources()...)
 	g.Resources = append(g.Resources, g.createHTTPServerProfileResources()...)
 	g.Resources = append(g.Resources, g.createSNMPTrapServerProfileResources()...)

--- a/providers/panos/helpers.go
+++ b/providers/panos/helpers.go
@@ -15,6 +15,7 @@
 package panos
 
 import (
+	"os"
 	"strings"
 	"unicode"
 
@@ -25,19 +26,22 @@ import (
 	"golang.org/x/text/unicode/norm"
 )
 
-func Initialize(hostname, username, password string) (*pango.Firewall, error) {
-	client := &pango.Firewall{Client: pango.Client{
-		Hostname: hostname,
-		Username: username,
-		Password: password,
-		Logging:  pango.LogQuiet,
-	}}
+func Initialize() (*pango.Firewall, error) {
+	fw := &pango.Firewall{
+		Client: pango.Client{
+			CheckEnvironment: true,
+		},
+	}
 
-	return client, client.Initialize()
+	if val := os.Getenv("PANOS_LOGGING"); val == "" {
+		fw.Client.Logging = pango.LogQuiet
+	}
+
+	return fw, fw.Initialize()
 }
 
-func GetVsysList(hostname, username, password string) ([]string, error) {
-	client, err := Initialize(hostname, username, password)
+func GetVsysList() ([]string, error) {
+	client, err := Initialize()
 	if err != nil {
 		return []string{}, err
 	}

--- a/providers/panos/panos_provider.go
+++ b/providers/panos/panos_provider.go
@@ -23,17 +23,11 @@ import (
 
 type PanosProvider struct { //nolint
 	terraformutils.Provider
-	hostname string
-	username string
-	password string
-	vsys     string
+	vsys string
 }
 
 func (p *PanosProvider) Init(args []string) error {
-	p.hostname = args[0]
-	p.username = args[1]
-	p.password = args[2]
-	p.vsys = args[3]
+	p.vsys = args[0]
 
 	return nil
 }
@@ -47,11 +41,7 @@ func (p *PanosProvider) GetProviderData(arg ...string) map[string]interface{} {
 }
 
 func (p *PanosProvider) GetConfig() cty.Value {
-	return cty.ObjectVal(map[string]cty.Value{
-		"hostname": cty.StringVal(p.hostname),
-		"username": cty.StringVal(p.username),
-		"password": cty.StringVal(p.password),
-	})
+	return cty.ObjectVal(map[string]cty.Value{})
 }
 
 func (p *PanosProvider) GetBasicConfig() cty.Value {
@@ -69,10 +59,7 @@ func (p *PanosProvider) InitService(serviceName string, verbose bool) error {
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
-		"hostname": p.hostname,
-		"username": p.username,
-		"password": p.password,
-		"vsys":     p.vsys,
+		"vsys": p.vsys,
 	})
 
 	return nil

--- a/providers/panos/panos_service.go
+++ b/providers/panos/panos_service.go
@@ -28,7 +28,7 @@ type PanosService struct { //nolint
 func (p *PanosService) Initialize() error {
 	p.vsys = p.Args["vsys"].(string)
 
-	c, err := Initialize(p.Args["hostname"].(string), p.Args["username"].(string), p.Args["password"].(string))
+	c, err := Initialize()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Improve authentication by letting [pango](https://github.com/PaloAltoNetworks/pango) managing the authentication
- Fix `panos_telemetry`, I was using the wrong ID
- Improve logging of [pango](https://github.com/PaloAltoNetworks/pango), now you can set PANGO_LOGGING to whatever you want (supported by pango); by default the log level is `quiet` (for other log levels, you can look at https://github.com/PaloAltoNetworks/pango/blob/05ba3593d486d205a4723bfce11c37994103ee8c/client.go#L1272-L1287)
- Update documentation