### PR TITLE
feat(panos): add PAN-OS Panorama support

### DIFF
--- a/docs/panos.md
+++ b/docs/panos.md
@@ -7,7 +7,7 @@ Example:
  export PANOS_USERNAME=[PANOS_USERNAME]
  export PANOS_PASSWORD=[PANOS_PASSWORD]
 
- terraformer import panos --resources=device_config,firewall_networking,firewall_objects,firewall_policy
+ terraformer import panos --resources=firewall_device_config,firewall_networking,firewall_objects,firewall_policy
 ```
 The list of usable environment variables is the same as the [pango go-client](https://github.com/PaloAltoNetworks/pango):
 *  `PANOS_HOSTNAME`
@@ -24,7 +24,7 @@ The list of usable environment variables is the same as the [pango go-client](ht
 
 Here is the list of resources which are currently supported:
 
-*   `device_config`
+*   `firewall_device_config`
     * `panos_general_settings`
     * `panos_telemetry` 
     * `panos_email_server_profile`
@@ -91,3 +91,77 @@ Here is the list of resources which are currently supported:
     * `panos_nat_rule_group`
     * `panos_pbf_rule_group`
     * `panos_security_rule_group`
+*   `panorama_device_config`
+    * `panos_device_group_parent`
+    * `panos_panorama_device_group`
+    * `panos_panorama_email_server_profile`
+    * `panos_panorama_http_server_profile`
+    * `panos_panorama_snmptrap_server_profile`
+    * `panos_panorama_syslog_server_profile`
+    * `panos_panorama_template`
+    * `panos_panorama_template_stack`
+    * `panos_panorama_template_variable`
+*   `panorama_networking`
+    * `panos_panorama_aggregate_interface`
+    * `panos_panorama_bfd_profile`
+    * `panos_panorama_bgp`
+    * `panos_panorama_bgp_aggregate`
+    * `panos_panorama_bgp_aggregate_advertise_filter`
+    * `panos_panorama_bgp_aggregate_suppress_filter`
+    * `panos_panorama_bgp_auth_profile` # The secret argument will contain "(incorrect)"
+    * `panos_panorama_bgp_conditional_adv`
+    * `panos_panorama_bgp_conditional_adv_advertise_filter`
+    * `panos_panorama_bgp_conditional_adv_non_exist_filter`
+    * `panos_panorama_bgp_dampening_profile`
+    * `panos_panorama_bgp_export_rule_group`
+    * `panos_panorama_bgp_import_rule_group`
+    * `panos_panorama_bgp_peer`
+    * `panos_panorama_bgp_peer_group`
+    * `panos_panorama_bgp_redist_rule`
+    * `panos_panorama_ethernet_interface`
+    * `panos_panorama_gre_tunnel`
+    * `panos_panorama_ike_crypto_profile`
+    * `panos_panorama_ike_gateway`
+    * `panos_panorama_ipsec_crypto_profile`
+    * `panos_panorama_ipsec_tunnel`
+    * `panos_panorama_ipsec_tunnel_proxy_id_ipv4`
+    * `panos_panorama_layer2_subinterface`
+    * `panos_panorama_layer3_subinterface`
+    * `panos_panorama_loopback_interface`
+    * `panos_panorama_management_profile`
+    * `panos_panorama_monitor_profile`
+    * `panos_panorama_redistribution_profile`
+    * `panos_panorama_static_route_ipv4`
+    * `panos_panorama_tunnel_interface`
+    * `panos_panorama_virtual_router`
+    * `panos_panorama_vlan`
+    * `panos_panorama_vlan_interface`
+    * `panos_panorama_zone`
+*   `panorama_objects`
+    * `panos_panorama_address_group`
+    * `panos_panorama_administrative_tag`
+    * `panos_panorama_application_group`
+    * `panos_panorama_application_object`
+    * `panos_panorama_edl`
+    * `panos_panorama_log_forwarding_profile`
+    * `panos_panorama_service_group`
+    * `panos_panorama_service_object`
+    * `panos_address_object`
+    * `panos_anti_spyware_security_profile`
+    * `panos_antivirus_security_profile`
+    * `panos_custom_data_pattern_object`
+    * `panos_data_filtering_security_profile`
+    * `panos_dos_protection_profile`
+    * `panos_dynamic_user_group`
+    * `panos_file_blocking_security_profile`
+    * `panos_url_filtering_security_profile`
+    * `panos_vulnerability_security_profile`
+    * `panos_wildfire_analysis_security_profile`
+*   `panorama_plugins`
+    * `panos_panorama_gcp_account`
+    * `panos_panorama_gke_cluster`
+    * `panos_panorama_gke_cluster_group`
+*   `panorama_policy`
+    * `panos_panorama_nat_rule_group`
+    * `panos_panorama_pbf_rule_group`
+    * `panos_panorama_security_rule_group`

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/IBM/vpc-go-sdk v0.4.1
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/OctopusDeploy/go-octopusdeploy v1.6.0
-	github.com/PaloAltoNetworks/pango v0.5.2-0.20210514062125-b809b85eb51c
+	github.com/PaloAltoNetworks/pango v0.6.0
 	github.com/SAP/go-hdb v0.105.2 // indirect
 	github.com/SermoDigital/jose v0.9.1 // indirect
 	github.com/aliyun/alibaba-cloud-sdk-go v1.60.295

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8
 github.com/OctopusDeploy/go-octopusdeploy v1.6.0 h1:r9ThVuANGkzm3noAjLF/i7LUcxQxbCJwpvn1DLwPoOA=
 github.com/OctopusDeploy/go-octopusdeploy v1.6.0/go.mod h1:maPbD8azyb2mcNN6E4SGrwiLN7XmDSML5ui+mcWR/R0=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/PaloAltoNetworks/pango v0.5.2-0.20210514062125-b809b85eb51c h1:4uQRvqtOkn0n4zb9BbYHhXzAmWDd25T6TfnE5I5gpFg=
-github.com/PaloAltoNetworks/pango v0.5.2-0.20210514062125-b809b85eb51c/go.mod h1:xpwEKL6CHhniRcqKYTjIiGBzPd3QIyto3sz2ynsP1qg=
+github.com/PaloAltoNetworks/pango v0.6.0 h1:QKe17XsICz2P1S6sKpaH1w8zr/4Q3jYsYVq7bQTjfv8=
+github.com/PaloAltoNetworks/pango v0.6.0/go.mod h1:xpwEKL6CHhniRcqKYTjIiGBzPd3QIyto3sz2ynsP1qg=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=

--- a/providers/panos/firewall_device_config.go
+++ b/providers/panos/firewall_device_config.go
@@ -16,15 +16,16 @@ package panos
 
 import (
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/PaloAltoNetworks/pango"
 )
 
-type DeviceConfigGenerator struct {
+type FirewallDeviceConfigGenerator struct {
 	PanosService
 }
 
-func (g *DeviceConfigGenerator) createResourcesFromList(o getGeneric, idPrefix, terraformResourceName string) (resources []terraformutils.Resource) {
+func (g *FirewallDeviceConfigGenerator) createResourcesFromList(o getGeneric, idPrefix, terraformResourceName string) (resources []terraformutils.Resource) {
 	l, err := o.i.(getListWithOneArg).GetList(o.params[0])
-	if err != nil {
+	if err != nil || len(l) == 0 {
 		return []terraformutils.Resource{}
 	}
 
@@ -42,7 +43,7 @@ func (g *DeviceConfigGenerator) createResourcesFromList(o getGeneric, idPrefix, 
 	return resources
 }
 
-func (g *DeviceConfigGenerator) createGeneralSettingsResource(hostname string) terraformutils.Resource {
+func (g *FirewallDeviceConfigGenerator) createGeneralSettingsResource(hostname string) terraformutils.Resource {
 	return terraformutils.NewSimpleResource(
 		hostname,
 		normalizeResourceName(hostname),
@@ -52,7 +53,7 @@ func (g *DeviceConfigGenerator) createGeneralSettingsResource(hostname string) t
 	)
 }
 
-func (g *DeviceConfigGenerator) createTelemetryResource(ipAddress, hostname string) terraformutils.Resource {
+func (g *FirewallDeviceConfigGenerator) createTelemetryResource(ipAddress, hostname string) terraformutils.Resource {
 	return terraformutils.NewSimpleResource(
 		ipAddress,
 		normalizeResourceName(hostname),
@@ -62,31 +63,31 @@ func (g *DeviceConfigGenerator) createTelemetryResource(ipAddress, hostname stri
 	)
 }
 
-func (g *DeviceConfigGenerator) createEmailServerProfileResources() []terraformutils.Resource {
-	return g.createResourcesFromList(getGeneric{g.client.Device.EmailServerProfile, []string{g.vsys}},
+func (g *FirewallDeviceConfigGenerator) createEmailServerProfileResources() []terraformutils.Resource {
+	return g.createResourcesFromList(getGeneric{g.client.(*pango.Firewall).Device.EmailServerProfile, []string{g.vsys}},
 		g.vsys+":", "panos_email_server_profile",
 	)
 }
 
-func (g *DeviceConfigGenerator) createHTTPServerProfileResources() []terraformutils.Resource {
-	return g.createResourcesFromList(getGeneric{g.client.Device.HttpServerProfile, []string{g.vsys}},
+func (g *FirewallDeviceConfigGenerator) createHTTPServerProfileResources() []terraformutils.Resource {
+	return g.createResourcesFromList(getGeneric{g.client.(*pango.Firewall).Device.HttpServerProfile, []string{g.vsys}},
 		g.vsys+":", "panos_http_server_profile",
 	)
 }
 
-func (g *DeviceConfigGenerator) createSNMPTrapServerProfileResources() []terraformutils.Resource {
-	return g.createResourcesFromList(getGeneric{g.client.Device.SnmpServerProfile, []string{g.vsys}},
+func (g *FirewallDeviceConfigGenerator) createSNMPTrapServerProfileResources() []terraformutils.Resource {
+	return g.createResourcesFromList(getGeneric{g.client.(*pango.Firewall).Device.SnmpServerProfile, []string{g.vsys}},
 		g.vsys+":", "panos_snmptrap_server_profile",
 	)
 }
 
-func (g *DeviceConfigGenerator) createSyslogServerProfileResources() []terraformutils.Resource {
-	return g.createResourcesFromList(getGeneric{g.client.Device.SyslogServerProfile, []string{g.vsys}},
+func (g *FirewallDeviceConfigGenerator) createSyslogServerProfileResources() []terraformutils.Resource {
+	return g.createResourcesFromList(getGeneric{g.client.(*pango.Firewall).Device.SyslogServerProfile, []string{g.vsys}},
 		g.vsys+":", "panos_syslog_server_profile",
 	)
 }
 
-func (g *DeviceConfigGenerator) InitResources() error {
+func (g *FirewallDeviceConfigGenerator) InitResources() error {
 	if err := g.Initialize(); err != nil {
 		return err
 	}
@@ -95,7 +96,7 @@ func (g *DeviceConfigGenerator) InitResources() error {
 		g.vsys = "shared"
 	}
 
-	generalConfig, err := g.client.Device.GeneralSettings.Get()
+	generalConfig, err := g.client.(*pango.Firewall).Device.GeneralSettings.Get()
 	if err != nil {
 		return err
 	}

--- a/providers/panos/firewall_networking.go
+++ b/providers/panos/firewall_networking.go
@@ -15,9 +15,12 @@
 package panos
 
 import (
+	"encoding/base64"
 	"fmt"
+	"strconv"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/PaloAltoNetworks/pango"
 	"github.com/PaloAltoNetworks/pango/netw/interface/eth"
 	"github.com/PaloAltoNetworks/pango/netw/interface/subinterface/layer2"
 	"github.com/PaloAltoNetworks/pango/netw/interface/subinterface/layer3"
@@ -44,13 +47,13 @@ func (g *FirewallNetworkingGenerator) createResourcesFromList(o getGeneric, idPr
 	default:
 		err = fmt.Errorf("not supported")
 	}
-	if err != nil {
+	if err != nil || len(l) == 0 {
 		return []terraformutils.Resource{}
 	}
 
 	for _, r := range l {
 		if checkIfIsVsys {
-			rv, err := g.client.IsImported(checkType, "", "", g.vsys, r)
+			rv, err := g.client.(*pango.Firewall).IsImported(checkType, "", "", g.vsys, r)
 			if err != nil || !rv {
 				continue
 			}
@@ -76,13 +79,13 @@ func (g *FirewallNetworkingGenerator) createResourcesFromList(o getGeneric, idPr
 }
 
 func (g *FirewallNetworkingGenerator) createAggregateInterfaceResources() (resources []terraformutils.Resource) {
-	l, err := g.client.Network.AggregateInterface.GetList()
+	l, err := g.client.(*pango.Firewall).Network.AggregateInterface.GetList()
 	if err != nil {
 		return []terraformutils.Resource{}
 	}
 
 	for _, aggregateInterface := range l {
-		rv, err := g.client.IsImported(util.InterfaceImport, "", "", g.vsys, aggregateInterface)
+		rv, err := g.client.(*pango.Firewall).IsImported(util.InterfaceImport, "", "", g.vsys, aggregateInterface)
 		if err != nil || !rv {
 			continue
 		}
@@ -96,7 +99,7 @@ func (g *FirewallNetworkingGenerator) createAggregateInterfaceResources() (resou
 			[]string{},
 		))
 
-		e, err := g.client.Network.AggregateInterface.Get(aggregateInterface)
+		e, err := g.client.(*pango.Firewall).Network.AggregateInterface.Get(aggregateInterface)
 		if err != nil {
 			continue
 		}
@@ -115,7 +118,7 @@ func (g *FirewallNetworkingGenerator) createAggregateInterfaceResources() (resou
 
 func (g *FirewallNetworkingGenerator) createBFDProfileResources() []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.BfdProfile, []string{}},
+		getGeneric{g.client.(*pango.Firewall).Network.BfdProfile, []string{}},
 		"", false, "panos_bfd_profile", false, "",
 	)
 }
@@ -131,7 +134,7 @@ func (g *FirewallNetworkingGenerator) createBGPResource(virtualRouter string) te
 }
 
 func (g *FirewallNetworkingGenerator) createBGPAggregateResources(virtualRouter string) (resources []terraformutils.Resource) {
-	l, err := g.client.Network.BgpAggregate.GetList(virtualRouter)
+	l, err := g.client.(*pango.Firewall).Network.BgpAggregate.GetList(virtualRouter)
 	if err != nil {
 		return []terraformutils.Resource{}
 	}
@@ -155,14 +158,14 @@ func (g *FirewallNetworkingGenerator) createBGPAggregateResources(virtualRouter 
 
 func (g *FirewallNetworkingGenerator) createBGPAggregateAdvertiseFilterResources(virtualRouter, bgpAggregate string) []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.BgpAggAdvertiseFilter, []string{virtualRouter, bgpAggregate}},
+		getGeneric{g.client.(*pango.Firewall).Network.BgpAggAdvertiseFilter, []string{virtualRouter, bgpAggregate}},
 		virtualRouter+":"+bgpAggregate+":", true, "panos_bgp_aggregate_advertise_filter", false, "",
 	)
 }
 
 func (g *FirewallNetworkingGenerator) createBGPAggregateSuppressFilterResources(virtualRouter, bgpAggregate string) []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.BgpAggSuppressFilter, []string{virtualRouter, bgpAggregate}},
+		getGeneric{g.client.(*pango.Firewall).Network.BgpAggSuppressFilter, []string{virtualRouter, bgpAggregate}},
 		virtualRouter+":"+bgpAggregate+":", true, "panos_bgp_aggregate_suppress_filter", false, "",
 	)
 }
@@ -170,13 +173,13 @@ func (g *FirewallNetworkingGenerator) createBGPAggregateSuppressFilterResources(
 // The secret argument will contain "(incorrect)", not the real value
 func (g *FirewallNetworkingGenerator) createBGPAuthProfileResources(virtualRouter string) []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.BgpAuthProfile, []string{virtualRouter}},
+		getGeneric{g.client.(*pango.Firewall).Network.BgpAuthProfile, []string{virtualRouter}},
 		virtualRouter+":", true, "panos_bgp_auth_profile", false, "",
 	)
 }
 
 func (g *FirewallNetworkingGenerator) createBGPConditionalAdvertisementResources(virtualRouter string) (resources []terraformutils.Resource) {
-	l, err := g.client.Network.BgpConditionalAdv.GetList(virtualRouter)
+	l, err := g.client.(*pango.Firewall).Network.BgpConditionalAdv.GetList(virtualRouter)
 	if err != nil {
 		return []terraformutils.Resource{}
 	}
@@ -200,41 +203,70 @@ func (g *FirewallNetworkingGenerator) createBGPConditionalAdvertisementResources
 
 func (g *FirewallNetworkingGenerator) createBGPConditionalAdvertisementAdvertiseFilterResources(virtualRouter, bgpConditionalAdv string) []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.BgpConAdvAdvertiseFilter, []string{virtualRouter, bgpConditionalAdv}},
+		getGeneric{g.client.(*pango.Firewall).Network.BgpConAdvAdvertiseFilter, []string{virtualRouter, bgpConditionalAdv}},
 		virtualRouter+":"+bgpConditionalAdv+":", true, "panos_bgp_conditional_adv_advertise_filter", false, "",
 	)
 }
 
 func (g *FirewallNetworkingGenerator) createBGPConditionalAdvertisementNonExistFilterResources(virtualRouter, bgpConditionalAdv string) []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.BgpConAdvNonExistFilter, []string{virtualRouter, bgpConditionalAdv}},
+		getGeneric{g.client.(*pango.Firewall).Network.BgpConAdvNonExistFilter, []string{virtualRouter, bgpConditionalAdv}},
 		virtualRouter+":"+bgpConditionalAdv+":", true, "panos_bgp_conditional_adv_non_exist_filter", false, "",
 	)
 }
 
 func (g *FirewallNetworkingGenerator) createBGPDampeningProfileResources(virtualRouter string) []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.BgpDampeningProfile, []string{virtualRouter}},
+		getGeneric{g.client.(*pango.Firewall).Network.BgpDampeningProfile, []string{virtualRouter}},
 		virtualRouter+":", true, "panos_bgp_dampening_profile", false, "",
 	)
 }
 
+func (g *FirewallNetworkingGenerator) createBGPRuleGroupResourcesFromList(o getGeneric, terraformResourceName string) (resources []terraformutils.Resource) {
+	l, err := o.i.(getListWithOneArg).GetList(o.params[0])
+	if err != nil || len(l) == 0 {
+		return []terraformutils.Resource{}
+	}
+
+	var positionReference string
+	id := o.params[0] + ":" + strconv.Itoa(util.MoveTop) + "::"
+
+	for k, r := range l {
+		if k > 0 {
+			id = o.params[0] + ":" + strconv.Itoa(util.MoveAfter) + ":" + positionReference + ":"
+		}
+
+		id += base64.StdEncoding.EncodeToString([]byte(r))
+		positionReference = r
+
+		resources = append(resources, terraformutils.NewSimpleResource(
+			id,
+			normalizeResourceName(r),
+			terraformResourceName,
+			"panos",
+			[]string{},
+		))
+	}
+
+	return resources
+}
+
 func (g *FirewallNetworkingGenerator) createBGPExportRuleGroupResources(virtualRouter string) []terraformutils.Resource {
-	return g.createResourcesFromList(
-		getGeneric{g.client.Network.BgpExport, []string{virtualRouter}},
-		virtualRouter+":", true, "panos_bgp_export_rule_group", false, "",
+	return g.createBGPRuleGroupResourcesFromList(
+		getGeneric{g.client.(*pango.Firewall).Network.BgpExport, []string{virtualRouter}},
+		"panos_bgp_export_rule_group",
 	)
 }
 
 func (g *FirewallNetworkingGenerator) createBGPImportRuleGroupResources(virtualRouter string) []terraformutils.Resource {
-	return g.createResourcesFromList(
-		getGeneric{g.client.Network.BgpImport, []string{virtualRouter}},
-		virtualRouter+":", true, "panos_bgp_import_rule_group", false, "",
+	return g.createBGPRuleGroupResourcesFromList(
+		getGeneric{g.client.(*pango.Firewall).Network.BgpImport, []string{virtualRouter}},
+		"panos_bgp_import_rule_group",
 	)
 }
 
 func (g *FirewallNetworkingGenerator) createBGPPeerGroupResources(virtualRouter string) (resources []terraformutils.Resource) {
-	l, err := g.client.Network.BgpPeerGroup.GetList(virtualRouter)
+	l, err := g.client.(*pango.Firewall).Network.BgpPeerGroup.GetList(virtualRouter)
 	if err != nil {
 		return []terraformutils.Resource{}
 	}
@@ -257,26 +289,26 @@ func (g *FirewallNetworkingGenerator) createBGPPeerGroupResources(virtualRouter 
 
 func (g *FirewallNetworkingGenerator) createBGPPeerResources(virtualRouter, bgpPeerGroup string) []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.BgpPeer, []string{virtualRouter, bgpPeerGroup}},
+		getGeneric{g.client.(*pango.Firewall).Network.BgpPeer, []string{virtualRouter, bgpPeerGroup}},
 		virtualRouter+":"+bgpPeerGroup+":", true, "panos_bgp_peer", false, "",
 	)
 }
 
 func (g *FirewallNetworkingGenerator) createBGPRedistResources(virtualRouter string) []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.BgpRedistRule, []string{virtualRouter}},
+		getGeneric{g.client.(*pango.Firewall).Network.BgpRedistRule, []string{virtualRouter}},
 		virtualRouter+":", true, "panos_bgp_redist_rule", false, "",
 	)
 }
 
 func (g *FirewallNetworkingGenerator) createEthernetInterfaceResources() (resources []terraformutils.Resource) {
-	l, err := g.client.Network.EthernetInterface.GetList()
+	l, err := g.client.(*pango.Firewall).Network.EthernetInterface.GetList()
 	if err != nil {
 		return []terraformutils.Resource{}
 	}
 
 	for _, ethernetInterface := range l {
-		rv, err := g.client.IsImported(util.InterfaceImport, "", "", g.vsys, ethernetInterface)
+		rv, err := g.client.(*pango.Firewall).IsImported(util.InterfaceImport, "", "", g.vsys, ethernetInterface)
 		if err != nil || !rv {
 			continue
 		}
@@ -290,7 +322,7 @@ func (g *FirewallNetworkingGenerator) createEthernetInterfaceResources() (resour
 			[]string{},
 		))
 
-		e, err := g.client.Network.EthernetInterface.Get(ethernetInterface)
+		e, err := g.client.(*pango.Firewall).Network.EthernetInterface.Get(ethernetInterface)
 		if err != nil {
 			continue
 		}
@@ -309,13 +341,13 @@ func (g *FirewallNetworkingGenerator) createEthernetInterfaceResources() (resour
 
 func (g *FirewallNetworkingGenerator) createGRETunnelResources() []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.GreTunnel, []string{}},
+		getGeneric{g.client.(*pango.Firewall).Network.GreTunnel, []string{}},
 		"", false, "panos_gre_tunnel", false, "",
 	)
 }
 
 func (g *FirewallNetworkingGenerator) createIKECryptoProfileResources() (resources []terraformutils.Resource) {
-	l, err := g.client.Network.IkeCryptoProfile.GetList()
+	l, err := g.client.(*pango.Firewall).Network.IkeCryptoProfile.GetList()
 	if err != nil {
 		return []terraformutils.Resource{}
 	}
@@ -338,7 +370,7 @@ func (g *FirewallNetworkingGenerator) createIKECryptoProfileResources() (resourc
 }
 
 func (g *FirewallNetworkingGenerator) createIKEGatewayResources() (resources []terraformutils.Resource) {
-	l, err := g.client.Network.IkeGateway.GetList()
+	l, err := g.client.(*pango.Firewall).Network.IkeGateway.GetList()
 	if err != nil {
 		return []terraformutils.Resource{}
 	}
@@ -361,7 +393,7 @@ func (g *FirewallNetworkingGenerator) createIKEGatewayResources() (resources []t
 }
 
 func (g *FirewallNetworkingGenerator) createIPSECCryptoProfileResources() (resources []terraformutils.Resource) {
-	l, err := g.client.Network.IpsecCryptoProfile.GetList()
+	l, err := g.client.(*pango.Firewall).Network.IpsecCryptoProfile.GetList()
 	if err != nil {
 		return []terraformutils.Resource{}
 	}
@@ -385,13 +417,13 @@ func (g *FirewallNetworkingGenerator) createIPSECCryptoProfileResources() (resou
 
 func (g *FirewallNetworkingGenerator) createIPSECTunnelProxyIDIPv4Resources(ipsecTunnel string) []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.IpsecTunnelProxyId, []string{ipsecTunnel}},
+		getGeneric{g.client.(*pango.Firewall).Network.IpsecTunnelProxyId, []string{ipsecTunnel}},
 		ipsecTunnel+":", false, "panos_ipsec_tunnel_proxy_id_ipv4", false, "",
 	)
 }
 
 func (g *FirewallNetworkingGenerator) createIPSECTunnelResources() (resources []terraformutils.Resource) {
-	l, err := g.client.Network.IpsecTunnel.GetList()
+	l, err := g.client.(*pango.Firewall).Network.IpsecTunnel.GetList()
 	if err != nil {
 		return []terraformutils.Resource{}
 	}
@@ -413,27 +445,27 @@ func (g *FirewallNetworkingGenerator) createIPSECTunnelResources() (resources []
 
 func (g *FirewallNetworkingGenerator) createLayer2SubInterfaceResources(interfaceType, parentInterface, parentMode string) []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.Layer2Subinterface, []string{interfaceType, parentInterface, parentMode}},
+		getGeneric{g.client.(*pango.Firewall).Network.Layer2Subinterface, []string{interfaceType, parentInterface, parentMode}},
 		interfaceType+":"+parentInterface+":"+parentMode+":"+g.vsys+":", false, "panos_layer2_subinterface", true, util.InterfaceImport,
 	)
 }
 
 func (g *FirewallNetworkingGenerator) createLayer3SubInterfaceResources(interfaceType, parentInterface string) []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.Layer3Subinterface, []string{interfaceType, parentInterface}},
+		getGeneric{g.client.(*pango.Firewall).Network.Layer3Subinterface, []string{interfaceType, parentInterface}},
 		interfaceType+":"+parentInterface+":"+g.vsys+":", false, "panos_layer3_subinterface", true, util.InterfaceImport,
 	)
 }
 
 func (g *FirewallNetworkingGenerator) createLoopbackInterfaceResources() []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.LoopbackInterface, []string{}},
+		getGeneric{g.client.(*pango.Firewall).Network.LoopbackInterface, []string{}},
 		g.vsys+":", false, "panos_loopback_interface", true, util.InterfaceImport,
 	)
 }
 
 func (g *FirewallNetworkingGenerator) createManagementProfileResources() (resources []terraformutils.Resource) {
-	l, err := g.client.Network.ManagementProfile.GetList()
+	l, err := g.client.(*pango.Firewall).Network.ManagementProfile.GetList()
 	if err != nil {
 		return []terraformutils.Resource{}
 	}
@@ -457,41 +489,41 @@ func (g *FirewallNetworkingGenerator) createManagementProfileResources() (resour
 
 func (g *FirewallNetworkingGenerator) createMonitorProfileResources() []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.MonitorProfile, []string{}},
+		getGeneric{g.client.(*pango.Firewall).Network.MonitorProfile, []string{}},
 		"", false, "panos_monitor_profile", false, "",
 	)
 }
 
 func (g *FirewallNetworkingGenerator) createRedistributionProfileResources(virtualRouter string) []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.RedistributionProfile, []string{virtualRouter}},
+		getGeneric{g.client.(*pango.Firewall).Network.RedistributionProfile, []string{virtualRouter}},
 		virtualRouter+":", true, "panos_redistribution_profile_ipv4", false, "",
 	)
 }
 
 func (g *FirewallNetworkingGenerator) createStaticRouteIpv4Resources(virtualRouter string) []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.StaticRoute, []string{virtualRouter}},
+		getGeneric{g.client.(*pango.Firewall).Network.StaticRoute, []string{virtualRouter}},
 		virtualRouter+":", true, "panos_static_route_ipv4", false, "",
 	)
 }
 
 func (g *FirewallNetworkingGenerator) createTunnelInterfaceResources() []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.TunnelInterface, []string{}},
+		getGeneric{g.client.(*pango.Firewall).Network.TunnelInterface, []string{}},
 		g.vsys+":", false, "panos_tunnel_interface", true, util.InterfaceImport,
 	)
 }
 
 func (g *FirewallNetworkingGenerator) createVirtualRouterResources() (resources []terraformutils.Resource) {
-	l, err := g.client.Network.VirtualRouter.GetList()
+	l, err := g.client.(*pango.Firewall).Network.VirtualRouter.GetList()
 	if err != nil {
 		return []terraformutils.Resource{}
 	}
 
 	for _, virtualRouter := range l {
 		// TODO: doesn't work!!?
-		// rv, err := g.client.IsImported(util.VirtualRouterImport, "", "", g.vsys, virtualRouter)
+		// rv, err := g.client.(*pango.Firewall).IsImported(util.VirtualRouterImport, "", "", g.vsys, virtualRouter)
 		// if err != nil || !rv {
 		// 	continue
 		// }
@@ -524,21 +556,21 @@ func (g *FirewallNetworkingGenerator) createVirtualRouterResources() (resources 
 func (g *FirewallNetworkingGenerator) createVlanResources() []terraformutils.Resource {
 	// TODO: should activate check with util.VlanImport, but doesn't work?
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.Vlan, []string{}},
+		getGeneric{g.client.(*pango.Firewall).Network.Vlan, []string{}},
 		g.vsys+":", false, "panos_vlan", false, "",
 	)
 }
 
 func (g *FirewallNetworkingGenerator) createVlanInterfaceResources() []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.VlanInterface, []string{}},
+		getGeneric{g.client.(*pango.Firewall).Network.VlanInterface, []string{}},
 		g.vsys+":", false, "panos_vlan_interface", true, util.InterfaceImport,
 	)
 }
 
 func (g *FirewallNetworkingGenerator) createZoneResources() []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Network.Zone, []string{g.vsys}},
+		getGeneric{g.client.(*pango.Firewall).Network.Zone, []string{g.vsys}},
 		g.vsys+":", false, "panos_zone", false, "",
 	)
 }
@@ -645,7 +677,6 @@ func (g *FirewallNetworkingGenerator) PostConvertHook() error {
 
 		if r.InstanceInfo.Type == "panos_bgp_peer" {
 			r.Item["virtual_router"] = "${panos_bgp." + normalizeResourceName(r.Item["virtual_router"].(string)) + ".virtual_router}"
-			r.Item["bgp_peer_group"] = "${panos_bgp_peer_group." + normalizeResourceName(r.Item["panos_bgp_peer_group"].(string)) + ".name}"
 			r.Item["peer_as"] = "${panos_bgp." + normalizeResourceName(r.Item["virtual_router"].(string)) + ".as_number}"
 		}
 
@@ -669,7 +700,9 @@ func (g *FirewallNetworkingGenerator) PostConvertHook() error {
 		if r.InstanceInfo.Type == "panos_ipsec_tunnel" {
 			r.Item["tunnel_interface"] = mapInterfaceNames[r.Item["tunnel_interface"].(string)]
 			r.Item["ak_ike_gateway"] = mapIKEGatewayNames[r.Item["ak_ike_gateway"].(string)]
-			r.Item["ak_ipsec_crypto_profile"] = mapIPSECCryptoProfileNames[r.Item["ak_ipsec_crypto_profile"].(string)]
+			if _, ok := r.Item["ak_ipsec_crypto_profile"]; ok {
+				r.Item["ak_ipsec_crypto_profile"] = mapIPSECCryptoProfileNames[r.Item["ak_ipsec_crypto_profile"].(string)]
+			}
 		}
 
 		if r.InstanceInfo.Type == "panos_ipsec_tunnel_proxy_id_ipv4" {

--- a/providers/panos/firewall_objects.go
+++ b/providers/panos/firewall_objects.go
@@ -16,6 +16,7 @@ package panos
 
 import (
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/PaloAltoNetworks/pango"
 )
 
 type FirewallObjectsGenerator struct {
@@ -24,7 +25,7 @@ type FirewallObjectsGenerator struct {
 
 func (g *FirewallObjectsGenerator) createResourcesFromList(o getGeneric, idPrefix string, terraformResourceName string) (resources []terraformutils.Resource) {
 	l, err := o.i.(getListWithOneArg).GetList(o.params[0])
-	if err != nil {
+	if err != nil || len(l) == 0 {
 		return []terraformutils.Resource{}
 	}
 
@@ -69,27 +70,27 @@ func (g *FirewallObjectsGenerator) createResourcesFromListWithVsys(o getGeneric,
 
 func (g *FirewallObjectsGenerator) createAddressGroupResources() []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Objects.AddressGroup, []string{g.vsys}},
+		getGeneric{g.client.(*pango.Firewall).Objects.AddressGroup, []string{g.vsys}},
 		g.vsys+":", "panos_address_group",
 	)
 }
 
 func (g *FirewallObjectsGenerator) createAdministrativeTagResources() []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Objects.Tags, []string{g.vsys}},
+		getGeneric{g.client.(*pango.Firewall).Objects.Tags, []string{g.vsys}},
 		g.vsys+":", "panos_administrative_tag",
 	)
 }
 
 func (g *FirewallObjectsGenerator) createApplicationGroupResources() []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Objects.AppGroup, []string{g.vsys}},
+		getGeneric{g.client.(*pango.Firewall).Objects.AppGroup, []string{g.vsys}},
 		g.vsys+":", "panos_application_group",
 	)
 }
 
 func (g *FirewallObjectsGenerator) createApplicationObjectResources() (resources []terraformutils.Resource) {
-	l, err := g.client.Objects.Application.GetList(g.vsys)
+	l, err := g.client.(*pango.Firewall).Objects.Application.GetList(g.vsys)
 	if err != nil {
 		return []terraformutils.Resource{}
 	}
@@ -113,112 +114,112 @@ func (g *FirewallObjectsGenerator) createApplicationObjectResources() (resources
 
 // func (g *FirewallObjectsGenerator) createApplicationSignatureResources(applicationObject string) []terraformutils.Resource {
 // 	return g.createResourcesFromList(
-// 		getGeneric{g.client.Objects.AppSignature, []string{g.vsys, applicationObject}},
+// 		getGeneric{g.client.(*pango.Firewall).Objects.AppSignature, []string{g.vsys, applicationObject}},
 // 		g.vsys+":"+applicationObject+":", "panos_application_signature",
 // 	)
 // }
 
 func (g *FirewallObjectsGenerator) createEDLResources() []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Objects.Edl, []string{g.vsys}},
+		getGeneric{g.client.(*pango.Firewall).Objects.Edl, []string{g.vsys}},
 		g.vsys+":", "panos_edl",
 	)
 }
 
 func (g *FirewallObjectsGenerator) createLogForwardingResources() []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Objects.LogForwardingProfile, []string{g.vsys}},
+		getGeneric{g.client.(*pango.Firewall).Objects.LogForwardingProfile, []string{g.vsys}},
 		g.vsys+":", "panos_log_forwarding_profile",
 	)
 }
 
 func (g *FirewallObjectsGenerator) createServiceGroupResources() []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Objects.ServiceGroup, []string{g.vsys}},
+		getGeneric{g.client.(*pango.Firewall).Objects.ServiceGroup, []string{g.vsys}},
 		g.vsys+":", "panos_service_group",
 	)
 }
 
 func (g *FirewallObjectsGenerator) createServiceObjectResources() []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Objects.Services, []string{g.vsys}},
+		getGeneric{g.client.(*pango.Firewall).Objects.Services, []string{g.vsys}},
 		g.vsys+":", "panos_service_object",
 	)
 }
 
 func (g *FirewallObjectsGenerator) createAddressObjectResources() []terraformutils.Resource {
 	return g.createResourcesFromList(
-		getGeneric{g.client.Objects.Address, []string{g.vsys}},
+		getGeneric{g.client.(*pango.Firewall).Objects.Address, []string{g.vsys}},
 		g.vsys+":", "panos_address_object",
 	)
 }
 
 func (g *FirewallObjectsGenerator) createAntiSpywareSecurityProfileResources() []terraformutils.Resource {
 	return g.createResourcesFromListWithVsys(
-		getGeneric{g.client.Objects.AntiSpywareProfile, []string{g.vsys}},
+		getGeneric{g.client.(*pango.Firewall).Objects.AntiSpywareProfile, []string{g.vsys}},
 		g.vsys+":", "panos_anti_spyware_security_profile",
 	)
 }
 
 func (g *FirewallObjectsGenerator) createAntivirusSecurityProfileResources() []terraformutils.Resource {
 	return g.createResourcesFromListWithVsys(
-		getGeneric{g.client.Objects.AntivirusProfile, []string{g.vsys}},
+		getGeneric{g.client.(*pango.Firewall).Objects.AntivirusProfile, []string{g.vsys}},
 		g.vsys+":", "panos_antivirus_security_profile",
 	)
 }
 
 func (g *FirewallObjectsGenerator) createCustomDataPatternObjectResources() []terraformutils.Resource {
 	return g.createResourcesFromListWithVsys(
-		getGeneric{g.client.Objects.DataPattern, []string{g.vsys}},
+		getGeneric{g.client.(*pango.Firewall).Objects.DataPattern, []string{g.vsys}},
 		g.vsys+":", "panos_custom_data_pattern_object",
 	)
 }
 
 func (g *FirewallObjectsGenerator) createDataFilteringSecurityProfileResources() []terraformutils.Resource {
 	return g.createResourcesFromListWithVsys(
-		getGeneric{g.client.Objects.DataFilteringProfile, []string{g.vsys}},
+		getGeneric{g.client.(*pango.Firewall).Objects.DataFilteringProfile, []string{g.vsys}},
 		g.vsys+":", "panos_data_filtering_security_profile",
 	)
 }
 
 func (g *FirewallObjectsGenerator) createDOSProtectionProfileResources() []terraformutils.Resource {
 	return g.createResourcesFromListWithVsys(
-		getGeneric{g.client.Objects.DosProtectionProfile, []string{g.vsys}},
+		getGeneric{g.client.(*pango.Firewall).Objects.DosProtectionProfile, []string{g.vsys}},
 		g.vsys+":", "panos_dos_protection_profile",
 	)
 }
 
 func (g *FirewallObjectsGenerator) createDynamicUserGroupResources() []terraformutils.Resource {
 	return g.createResourcesFromListWithVsys(
-		getGeneric{g.client.Objects.DynamicUserGroup, []string{g.vsys}},
+		getGeneric{g.client.(*pango.Firewall).Objects.DynamicUserGroup, []string{g.vsys}},
 		g.vsys+":", "panos_dynamic_user_group",
 	)
 }
 
 func (g *FirewallObjectsGenerator) createFileBlockingSecurityProfileResources() []terraformutils.Resource {
 	return g.createResourcesFromListWithVsys(
-		getGeneric{g.client.Objects.FileBlockingProfile, []string{g.vsys}},
+		getGeneric{g.client.(*pango.Firewall).Objects.FileBlockingProfile, []string{g.vsys}},
 		g.vsys+":", "panos_file_blocking_security_profile",
 	)
 }
 
 func (g *FirewallObjectsGenerator) createURLFilteringSecurityProfileResources() []terraformutils.Resource {
 	return g.createResourcesFromListWithVsys(
-		getGeneric{g.client.Objects.UrlFilteringProfile, []string{g.vsys}},
+		getGeneric{g.client.(*pango.Firewall).Objects.UrlFilteringProfile, []string{g.vsys}},
 		g.vsys+":", "panos_url_filtering_security_profile",
 	)
 }
 
 func (g *FirewallObjectsGenerator) createVulnerabilitySecurityProfileResources() []terraformutils.Resource {
 	return g.createResourcesFromListWithVsys(
-		getGeneric{g.client.Objects.VulnerabilityProfile, []string{g.vsys}},
+		getGeneric{g.client.(*pango.Firewall).Objects.VulnerabilityProfile, []string{g.vsys}},
 		g.vsys+":", "panos_vulnerability_security_profile",
 	)
 }
 
 func (g *FirewallObjectsGenerator) createWildfireAnalysisSecurityProfileResources() []terraformutils.Resource {
 	return g.createResourcesFromListWithVsys(
-		getGeneric{g.client.Objects.WildfireAnalysisProfile, []string{g.vsys}},
+		getGeneric{g.client.(*pango.Firewall).Objects.WildfireAnalysisProfile, []string{g.vsys}},
 		g.vsys+":", "panos_wildfire_analysis_security_profile",
 	)
 }

--- a/providers/panos/panorama_device_config.go
+++ b/providers/panos/panorama_device_config.go
@@ -1,0 +1,308 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package panos
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/PaloAltoNetworks/pango"
+	"github.com/PaloAltoNetworks/pango/util"
+)
+
+type PanoramaDeviceConfigGenerator struct {
+	PanosService
+}
+
+func (g *PanoramaDeviceConfigGenerator) createResourcesFromList(o getGeneric, idPrefix string, useIDForResourceName bool, terraformResourceName string) (resources []terraformutils.Resource) {
+	var l []string
+	var err error
+
+	switch f := o.i.(type) {
+	case getListWithoutArg:
+		l, err = f.GetList()
+	case getListWithTwoArgs:
+		l, err = f.GetList(o.params[0], o.params[1])
+	default:
+		err = fmt.Errorf("not supported")
+	}
+	if err != nil || len(l) == 0 {
+		return []terraformutils.Resource{}
+	}
+
+	for _, r := range l {
+		id := idPrefix + r
+		resources = append(resources, terraformutils.NewSimpleResource(
+			id,
+			normalizeResourceName(func() string {
+				if useIDForResourceName {
+					return id
+				}
+
+				return r
+			}()),
+			terraformResourceName,
+			"panos",
+			[]string{},
+		))
+	}
+
+	return resources
+}
+
+func (g *PanoramaDeviceConfigGenerator) createDeviceGroupResources() []terraformutils.Resource {
+	return g.createResourcesFromList(getGeneric{g.client.(*pango.Panorama).Panorama.DeviceGroup, []string{}},
+		"", false, "panos_panorama_device_group",
+	)
+}
+
+func (g *PanoramaDeviceConfigGenerator) createDeviceGroupParentResources() (resources []terraformutils.Resource) {
+	p, err := g.client.(*pango.Panorama).Panorama.DeviceGroup.GetParents()
+	if err != nil {
+		return resources
+	}
+
+	for dg, parent := range p {
+		if parent != "" {
+			resources = append(resources, terraformutils.NewResource(
+				dg,
+				normalizeResourceName(dg),
+				"panos_device_group_parent",
+				"panos",
+				map[string]string{
+					"device_group": dg,
+					"parent":       parent,
+				},
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+	}
+
+	return resources
+}
+
+func createAttributes(tmpl, ts, dg string) map[string]string {
+	attributes := make(map[string]string)
+
+	if tmpl != "" {
+		attributes["template"] = tmpl
+	}
+	if ts != "" {
+		attributes["template_stack"] = ts
+	}
+	if dg != "" {
+		attributes["device_group"] = dg
+	}
+
+	return attributes
+}
+
+func createServerProfileResources(tmpl, ts, vsys, dg, terraformResourceName string, l []string) (resources []terraformutils.Resource) {
+	attributes := createAttributes(tmpl, ts, dg)
+
+	for _, r := range l {
+		id := tmpl + ":" + ts + ":" + vsys + ":" + dg + ":" + r
+		resources = append(resources, terraformutils.NewResource(
+			id,
+			normalizeResourceName(id),
+			terraformResourceName,
+			"panos",
+			attributes,
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+
+	return resources
+}
+
+func (g *PanoramaDeviceConfigGenerator) createEmailServerProfileResources(tmpl, ts, vsys, dg string) (resources []terraformutils.Resource) {
+	l := make([]string, 0)
+	var err error
+
+	if tmpl != "" || ts != "" {
+		l, err = g.client.(*pango.Panorama).Device.EmailServerProfile.GetList(tmpl, ts, vsys)
+	}
+	if dg != "" {
+		ans := make([]string, 0, 7)
+		ans = append(ans, util.DeviceGroupXpathPrefix(dg)...)
+		ans = append(ans, []string{"log-settings", "email"}...)
+		l, err = g.client.(util.XapiClient).EntryListUsing(g.client.(util.XapiClient).Get, ans)
+	}
+
+	if err != nil || len(l) == 0 {
+		return resources
+	}
+
+	return createServerProfileResources(tmpl, ts, vsys, dg, "panos_panorama_email_server_profile", l)
+}
+
+func (g *PanoramaDeviceConfigGenerator) createHTTPServerProfileResources(tmpl, ts, vsys, dg string) (resources []terraformutils.Resource) {
+	l := make([]string, 0)
+	var err error
+
+	if tmpl != "" || ts != "" {
+		l, err = g.client.(*pango.Panorama).Device.HttpServerProfile.GetList(tmpl, ts, vsys)
+	}
+	if dg != "" {
+		ans := make([]string, 0, 7)
+		ans = append(ans, util.DeviceGroupXpathPrefix(dg)...)
+		ans = append(ans, []string{"log-settings", "http"}...)
+		l, err = g.client.(util.XapiClient).EntryListUsing(g.client.(util.XapiClient).Get, ans)
+	}
+
+	if err != nil || len(l) == 0 {
+		return resources
+	}
+
+	return createServerProfileResources(tmpl, ts, vsys, dg, "panos_panorama_http_server_profile", l)
+}
+
+func (g *PanoramaDeviceConfigGenerator) createSNMPTrapServerProfileResources(tmpl, ts, vsys, dg string) (resources []terraformutils.Resource) {
+	l := make([]string, 0)
+	var err error
+
+	if tmpl != "" || ts != "" {
+		l, err = g.client.(*pango.Panorama).Device.SnmpServerProfile.GetList(tmpl, ts, vsys)
+	}
+	if dg != "" {
+		ans := make([]string, 0, 7)
+		ans = append(ans, util.DeviceGroupXpathPrefix(dg)...)
+		ans = append(ans, []string{"log-settings", "snmptrap"}...)
+		l, err = g.client.(util.XapiClient).EntryListUsing(g.client.(util.XapiClient).Get, ans)
+	}
+
+	if err != nil || len(l) == 0 {
+		return resources
+	}
+
+	return createServerProfileResources(tmpl, ts, vsys, dg, "panos_panorama_snmptrap_server_profile", l)
+}
+
+func (g *PanoramaDeviceConfigGenerator) createSyslogServerProfileResources(tmpl, ts, vsys, dg string) (resources []terraformutils.Resource) {
+	l := make([]string, 0)
+	var err error
+
+	if tmpl != "" || ts != "" {
+		l, err = g.client.(*pango.Panorama).Device.SyslogServerProfile.GetList(tmpl, ts, vsys)
+	}
+	if dg != "" {
+		ans := make([]string, 0, 7)
+		ans = append(ans, util.DeviceGroupXpathPrefix(dg)...)
+		ans = append(ans, []string{"log-settings", "syslog"}...)
+		l, err = g.client.(util.XapiClient).EntryListUsing(g.client.(util.XapiClient).Get, ans)
+	}
+
+	if err != nil || len(l) == 0 {
+		return resources
+	}
+
+	return createServerProfileResources(tmpl, ts, vsys, dg, "panos_panorama_syslog_server_profile", l)
+}
+
+func (g *PanoramaDeviceConfigGenerator) createTemplateResources() []terraformutils.Resource {
+	return g.createResourcesFromList(getGeneric{g.client.(*pango.Panorama).Panorama.Template, []string{}},
+		"", false, "panos_panorama_template",
+	)
+}
+
+func (g *PanoramaDeviceConfigGenerator) createTemplateStackResources() []terraformutils.Resource {
+	return g.createResourcesFromList(getGeneric{g.client.(*pango.Panorama).Panorama.TemplateStack, []string{}},
+		"", false, "panos_panorama_template_stack",
+	)
+}
+
+func (g *PanoramaDeviceConfigGenerator) createTemplateVariableResources(tmpl, ts string) []terraformutils.Resource {
+	return g.createResourcesFromList(getGeneric{g.client.(*pango.Panorama).Panorama.TemplateVariable, []string{tmpl, ts}},
+		tmpl+":"+ts+":", true, "panos_panorama_template_variable",
+	)
+}
+
+func (g *PanoramaDeviceConfigGenerator) InitResources() error {
+	if err := g.Initialize(); err != nil {
+		return err
+	}
+
+	g.Resources = append(g.Resources, g.createTemplateStackResources()...)
+	g.Resources = append(g.Resources, g.createTemplateResources()...)
+	g.Resources = append(g.Resources, g.createDeviceGroupResources()...)
+	g.Resources = append(g.Resources, g.createDeviceGroupParentResources()...)
+
+	ts, err := g.client.(*pango.Panorama).Panorama.TemplateStack.GetList()
+	if err != nil {
+		return err
+	}
+
+	for _, v := range ts {
+		g.Resources = append(g.Resources, g.createTemplateVariableResources("", v)...)
+
+		vsysList, err := g.client.(*pango.Panorama).Vsys.GetList("", v)
+		if err != nil {
+			continue
+		}
+
+		vsysList = append(vsysList, "shared")
+
+		for _, vsys := range vsysList {
+			g.Resources = append(g.Resources, g.createEmailServerProfileResources("", v, vsys, "")...)
+			g.Resources = append(g.Resources, g.createHTTPServerProfileResources("", v, vsys, "")...)
+			g.Resources = append(g.Resources, g.createSNMPTrapServerProfileResources("", v, vsys, "")...)
+			g.Resources = append(g.Resources, g.createSyslogServerProfileResources("", v, vsys, "")...)
+		}
+	}
+
+	tmpl, err := g.client.(*pango.Panorama).Panorama.Template.GetList()
+	if err != nil {
+		return err
+	}
+
+	for _, v := range tmpl {
+		g.Resources = append(g.Resources, g.createTemplateVariableResources(v, "")...)
+
+		vsysList, err := g.client.(*pango.Panorama).Vsys.GetList(v, "")
+		if err != nil {
+			continue
+		}
+		if err != nil {
+			continue
+		}
+
+		vsysList = append(vsysList, "shared")
+
+		for _, vsys := range vsysList {
+			g.Resources = append(g.Resources, g.createEmailServerProfileResources(v, "", vsys, "")...)
+			g.Resources = append(g.Resources, g.createHTTPServerProfileResources(v, "", vsys, "")...)
+			g.Resources = append(g.Resources, g.createSNMPTrapServerProfileResources(v, "", vsys, "")...)
+			g.Resources = append(g.Resources, g.createSyslogServerProfileResources(v, "", vsys, "")...)
+		}
+	}
+
+	dg, err := g.client.(*pango.Panorama).Panorama.DeviceGroup.GetList()
+	if err != nil {
+		return err
+	}
+
+	for _, v := range dg {
+		g.Resources = append(g.Resources, g.createEmailServerProfileResources("", "", "", v)...)
+		g.Resources = append(g.Resources, g.createHTTPServerProfileResources("", "", "", v)...)
+		g.Resources = append(g.Resources, g.createSNMPTrapServerProfileResources("", "", "", v)...)
+		g.Resources = append(g.Resources, g.createSyslogServerProfileResources("", "", "", v)...)
+	}
+
+	// TODO: Panorama's own profiles are not yet supported by the Terraform provider
+
+	return nil
+}

--- a/providers/panos/panorama_networking.go
+++ b/providers/panos/panorama_networking.go
@@ -1,0 +1,931 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package panos
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/PaloAltoNetworks/pango"
+	"github.com/PaloAltoNetworks/pango/netw/interface/eth"
+	"github.com/PaloAltoNetworks/pango/netw/interface/subinterface/layer2"
+	"github.com/PaloAltoNetworks/pango/netw/interface/subinterface/layer3"
+	"github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/vsys"
+)
+
+type PanoramaNetworkingGenerator struct {
+	PanosService
+}
+
+func (g *PanoramaNetworkingGenerator) createResourcesFromList(
+	o getGeneric,
+	idPrefix string,
+	useIDForResourceName bool,
+	terraformResourceName string,
+) (resources []terraformutils.Resource) {
+	var l []string
+	var err error
+
+	switch f := o.i.(type) {
+	case getListWithoutArg:
+		l, err = f.GetList()
+	case getListWithOneArg:
+		l, err = f.GetList(o.params[0])
+	case getListWithTwoArgs:
+		l, err = f.GetList(o.params[0], o.params[1])
+	case getListWithThreeArgs:
+		l, err = f.GetList(o.params[0], o.params[1], o.params[2])
+	case getListWithFourArgs:
+		l, err = f.GetList(o.params[0], o.params[1], o.params[2], o.params[3])
+	case getListWithFiveArgs:
+		l, err = f.GetList(o.params[0], o.params[1], o.params[2], o.params[3], o.params[4])
+	default:
+		err = fmt.Errorf("not supported")
+	}
+	if err != nil || len(l) == 0 {
+		return []terraformutils.Resource{}
+	}
+
+	for _, r := range l {
+		id := idPrefix + r
+		resources = append(resources, terraformutils.NewSimpleResource(
+			id,
+			normalizeResourceName(func() string {
+				if useIDForResourceName {
+					return id
+				}
+
+				return r
+			}()),
+			terraformResourceName,
+			"panos",
+			[]string{},
+		))
+	}
+
+	return resources
+}
+
+func (g *PanoramaNetworkingGenerator) createAggregateInterfaceResources(tmpl, ts string, v []vsys.Entry) (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Network.AggregateInterface.GetList(tmpl, ts)
+	if err != nil {
+		return []terraformutils.Resource{}
+	}
+
+	for _, vsys := range v {
+		for _, aggregateInterface := range l {
+			if !contains(vsys.NetworkImports.Interfaces, aggregateInterface) {
+				continue
+			}
+
+			rv, err := g.client.(*pango.Panorama).IsImported(util.InterfaceImport, tmpl, ts, vsys.Name, aggregateInterface)
+			if err != nil || !rv {
+				continue
+			}
+
+			id := tmpl + ":" + ts + ":" + vsys.Name + ":" + aggregateInterface
+			resources = append(resources, terraformutils.NewSimpleResource(
+				id,
+				normalizeResourceName(id),
+				"panos_panorama_aggregate_interface",
+				"panos",
+				[]string{},
+			))
+
+			e, err := g.client.(*pango.Panorama).Network.AggregateInterface.Get(tmpl, ts, aggregateInterface)
+			if err != nil {
+				continue
+			}
+
+			if e.Mode == eth.ModeLayer2 || e.Mode == eth.ModeVirtualWire {
+				g.Resources = append(g.Resources, g.createLayer2SubInterfaceResources(tmpl, ts, vsys.Name, layer2.EthernetInterface, aggregateInterface, e.Mode)...)
+			}
+
+			if e.Mode == eth.ModeLayer3 {
+				g.Resources = append(g.Resources, g.createLayer3SubInterfaceResources(tmpl, ts, vsys.Name, layer3.EthernetInterface, aggregateInterface)...)
+			}
+		}
+	}
+
+	return resources
+}
+
+func (g *PanoramaNetworkingGenerator) createBFDProfileResources(tmpl, ts string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Network.BfdProfile, []string{tmpl, ts}},
+		tmpl+":"+ts+":", false, "panos_panorama_bfd_profile",
+	)
+}
+
+func (g *PanoramaNetworkingGenerator) createBGPResource(tmpl, ts, virtualRouter string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		tmpl+":"+ts+":"+virtualRouter,
+		normalizeResourceName(tmpl+":"+ts+":"+virtualRouter),
+		"panos_panorama_bgp",
+		"panos",
+		[]string{},
+	)
+}
+
+func (g *PanoramaNetworkingGenerator) createBGPAggregateResources(tmpl, ts, virtualRouter string) (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Network.BgpAggregate.GetList(tmpl, ts, virtualRouter)
+	if err != nil {
+		return []terraformutils.Resource{}
+	}
+
+	for _, bgpAggregate := range l {
+		id := tmpl + ":" + ts + ":" + virtualRouter + ":" + bgpAggregate
+		resources = append(resources, terraformutils.NewSimpleResource(
+			id,
+			normalizeResourceName(id),
+			"panos_panorama_bgp_aggregate",
+			"panos",
+			[]string{},
+		))
+
+		resources = append(resources, g.createBGPAggregateAdvertiseFilterResources(tmpl, ts, virtualRouter, bgpAggregate)...)
+		resources = append(resources, g.createBGPAggregateSuppressFilterResources(tmpl, ts, virtualRouter, bgpAggregate)...)
+	}
+
+	return resources
+}
+
+func (g *PanoramaNetworkingGenerator) createBGPAggregateAdvertiseFilterResources(tmpl, ts, virtualRouter, bgpAggregate string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Network.BgpAggAdvertiseFilter, []string{tmpl, ts, virtualRouter, bgpAggregate}},
+		tmpl+":"+ts+":"+virtualRouter+":"+bgpAggregate+":", true, "panos_panorama_bgp_aggregate_advertise_filter",
+	)
+}
+
+func (g *PanoramaNetworkingGenerator) createBGPAggregateSuppressFilterResources(tmpl, ts, virtualRouter, bgpAggregate string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Network.BgpAggSuppressFilter, []string{tmpl, ts, virtualRouter, bgpAggregate}},
+		tmpl+":"+ts+":"+virtualRouter+":"+bgpAggregate+":", true, "panos_panorama_bgp_aggregate_suppress_filter",
+	)
+}
+
+// The secret argument will contain "(incorrect)", not the real value
+func (g *PanoramaNetworkingGenerator) createBGPAuthProfileResources(tmpl, ts, virtualRouter string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Network.BgpAuthProfile, []string{tmpl, ts, virtualRouter}},
+		tmpl+":"+ts+":"+virtualRouter+":", true, "panos_panorama_bgp_auth_profile",
+	)
+}
+
+func (g *PanoramaNetworkingGenerator) createBGPConditionalAdvertisementResources(tmpl, ts, virtualRouter string) (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Network.BgpConditionalAdv.GetList(tmpl, ts, virtualRouter)
+	if err != nil {
+		return []terraformutils.Resource{}
+	}
+
+	for _, bgpConditionalAdv := range l {
+		id := tmpl + ":" + ts + ":" + virtualRouter + ":" + bgpConditionalAdv
+		resources = append(resources, terraformutils.NewSimpleResource(
+			id,
+			normalizeResourceName(id),
+			"panos_panorama_bgp_conditional_adv",
+			"panos",
+			[]string{},
+		))
+
+		resources = append(resources, g.createBGPConditionalAdvertisementAdvertiseFilterResources(tmpl, ts, virtualRouter, bgpConditionalAdv)...)
+		resources = append(resources, g.createBGPConditionalAdvertisementNonExistFilterResources(tmpl, ts, virtualRouter, bgpConditionalAdv)...)
+	}
+
+	return resources
+}
+
+func (g *PanoramaNetworkingGenerator) createBGPConditionalAdvertisementAdvertiseFilterResources(tmpl, ts, virtualRouter, bgpConditionalAdv string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Network.BgpConAdvAdvertiseFilter, []string{tmpl, ts, virtualRouter, bgpConditionalAdv}},
+		tmpl+":"+ts+":"+virtualRouter+":"+bgpConditionalAdv+":", true, "panos_panorama_bgp_conditional_adv_advertise_filter",
+	)
+}
+
+func (g *PanoramaNetworkingGenerator) createBGPConditionalAdvertisementNonExistFilterResources(tmpl, ts, virtualRouter, bgpConditionalAdv string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Network.BgpConAdvNonExistFilter, []string{tmpl, ts, virtualRouter, bgpConditionalAdv}},
+		tmpl+":"+ts+":"+virtualRouter+":"+bgpConditionalAdv+":", true, "panos_panorama_bgp_conditional_adv_non_exist_filter",
+	)
+}
+
+func (g *PanoramaNetworkingGenerator) createBGPDampeningProfileResources(tmpl, ts, virtualRouter string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Network.BgpDampeningProfile, []string{tmpl, ts, virtualRouter}},
+		tmpl+":"+ts+":"+virtualRouter+":", true, "panos_panorama_bgp_dampening_profile",
+	)
+}
+
+func (g *PanoramaNetworkingGenerator) createBGPExportRuleGroupResources(tmpl, ts, virtualRouter string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Network.BgpExport, []string{tmpl, ts, virtualRouter}},
+		tmpl+":"+ts+":"+virtualRouter+":", true, "panos_panorama_bgp_export_rule_group",
+	)
+}
+
+func (g *PanoramaNetworkingGenerator) createBGPImportRuleGroupResources(tmpl, ts, virtualRouter string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Network.BgpImport, []string{tmpl, ts, virtualRouter}},
+		tmpl+":"+ts+":"+virtualRouter+":", true, "panos_panorama_bgp_import_rule_group",
+	)
+}
+
+func (g *PanoramaNetworkingGenerator) createBGPPeerGroupResources(tmpl, ts, virtualRouter string) (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Network.BgpPeerGroup.GetList(tmpl, ts, virtualRouter)
+	if err != nil {
+		return []terraformutils.Resource{}
+	}
+
+	for _, bgpPeerGroup := range l {
+		id := tmpl + ":" + ts + ":" + virtualRouter + ":" + bgpPeerGroup
+		resources = append(resources, terraformutils.NewSimpleResource(
+			id,
+			normalizeResourceName(id),
+			"panos_panorama_bgp_peer_group",
+			"panos",
+			[]string{},
+		))
+
+		resources = append(resources, g.createBGPPeerResources(tmpl, ts, virtualRouter, bgpPeerGroup)...)
+	}
+
+	return resources
+}
+
+func (g *PanoramaNetworkingGenerator) createBGPPeerResources(tmpl, ts, virtualRouter, bgpPeerGroup string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Network.BgpPeer, []string{tmpl, ts, virtualRouter, bgpPeerGroup}},
+		tmpl+":"+ts+":"+virtualRouter+":"+bgpPeerGroup+":", true, "panos_panorama_bgp_peer",
+	)
+}
+
+func (g *PanoramaNetworkingGenerator) createBGPRedistResources(tmpl, ts, virtualRouter string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Network.BgpRedistRule, []string{tmpl, ts, virtualRouter}},
+		tmpl+":"+ts+":"+virtualRouter+":", true, "panos_panorama_bgp_redist_rule",
+	)
+}
+
+func (g *PanoramaNetworkingGenerator) createEthernetInterfaceResources(tmpl, ts string, v []vsys.Entry) (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Network.EthernetInterface.GetList(tmpl, ts)
+	if err != nil {
+		return []terraformutils.Resource{}
+	}
+
+	for _, vsys := range v {
+		for _, ethernetInterface := range l {
+			if !contains(vsys.NetworkImports.Interfaces, ethernetInterface) {
+				continue
+			}
+
+			rv, err := g.client.(*pango.Panorama).IsImported(util.InterfaceImport, tmpl, ts, vsys.Name, ethernetInterface)
+			if err != nil || !rv {
+				continue
+			}
+
+			id := tmpl + ":" + ts + ":" + vsys.Name + ":" + ethernetInterface
+			resources = append(resources, terraformutils.NewSimpleResource(
+				id,
+				normalizeResourceName(id),
+				"panos_panorama_ethernet_interface",
+				"panos",
+				[]string{},
+			))
+
+			e, err := g.client.(*pango.Panorama).Network.EthernetInterface.Get(tmpl, ts, ethernetInterface)
+			if err != nil {
+				continue
+			}
+
+			if e.Mode == eth.ModeLayer2 || e.Mode == eth.ModeVirtualWire {
+				g.Resources = append(g.Resources, g.createLayer2SubInterfaceResources(tmpl, ts, vsys.Name, layer2.EthernetInterface, ethernetInterface, e.Mode)...)
+			}
+
+			if e.Mode == eth.ModeLayer3 {
+				g.Resources = append(g.Resources, g.createLayer3SubInterfaceResources(tmpl, ts, vsys.Name, layer3.EthernetInterface, ethernetInterface)...)
+			}
+		}
+	}
+
+	return resources
+}
+
+func (g *PanoramaNetworkingGenerator) createGRETunnelResources(tmpl, ts string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Network.GreTunnel, []string{tmpl, ts}},
+		tmpl+":"+ts+":", false, "panos_panorama_gre_tunnel",
+	)
+}
+
+func (g *PanoramaNetworkingGenerator) createIKECryptoProfileResources(tmpl, ts string) (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Network.IkeCryptoProfile.GetList(tmpl, ts)
+	if err != nil {
+		return []terraformutils.Resource{}
+	}
+
+	idPrefix := tmpl + ":" + ts + ":"
+	for _, ikeCryptoProfile := range l {
+		id := idPrefix + ikeCryptoProfile
+		resources = append(resources, terraformutils.NewResource(
+			id,
+			normalizeResourceName(id),
+			"panos_panorama_ike_crypto_profile",
+			"panos",
+			map[string]string{
+				"name": ikeCryptoProfile,
+			},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+
+	return resources
+}
+
+func (g *PanoramaNetworkingGenerator) createIKEGatewayResources(tmpl, ts string) (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Network.IkeGateway.GetList(tmpl, ts)
+	if err != nil {
+		return []terraformutils.Resource{}
+	}
+
+	idPrefix := tmpl + ":" + ts + ":"
+	for _, ikeGateway := range l {
+		id := idPrefix + ikeGateway
+		resources = append(resources, terraformutils.NewResource(
+			id,
+			normalizeResourceName(id),
+			"panos_panorama_ike_gateway",
+			"panos",
+			map[string]string{
+				"name": ikeGateway,
+			},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+
+	return resources
+}
+
+func (g *PanoramaNetworkingGenerator) createIPSECCryptoProfileResources(tmpl, ts string) (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Network.IpsecCryptoProfile.GetList(tmpl, ts)
+	if err != nil {
+		return []terraformutils.Resource{}
+	}
+
+	idPrefix := tmpl + ":" + ts + ":"
+	for _, ipsecCryptoProfile := range l {
+		id := idPrefix + ipsecCryptoProfile
+		resources = append(resources, terraformutils.NewResource(
+			id,
+			normalizeResourceName(id),
+			"panos_panorama_ipsec_crypto_profile",
+			"panos",
+			map[string]string{
+				"name": ipsecCryptoProfile,
+			},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+
+	return resources
+}
+
+func (g *PanoramaNetworkingGenerator) createIPSECTunnelProxyIDIPv4Resources(tmpl, ts, ipsecTunnel string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Network.IpsecTunnelProxyId, []string{tmpl, ts, ipsecTunnel}},
+		tmpl+":"+ts+":"+ipsecTunnel+":", true, "panos_panorama_ipsec_tunnel_proxy_id_ipv4",
+	)
+}
+
+func (g *PanoramaNetworkingGenerator) createIPSECTunnelResources(tmpl, ts string) (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Network.IpsecTunnel.GetList(tmpl, ts)
+	if err != nil {
+		return []terraformutils.Resource{}
+	}
+
+	idPrefix := tmpl + "::"
+	for _, ipsecTunnel := range l {
+		id := idPrefix + ipsecTunnel
+		resources = append(resources, terraformutils.NewSimpleResource(
+			id,
+			normalizeResourceName(id),
+			"panos_panorama_ipsec_tunnel",
+			"panos",
+			[]string{},
+		))
+
+		resources = append(resources, g.createIPSECTunnelProxyIDIPv4Resources(tmpl, ts, ipsecTunnel)...)
+	}
+
+	return resources
+}
+
+func (g *PanoramaNetworkingGenerator) createLayer2SubInterfaceResources(tmpl, ts, vsys, interfaceType, parentInterface, parentMode string) []terraformutils.Resource {
+	// TO FIX: check disabled!
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Network.Layer2Subinterface, []string{tmpl, ts, interfaceType, parentInterface, parentMode}},
+		tmpl+":"+ts+":"+interfaceType+":"+parentInterface+":"+parentMode+":"+vsys+":", true, "panos_panorama_layer2_subinterface",
+	)
+}
+
+func (g *PanoramaNetworkingGenerator) createLayer3SubInterfaceResources(tmpl, ts, vsys, interfaceType, parentInterface string) []terraformutils.Resource {
+	// TO FIX: check disabled!
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Network.Layer3Subinterface, []string{tmpl, ts, interfaceType, parentInterface}},
+		tmpl+":"+ts+":"+interfaceType+":"+parentInterface+":"+vsys+":", true, "panos_panorama_layer3_subinterface",
+	)
+}
+
+func (g *PanoramaNetworkingGenerator) createLoopbackInterfaceResources(tmpl, ts string, v []vsys.Entry) (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Network.LoopbackInterface.GetList(tmpl, ts)
+	if err != nil {
+		return []terraformutils.Resource{}
+	}
+
+	for _, vsys := range v {
+		for _, loopbackInterface := range l {
+			if !contains(vsys.NetworkImports.Interfaces, loopbackInterface) {
+				continue
+			}
+
+			rv, err := g.client.(*pango.Panorama).IsImported(util.InterfaceImport, tmpl, ts, vsys.Name, loopbackInterface)
+			if err != nil || !rv {
+				continue
+			}
+
+			id := tmpl + ":" + ts + ":" + vsys.Name + ":" + loopbackInterface
+			resources = append(resources, terraformutils.NewSimpleResource(
+				id,
+				normalizeResourceName(id),
+				"panos_panorama_loopback_interface",
+				"panos",
+				[]string{},
+			))
+		}
+	}
+
+	return resources
+}
+
+func (g *PanoramaNetworkingGenerator) createManagementProfileResources(tmpl, ts string) (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Network.ManagementProfile.GetList(tmpl, ts)
+	if err != nil {
+		return []terraformutils.Resource{}
+	}
+
+	idPrefix := tmpl + ":" + ts + ":"
+	for _, managementProfile := range l {
+		id := idPrefix + managementProfile
+		resources = append(resources, terraformutils.NewResource(
+			id,
+			normalizeResourceName(id),
+			"panos_panorama_management_profile",
+			"panos",
+			map[string]string{
+				"name": managementProfile,
+			},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+
+	return resources
+}
+
+func (g *PanoramaNetworkingGenerator) createMonitorProfileResources(tmpl, ts string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Network.MonitorProfile, []string{tmpl, ts}},
+		tmpl+":"+ts+":", true, "panos_panorama_monitor_profile",
+	)
+}
+
+func (g *PanoramaNetworkingGenerator) createRedistributionProfileResources(tmpl, ts, virtualRouter string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Network.RedistributionProfile, []string{tmpl, ts, virtualRouter}},
+		tmpl+":"+ts+":"+virtualRouter+":", true, "panos_panorama_redistribution_profile_ipv4",
+	)
+}
+
+func (g *PanoramaNetworkingGenerator) createStaticRouteIpv4Resources(tmpl, ts, virtualRouter string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Network.StaticRoute, []string{tmpl, ts, virtualRouter}},
+		tmpl+":"+ts+":"+virtualRouter+":", true, "panos_panorama_static_route_ipv4",
+	)
+}
+
+func (g *PanoramaNetworkingGenerator) createTunnelInterfaceResources(tmpl, ts string, v []vsys.Entry) (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Network.TunnelInterface.GetList(tmpl, ts)
+	if err != nil {
+		return []terraformutils.Resource{}
+	}
+
+	for _, vsys := range v {
+		for _, tunnelInterface := range l {
+			if !contains(vsys.NetworkImports.Interfaces, tunnelInterface) {
+				continue
+			}
+
+			rv, err := g.client.(*pango.Panorama).IsImported(util.InterfaceImport, tmpl, ts, vsys.Name, tunnelInterface)
+			if err != nil || !rv {
+				continue
+			}
+
+			id := tmpl + ":" + ts + ":" + vsys.Name + ":" + tunnelInterface
+			resources = append(resources, terraformutils.NewSimpleResource(
+				id,
+				normalizeResourceName(id),
+				"panos_panorama_tunnel_interface",
+				"panos",
+				[]string{},
+			))
+		}
+	}
+
+	return resources
+}
+
+func (g *PanoramaNetworkingGenerator) createVirtualRouterResources(tmpl, ts string, v []vsys.Entry) (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Network.VirtualRouter.GetList(tmpl, ts)
+	if err != nil {
+		return []terraformutils.Resource{}
+	}
+
+	for _, vsys := range v {
+		for _, virtualRouter := range l {
+			if !contains(vsys.NetworkImports.VirtualRouters, virtualRouter) {
+				continue
+			}
+
+			// TODO: doesn't work!!?
+			// rv, err := g.client.(*pango.Panorama).IsImported(util.InterfaceImport, tmpl, ts, vsys.Name, virtualRouter)
+			// if err != nil || !rv {
+			// 	continue
+			// }
+
+			id := tmpl + ":" + ts + ":" + vsys.Name + ":" + virtualRouter
+			resources = append(resources, terraformutils.NewSimpleResource(
+				id,
+				normalizeResourceName(id),
+				"panos_panorama_virtual_router",
+				"panos",
+				[]string{},
+			))
+
+			resources = append(resources, g.createBGPResource(tmpl, ts, virtualRouter))
+			resources = append(resources, g.createBGPAggregateResources(tmpl, ts, virtualRouter)...)
+			resources = append(resources, g.createBGPAuthProfileResources(tmpl, ts, virtualRouter)...)
+			resources = append(resources, g.createBGPConditionalAdvertisementResources(tmpl, ts, virtualRouter)...)
+			resources = append(resources, g.createBGPDampeningProfileResources(tmpl, ts, virtualRouter)...)
+			resources = append(resources, g.createBGPExportRuleGroupResources(tmpl, ts, virtualRouter)...)
+			resources = append(resources, g.createBGPImportRuleGroupResources(tmpl, ts, virtualRouter)...)
+			resources = append(resources, g.createBGPPeerGroupResources(tmpl, ts, virtualRouter)...)
+			resources = append(resources, g.createBGPRedistResources(tmpl, ts, virtualRouter)...)
+			resources = append(resources, g.createRedistributionProfileResources(tmpl, ts, virtualRouter)...)
+			resources = append(resources, g.createStaticRouteIpv4Resources(tmpl, ts, virtualRouter)...)
+		}
+	}
+
+	return resources
+}
+
+// FIX: get VLANs in Vsys = None
+func (g *PanoramaNetworkingGenerator) createVlanResources(tmpl, ts string, v []vsys.Entry) (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Network.Vlan.GetList(tmpl, ts)
+	if err != nil {
+		return []terraformutils.Resource{}
+	}
+
+	for _, vsys := range v {
+		for _, vlan := range l {
+			if !contains(vsys.NetworkImports.Vlans, vlan) {
+				continue
+			}
+
+			rv, err := g.client.(*pango.Panorama).IsImported(util.VlanImport, tmpl, ts, vsys.Name, vlan)
+			if err != nil || !rv {
+				continue
+			}
+
+			id := tmpl + ":" + ts + ":" + vsys.Name + ":" + vlan
+			resources = append(resources, terraformutils.NewSimpleResource(
+				id,
+				normalizeResourceName(id),
+				"panos_panorama_vlan",
+				"panos",
+				[]string{},
+			))
+		}
+	}
+
+	return resources
+}
+
+func (g *PanoramaNetworkingGenerator) createVlanInterfaceResources(tmpl, ts string, v []vsys.Entry) (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Network.VlanInterface.GetList(tmpl, ts)
+	if err != nil {
+		return []terraformutils.Resource{}
+	}
+
+	for _, vsys := range v {
+		for _, vlanInterface := range l {
+			if !contains(vsys.NetworkImports.Interfaces, vlanInterface) {
+				continue
+			}
+
+			rv, err := g.client.(*pango.Panorama).IsImported(util.InterfaceImport, tmpl, ts, vsys.Name, vlanInterface)
+			if err != nil || !rv {
+				continue
+			}
+
+			id := tmpl + ":" + ts + ":" + vsys.Name + ":" + vlanInterface
+			resources = append(resources, terraformutils.NewSimpleResource(
+				id,
+				normalizeResourceName(id),
+				"panos_panorama_vlan_interface",
+				"panos",
+				[]string{},
+			))
+		}
+	}
+
+	return resources
+}
+
+func (g *PanoramaNetworkingGenerator) createZoneResources(tmpl, ts string, v []vsys.Entry) (resources []terraformutils.Resource) {
+	for _, vsys := range v {
+		l, err := g.client.(*pango.Panorama).Network.Zone.GetList(tmpl, ts, vsys.Name)
+		if err != nil {
+			return []terraformutils.Resource{}
+		}
+
+		for _, zone := range l {
+			id := tmpl + ":" + ts + ":" + vsys.Name + ":" + zone
+			resources = append(resources, terraformutils.NewSimpleResource(
+				id,
+				normalizeResourceName(id),
+				"panos_panorama_zone",
+				"panos",
+				[]string{},
+			))
+		}
+	}
+
+	return resources
+}
+
+func (g *PanoramaNetworkingGenerator) InitResources() error {
+	if err := g.Initialize(); err != nil {
+		return err
+	}
+
+	ts, err := g.client.(*pango.Panorama).Panorama.TemplateStack.GetList()
+	if err != nil {
+		return err
+	}
+
+	for _, v := range ts {
+		g.Resources = append(g.Resources, g.createBFDProfileResources("", v)...)
+		g.Resources = append(g.Resources, g.createIKECryptoProfileResources("", v)...)
+		g.Resources = append(g.Resources, g.createIKEGatewayResources("", v)...)
+		g.Resources = append(g.Resources, g.createIPSECCryptoProfileResources("", v)...)
+		g.Resources = append(g.Resources, g.createManagementProfileResources("", v)...)
+		g.Resources = append(g.Resources, g.createMonitorProfileResources("", v)...)
+	}
+
+	tmpl, err := g.client.(*pango.Panorama).Panorama.Template.GetList()
+	if err != nil {
+		return err
+	}
+
+	for _, v := range tmpl {
+		vsysAll, err := g.client.(*pango.Panorama).Vsys.GetAll(v, "")
+		if err != nil {
+			return err
+		}
+
+		g.Resources = append(g.Resources, g.createAggregateInterfaceResources(v, "", vsysAll)...)
+		g.Resources = append(g.Resources, g.createBFDProfileResources(v, "")...)
+		g.Resources = append(g.Resources, g.createEthernetInterfaceResources(v, "", vsysAll)...)
+		g.Resources = append(g.Resources, g.createGRETunnelResources(v, "")...)
+		g.Resources = append(g.Resources, g.createIKECryptoProfileResources(v, "")...)
+		g.Resources = append(g.Resources, g.createIKEGatewayResources(v, "")...)
+		g.Resources = append(g.Resources, g.createIPSECCryptoProfileResources(v, "")...)
+		g.Resources = append(g.Resources, g.createIPSECTunnelResources(v, "")...)
+		g.Resources = append(g.Resources, g.createLoopbackInterfaceResources(v, "", vsysAll)...)
+		g.Resources = append(g.Resources, g.createManagementProfileResources(v, "")...)
+		g.Resources = append(g.Resources, g.createMonitorProfileResources(v, "")...)
+		g.Resources = append(g.Resources, g.createTunnelInterfaceResources(v, "", vsysAll)...)
+		g.Resources = append(g.Resources, g.createVirtualRouterResources(v, "", vsysAll)...)
+		g.Resources = append(g.Resources, g.createVlanResources(v, "", vsysAll)...)
+		g.Resources = append(g.Resources, g.createVlanInterfaceResources(v, "", vsysAll)...)
+		g.Resources = append(g.Resources, g.createZoneResources(v, "", vsysAll)...)
+	}
+
+	return nil
+}
+
+func (g *PanoramaNetworkingGenerator) PostConvertHook() error {
+	mapInterfaceNames := map[string]string{}
+	mapInterfaceModes := map[string]string{}
+	mapIKECryptoProfileNames := map[string]string{}
+	mapIKEGatewayNames := map[string]string{}
+	mapIPSECCryptoProfileNames := map[string]string{}
+
+	for _, r := range g.Resources {
+		if r.InstanceInfo.Type == "panos_panorama_aggregate_interface" {
+			mapInterfaceNames[r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
+			mapInterfaceModes[r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".mode}"
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_ethernet_interface" {
+			mapInterfaceNames[r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
+			mapInterfaceModes[r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".mode}"
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_layer2_subinterface" {
+			mapInterfaceNames[r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_layer3_subinterface" {
+			mapInterfaceNames[r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_loopback_interface" {
+			mapInterfaceNames[r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_tunnel_interface" {
+			mapInterfaceNames[r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_vlan_interface" {
+			mapInterfaceNames[r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_ike_crypto_profile" {
+			mapIKECryptoProfileNames[r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_ike_gateway" {
+			mapIKEGatewayNames[r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_ipsec_crypto_profile" {
+			mapIPSECCryptoProfileNames[r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
+		}
+	}
+
+	for _, r := range g.Resources {
+		if r.InstanceInfo.Type == "panos_panorama_bgp" ||
+			r.InstanceInfo.Type == "panos_panorama_redistribution_profile_ipv4" ||
+			r.InstanceInfo.Type == "panos_panorama_static_route_ipv4" {
+			if r.Item["virtual_router"].(string) != "default" {
+				r.Item["virtual_router"] = "${panos_panorama_virtual_router." + normalizeResourceName(r.Item["virtual_router"].(string)) + ".name}"
+			}
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_bgp_aggregate" ||
+			r.InstanceInfo.Type == "panos_panorama_bgp_auth_profile" ||
+			r.InstanceInfo.Type == "panos_panorama_bgp_conditional_adv" ||
+			r.InstanceInfo.Type == "panos_panorama_bgp_dampening_profile" ||
+			r.InstanceInfo.Type == "panos_panorama_bgp_export_rule_group" ||
+			r.InstanceInfo.Type == "panos_panorama_bgp_import_rule_group" ||
+			r.InstanceInfo.Type == "panos_panorama_bgp_peer_group" ||
+			r.InstanceInfo.Type == "panos_panorama_bgp_redist_rule" {
+			if r.Item["virtual_router"].(string) != "default" {
+				r.Item["virtual_router"] = "${panos_panorama_bgp." + normalizeResourceName(r.Item["virtual_router"].(string)) + ".virtual_router}"
+			}
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_bgp_aggregate_advertise_filter" ||
+			r.InstanceInfo.Type == "panos_panorama_bgp_aggregate_suppress_filter" {
+			if r.Item["virtual_router"].(string) != "default" {
+				r.Item["virtual_router"] = "${panos_panorama_bgp_aggregate." + normalizeResourceName(r.Item["virtual_router"].(string)) + ".virtual_router}"
+			}
+			r.Item["bgp_aggregate"] = "${panos_panorama_bgp_aggregate." + normalizeResourceName(r.Item["bgp_aggregate"].(string)) + ".name}"
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_bgp_peer" {
+			if r.Item["virtual_router"].(string) != "default" {
+				r.Item["virtual_router"] = "${panos_panorama_bgp." + normalizeResourceName(r.Item["virtual_router"].(string)) + ".virtual_router}"
+				r.Item["peer_as"] = "${panos_panorama_bgp." + normalizeResourceName(r.Item["virtual_router"].(string)) + ".as_number}"
+			}
+			r.Item["bgp_peer_group"] = "${panos_panorama_bgp_peer_group." + normalizeResourceName(r.Item["panos_bgp_peer_group"].(string)) + ".name}"
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_bgp_conditional_adv_advertise_filter" ||
+			r.InstanceInfo.Type == "panos_panorama_bgp_conditional_adv_non_exist_filter" {
+			if r.Item["virtual_router"].(string) != "default" {
+				r.Item["virtual_router"] = "${panos_panorama_bgp." + normalizeResourceName(r.Item["virtual_router"].(string)) + ".virtual_router}"
+			}
+			r.Item["bgp_conditional_adv"] = "${panos_panorama_bgp_conditional_adv." + normalizeResourceName(r.Item["panos_bgp_conditional_adv"].(string)) + ".name}"
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_gre_tunnel" {
+			r.Item["interface"] = mapInterfaceNames[r.Item["interface"].(string)]
+			r.Item["tunnel_interface"] = mapInterfaceNames[r.Item["tunnel_interface"].(string)]
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_ike_gateway" {
+			if _, ok := r.Item["ikev1_crypto_profile"]; ok {
+				r.Item["ikev1_crypto_profile"] = mapIKECryptoProfileNames[r.Item["ikev1_crypto_profile"].(string)]
+			}
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_ipsec_tunnel" {
+			r.Item["tunnel_interface"] = mapInterfaceNames[r.Item["tunnel_interface"].(string)]
+			r.Item["ak_ike_gateway"] = mapIKEGatewayNames[r.Item["ak_ike_gateway"].(string)]
+			r.Item["ak_ipsec_crypto_profile"] = mapIPSECCryptoProfileNames[r.Item["ak_ipsec_crypto_profile"].(string)]
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_ipsec_tunnel_proxy_id_ipv4" {
+			r.Item["tunnel_interface"] = mapInterfaceNames[r.Item["tunnel_interface"].(string)]
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_layer2_subinterface" {
+			if _, ok := mapInterfaceModes[r.Item["parent_interface"].(string)]; ok {
+				r.Item["parent_mode"] = mapInterfaceModes[r.Item["parent_interface"].(string)]
+			}
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_layer2_subinterface" ||
+			r.InstanceInfo.Type == "panos_panorama_layer3_subinterface" {
+			if _, ok := mapInterfaceNames[r.Item["parent_interface"].(string)]; ok {
+				r.Item["parent_interface"] = mapInterfaceNames[r.Item["parent_interface"].(string)]
+			}
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_virtual_router" {
+			if r.Item["ospfv3_ext_dist"].(string) == "0" {
+				r.Item["ospfv3_ext_dist"] = "110"
+			}
+
+			if r.Item["ebgp_dist"].(string) == "0" {
+				r.Item["ebgp_dist"] = "20"
+			}
+
+			if r.Item["rip_dist"].(string) == "0" {
+				r.Item["rip_dist"] = "120"
+			}
+
+			if r.Item["ibgp_dist"].(string) == "0" {
+				r.Item["ibgp_dist"] = "200"
+			}
+
+			if r.Item["static_dist"].(string) == "0" {
+				r.Item["static_dist"] = "10"
+			}
+
+			if r.Item["ospf_int_dist"].(string) == "0" {
+				r.Item["ospf_int_dist"] = "30"
+			}
+
+			if r.Item["static_ipv6_dist"].(string) == "0" {
+				r.Item["static_ipv6_dist"] = "10"
+			}
+
+			if r.Item["ospf_ext_dist"].(string) == "0" {
+				r.Item["ospf_ext_dist"] = "110"
+			}
+
+			if r.Item["ospfv3_int_dist"].(string) == "0" {
+				r.Item["ospfv3_int_dist"] = "30"
+			}
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_virtual_router" ||
+			r.InstanceInfo.Type == "panos_panorama_zone" {
+			if _, ok := r.Item["interfaces"]; ok {
+				interfaces := make([]string, len(r.Item["interfaces"].([]interface{})))
+				for k, eth := range r.Item["interfaces"].([]interface{}) {
+					if name, ok := mapInterfaceNames[eth.(string)]; ok {
+						interfaces[k] = name
+					}
+				}
+
+				r.Item["interfaces"] = interfaces
+			}
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_vlan" {
+			r.Item["vlan_interface"] = mapInterfaceNames[r.Item["vlan_interface"].(string)]
+		}
+	}
+
+	return nil
+}

--- a/providers/panos/panorama_objects.go
+++ b/providers/panos/panorama_objects.go
@@ -1,0 +1,290 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package panos
+
+import (
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/PaloAltoNetworks/pango"
+)
+
+type PanoramaObjectsGenerator struct {
+	PanosService
+}
+
+func (g *PanoramaObjectsGenerator) createResourcesFromList(o getGeneric, dg string, terraformResourceName string) (resources []terraformutils.Resource) {
+	l, err := o.i.(getListWithOneArg).GetList(o.params[0])
+	if err != nil || len(l) == 0 {
+		return []terraformutils.Resource{}
+	}
+
+	for _, r := range l {
+		id := dg + ":" + r
+		resources = append(resources, terraformutils.NewResource(
+			id,
+			normalizeResourceName(id),
+			terraformResourceName,
+			"panos",
+			map[string]string{
+				"device_group": dg,
+			},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+
+	return resources
+}
+
+func (g *PanoramaObjectsGenerator) createAddressGroupResources(dg string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Objects.AddressGroup, []string{dg}},
+		dg, "panos_panorama_address_group",
+	)
+}
+
+func (g *PanoramaObjectsGenerator) createAdministrativeTagResources(dg string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Objects.Tags, []string{dg}},
+		dg, "panos_panorama_administrative_tag",
+	)
+}
+
+func (g *PanoramaObjectsGenerator) createApplicationGroupResources(dg string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Objects.AppGroup, []string{dg}},
+		dg, "panos_panorama_application_group",
+	)
+}
+
+func (g *PanoramaObjectsGenerator) createApplicationObjectResources(dg string) (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Objects.Application.GetList(dg)
+	if err != nil {
+		return []terraformutils.Resource{}
+	}
+
+	for _, r := range l {
+		id := dg + ":" + r
+		resources = append(resources, terraformutils.NewSimpleResource(
+			id,
+			normalizeResourceName(id),
+			"panos_panorama_application_object",
+			"panos",
+			[]string{},
+		))
+
+		// TODO
+		// resources = append(resources, g.createApplicationSignatureResources(dg, r)...)
+	}
+
+	return resources
+}
+
+func (g *PanoramaObjectsGenerator) createEDLResources(dg string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Objects.Edl, []string{dg}},
+		dg, "panos_panorama_edl",
+	)
+}
+
+func (g *PanoramaObjectsGenerator) createLogForwardingResources(dg string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Objects.LogForwardingProfile, []string{dg}},
+		dg, "panos_panorama_log_forwarding_profile",
+	)
+}
+
+func (g *PanoramaObjectsGenerator) createServiceGroupResources(dg string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Objects.ServiceGroup, []string{dg}},
+		dg, "panos_panorama_service_group",
+	)
+}
+
+func (g *PanoramaObjectsGenerator) createServiceObjectResources(dg string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Objects.Services, []string{dg}},
+		dg, "panos_panorama_service_object",
+	)
+}
+
+func (g *PanoramaObjectsGenerator) createAddressObjectResources(dg string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Objects.Address, []string{dg}},
+		dg, "panos_address_object",
+	)
+}
+
+func (g *PanoramaObjectsGenerator) createAntiSpywareSecurityProfileResources(dg string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Objects.AntiSpywareProfile, []string{dg}},
+		dg, "panos_anti_spyware_security_profile",
+	)
+}
+
+func (g *PanoramaObjectsGenerator) createAntivirusSecurityProfileResources(dg string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Objects.AntivirusProfile, []string{dg}},
+		dg, "panos_antivirus_security_profile",
+	)
+}
+
+func (g *PanoramaObjectsGenerator) createCustomDataPatternObjectResources(dg string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Objects.DataPattern, []string{dg}},
+		dg, "panos_custom_data_pattern_object",
+	)
+}
+
+func (g *PanoramaObjectsGenerator) createDataFilteringSecurityProfileResources(dg string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Objects.DataFilteringProfile, []string{dg}},
+		dg, "panos_data_filtering_security_profile",
+	)
+}
+
+func (g *PanoramaObjectsGenerator) createDOSProtectionProfileResources(dg string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Objects.DosProtectionProfile, []string{dg}},
+		dg, "panos_dos_protection_profile",
+	)
+}
+
+func (g *PanoramaObjectsGenerator) createDynamicUserGroupResources(dg string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Objects.DynamicUserGroup, []string{dg}},
+		dg, "panos_dynamic_user_group",
+	)
+}
+
+func (g *PanoramaObjectsGenerator) createFileBlockingSecurityProfileResources(dg string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Objects.FileBlockingProfile, []string{dg}},
+		dg, "panos_file_blocking_security_profile",
+	)
+}
+
+func (g *PanoramaObjectsGenerator) createURLFilteringSecurityProfileResources(dg string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Objects.UrlFilteringProfile, []string{dg}},
+		dg, "panos_url_filtering_security_profile",
+	)
+}
+
+func (g *PanoramaObjectsGenerator) createVulnerabilitySecurityProfileResources(dg string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Objects.VulnerabilityProfile, []string{dg}},
+		dg, "panos_vulnerability_security_profile",
+	)
+}
+
+func (g *PanoramaObjectsGenerator) createWildfireAnalysisSecurityProfileResources(dg string) []terraformutils.Resource {
+	return g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Objects.WildfireAnalysisProfile, []string{dg}},
+		dg, "panos_wildfire_analysis_security_profile",
+	)
+}
+func (g *PanoramaObjectsGenerator) InitResources() error {
+	if err := g.Initialize(); err != nil {
+		return err
+	}
+
+	dg, err := g.client.(*pango.Panorama).Panorama.DeviceGroup.GetList()
+	if err != nil {
+		return err
+	}
+
+	for _, v := range dg {
+		g.Resources = append(g.Resources, g.createAddressGroupResources(v)...)
+		g.Resources = append(g.Resources, g.createAdministrativeTagResources(v)...)
+		g.Resources = append(g.Resources, g.createApplicationGroupResources(v)...)
+		g.Resources = append(g.Resources, g.createApplicationObjectResources(v)...)
+		g.Resources = append(g.Resources, g.createEDLResources(v)...)
+		g.Resources = append(g.Resources, g.createLogForwardingResources(v)...)
+		g.Resources = append(g.Resources, g.createServiceGroupResources(v)...)
+		g.Resources = append(g.Resources, g.createServiceObjectResources(v)...)
+		g.Resources = append(g.Resources, g.createAddressObjectResources(v)...)
+		g.Resources = append(g.Resources, g.createAntiSpywareSecurityProfileResources(v)...)
+		g.Resources = append(g.Resources, g.createAntivirusSecurityProfileResources(v)...)
+		g.Resources = append(g.Resources, g.createCustomDataPatternObjectResources(v)...)
+		g.Resources = append(g.Resources, g.createDataFilteringSecurityProfileResources(v)...)
+		g.Resources = append(g.Resources, g.createDOSProtectionProfileResources(v)...)
+		g.Resources = append(g.Resources, g.createDynamicUserGroupResources(v)...)
+		g.Resources = append(g.Resources, g.createFileBlockingSecurityProfileResources(v)...)
+		g.Resources = append(g.Resources, g.createURLFilteringSecurityProfileResources(v)...)
+		g.Resources = append(g.Resources, g.createVulnerabilitySecurityProfileResources(v)...)
+		g.Resources = append(g.Resources, g.createWildfireAnalysisSecurityProfileResources(v)...)
+	}
+
+	return nil
+}
+
+func (g *PanoramaObjectsGenerator) PostConvertHook() error {
+	mapAddressObjectIDs := map[string]string{}
+	mapApplicationObjectIDs := map[string]string{}
+	mapServiceObjectIDs := map[string]string{}
+
+	for _, r := range g.Resources {
+		if r.InstanceInfo.Type == "panos_address_object" {
+			mapAddressObjectIDs[r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_application_object" {
+			mapApplicationObjectIDs[r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_service_object" {
+			mapServiceObjectIDs[r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
+		}
+	}
+
+	for _, r := range g.Resources {
+		if r.InstanceInfo.Type == "panos_panorama_address_group" {
+			if _, ok := r.Item["static_addresses"]; ok {
+				staticAddresses := make([]string, len(r.Item["static_addresses"].([]interface{})))
+				for k, staticAddress := range r.Item["static_addresses"].([]interface{}) {
+					staticAddresses[k] = mapAddressObjectIDs[staticAddress.(string)]
+				}
+
+				r.Item["static_addresses"] = staticAddresses
+			}
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_application_group" {
+			if _, ok := r.Item["applications"]; ok {
+				applications := make([]string, len(r.Item["applications"].([]interface{})))
+				for k, application := range r.Item["applications"].([]interface{}) {
+					if _, ok := mapApplicationObjectIDs[application.(string)]; ok {
+						applications[k] = mapApplicationObjectIDs[application.(string)]
+						continue
+					}
+					applications[k] = application.(string)
+				}
+
+				r.Item["applications"] = applications
+			}
+		}
+
+		if r.InstanceInfo.Type == "panos_panorama_service_group" {
+			services := make([]string, len(r.Item["services"].([]interface{})))
+			for k, service := range r.Item["services"].([]interface{}) {
+				services[k] = mapServiceObjectIDs[service.(string)]
+			}
+
+			r.Item["services"] = services
+		}
+	}
+
+	return nil
+}

--- a/providers/panos/panorama_plugins.go
+++ b/providers/panos/panorama_plugins.go
@@ -1,0 +1,113 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package panos
+
+import (
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/PaloAltoNetworks/pango"
+)
+
+type PanoramaPluginsGenerator struct {
+	PanosService
+}
+
+func (g *PanoramaPluginsGenerator) createGCPAccountResources() (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Panorama.GcpAccount.GetList()
+	if err != nil || len(l) == 0 {
+		return resources
+	}
+
+	for _, r := range l {
+		resources = append(resources, terraformutils.NewSimpleResource(
+			r,
+			normalizeResourceName(r),
+			"panos_panorama_gcp_account",
+			"panos",
+			[]string{},
+		))
+	}
+
+	return resources
+}
+
+func (g *PanoramaPluginsGenerator) createGKEClusterResources(group string) (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Panorama.GkeCluster.GetList(group)
+	if err != nil || len(l) == 0 {
+		return resources
+	}
+
+	for _, r := range l {
+		id := group + ":" + r
+		resources = append(resources, terraformutils.NewSimpleResource(
+			id,
+			normalizeResourceName(id),
+			"panos_panorama_gke_cluster",
+			"panos",
+			[]string{},
+		))
+	}
+
+	return resources
+}
+
+func (g *PanoramaPluginsGenerator) createGKEClusterGroupResources() (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Panorama.GkeClusterGroup.GetList()
+	if err != nil || len(l) == 0 {
+		return resources
+	}
+
+	for _, r := range l {
+		resources = append(resources, terraformutils.NewSimpleResource(
+			r,
+			normalizeResourceName(r),
+			"panos_panorama_gke_cluster_group",
+			"panos",
+			[]string{},
+		))
+
+		resources = append(resources, g.createGKEClusterResources(r)...)
+	}
+
+	return resources
+}
+
+func (g *PanoramaPluginsGenerator) InitResources() error {
+	if err := g.Initialize(); err != nil {
+		return err
+	}
+
+	g.Resources = append(g.Resources, g.createGCPAccountResources()...)
+	g.Resources = append(g.Resources, g.createGKEClusterGroupResources()...)
+
+	return nil
+}
+
+func (g *PanoramaPluginsGenerator) PostConvertHook() error {
+	mapGKEClusterGroupNames := map[string]string{}
+
+	for _, r := range g.Resources {
+		if r.InstanceInfo.Type == "panos_panorama_gke_cluster_group" {
+			mapGKEClusterGroupNames[r.Item["name"].(string)] = "${" + r.InstanceInfo.Type + "." + r.ResourceName + ".name}"
+		}
+	}
+
+	for _, r := range g.Resources {
+		if r.InstanceInfo.Type == "panos_panorama_gke_cluster" {
+			r.Item["gke_cluster_group"] = mapGKEClusterGroupNames[r.Item["gke_cluster_group"].(string)]
+		}
+	}
+
+	return nil
+}

--- a/providers/panos/panorama_policy.go
+++ b/providers/panos/panorama_policy.go
@@ -1,0 +1,192 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package panos
+
+import (
+	"encoding/base64"
+	"strconv"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/PaloAltoNetworks/pango"
+	"github.com/PaloAltoNetworks/pango/util"
+)
+
+type PanoramaPolicyGenerator struct {
+	PanosService
+}
+
+func (g *PanoramaPolicyGenerator) createResourcesFromList(o getGeneric, terraformResourceName string) (resources []terraformutils.Resource) {
+	l, err := o.i.(getListWithTwoArgs).GetList(o.params[0], o.params[1])
+	if err != nil || len(l) == 0 {
+		return []terraformutils.Resource{}
+	}
+
+	var positionReference string
+	id := o.params[0] + ":" + o.params[1] + ":" + strconv.Itoa(util.MoveTop) + "::"
+
+	for k, r := range l {
+		if k > 0 {
+			id = o.params[0] + ":" + o.params[1] + ":" + strconv.Itoa(util.MoveAfter) + ":" + positionReference + ":"
+		}
+
+		id += base64.StdEncoding.EncodeToString([]byte(r))
+		positionReference = r
+
+		resources = append(resources, terraformutils.NewSimpleResource(
+			id,
+			normalizeResourceName(o.params[0]+":"+o.params[1]+":"+r),
+			terraformResourceName,
+			"panos",
+			[]string{},
+		))
+	}
+
+	return resources
+}
+
+func (g *PanoramaPolicyGenerator) createNATRuleGroupResources(dg string) (resources []terraformutils.Resource) {
+	resources = append(resources, g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Policies.Nat, []string{dg, util.PreRulebase}},
+		"panos_panorama_nat_rule_group")...,
+	)
+
+	resources = append(resources, g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Policies.Nat, []string{dg, util.Rulebase}},
+		"panos_panorama_nat_rule_group")...,
+	)
+
+	resources = append(resources, g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Policies.Nat, []string{dg, util.PostRulebase}},
+		"panos_panorama_nat_rule_group")...,
+	)
+
+	return resources
+}
+
+func (g *PanoramaPolicyGenerator) createPBFRuleGroupResources(dg string) (resources []terraformutils.Resource) {
+	resources = append(resources, g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Policies.PolicyBasedForwarding, []string{dg, util.PreRulebase}},
+		"panos_panorama_pbf_rule_group")...,
+	)
+
+	resources = append(resources, g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Policies.PolicyBasedForwarding, []string{dg, util.Rulebase}},
+		"panos_panorama_pbf_rule_group")...,
+	)
+
+	resources = append(resources, g.createResourcesFromList(
+		getGeneric{g.client.(*pango.Panorama).Policies.PolicyBasedForwarding, []string{dg, util.PostRulebase}},
+		"panos_panorama_pbf_rule_group")...,
+	)
+
+	return resources
+}
+
+func (g *PanoramaPolicyGenerator) createSecurityRuleGroupRulebaseResources(dg, rulebase string) (resources []terraformutils.Resource) {
+	l, err := g.client.(*pango.Panorama).Policies.Security.GetList(dg, rulebase)
+	if err != nil || len(l) == 0 {
+		return []terraformutils.Resource{}
+	}
+
+	var positionReference string
+	id := dg + ":" + rulebase + ":" + strconv.Itoa(util.MoveTop) + "::"
+
+	for k, r := range l {
+		if k > 0 {
+			id = dg + ":" + rulebase + ":" + strconv.Itoa(util.MoveAfter) + ":" + positionReference + ":"
+		}
+
+		id += base64.StdEncoding.EncodeToString([]byte(r))
+		positionReference = r
+
+		resources = append(resources, terraformutils.NewResource(
+			id,
+			normalizeResourceName(dg+":"+rulebase+":"+r),
+			"panos_panorama_security_rule_group",
+			"panos",
+			map[string]string{
+				"device_group":    dg,
+				"rulebase":        rulebase,
+				"rule.#":          "1", // Add just enough attributes to make the refresh work...
+				"rule.0.name":     r,   // Add just enough attributes to make the refresh work...
+				"rule.0.target.#": "0", // Add just enough attributes to make the refresh work...
+			},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+
+	return resources
+}
+
+func (g *PanoramaPolicyGenerator) createSecurityRuleGroupResources(dg string) (resources []terraformutils.Resource) {
+	resources = append(resources, g.createSecurityRuleGroupRulebaseResources(dg, util.PreRulebase)...)
+	resources = append(resources, g.createSecurityRuleGroupRulebaseResources(dg, util.Rulebase)...)
+	resources = append(resources, g.createSecurityRuleGroupRulebaseResources(dg, util.PostRulebase)...)
+
+	return resources
+}
+
+func (g *PanoramaPolicyGenerator) InitResources() error {
+	if err := g.Initialize(); err != nil {
+		return err
+	}
+
+	dg, err := g.client.(*pango.Panorama).Panorama.DeviceGroup.GetList()
+	if err != nil {
+		return err
+	}
+
+	for _, v := range dg {
+		g.Resources = append(g.Resources, g.createNATRuleGroupResources(v)...)
+		g.Resources = append(g.Resources, g.createPBFRuleGroupResources(v)...)
+		g.Resources = append(g.Resources, g.createSecurityRuleGroupResources(v)...)
+	}
+
+	return nil
+}
+
+func (g *PanoramaPolicyGenerator) PostConvertHook() error {
+	for _, res := range g.Resources {
+		if res.InstanceInfo.Type == "panos_panorama_nat_rule_group" {
+			for _, rule := range res.Item["rule"].([]interface{}) {
+				if _, ok := rule.(map[string]interface{})["translated_packet"]; ok {
+					a := rule.(map[string]interface{})["translated_packet"].([]interface{})
+					for _, b := range a {
+						if _, okb := b.(map[string]interface{})["source"]; !okb {
+							b.(map[string]interface{})["source"] = make(map[string]interface{})
+						}
+					}
+
+					for _, b := range a {
+						if _, okb := b.(map[string]interface{})["destination"]; !okb {
+							b.(map[string]interface{})["destination"] = make(map[string]interface{})
+						}
+					}
+				}
+			}
+		}
+
+		if res.InstanceInfo.Type == "panos_panorama_security_rule_group" {
+			for _, rule := range res.Item["rule"].([]interface{}) {
+				if _, ok := rule.(map[string]interface{})["hip_profiles"]; !ok {
+					rule.(map[string]interface{})["hip_profiles"] = []string{"any"}
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/providers/panos/panos_provider.go
+++ b/providers/panos/panos_provider.go
@@ -68,10 +68,15 @@ func (p *PanosProvider) InitService(serviceName string, verbose bool) error {
 func (p *PanosProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
 
 	return map[string]terraformutils.ServiceGenerator{
-		"device_config":       &DeviceConfigGenerator{},
-		"firewall_networking": &FirewallNetworkingGenerator{},
-		"firewall_objects":    &FirewallObjectsGenerator{},
-		"firewall_policy":     &FirewallPolicyGenerator{},
+		"firewall_device_config": &FirewallDeviceConfigGenerator{},
+		"firewall_networking":    &FirewallNetworkingGenerator{},
+		"firewall_objects":       &FirewallObjectsGenerator{},
+		"firewall_policy":        &FirewallPolicyGenerator{},
+		"panorama_device_config": &PanoramaDeviceConfigGenerator{},
+		"panorama_networking":    &PanoramaNetworkingGenerator{},
+		"panorama_objects":       &PanoramaObjectsGenerator{},
+		"panorama_plugins":       &PanoramaPluginsGenerator{},
+		"panorama_policy":        &PanoramaPolicyGenerator{},
 	}
 }
 

--- a/providers/panos/panos_service.go
+++ b/providers/panos/panos_service.go
@@ -16,12 +16,11 @@ package panos
 
 import (
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
-	"github.com/PaloAltoNetworks/pango"
 )
 
 type PanosService struct { //nolint
 	terraformutils.Service
-	client *pango.Firewall
+	client interface{}
 	vsys   string
 }
 


### PR DESCRIPTION
Add Panorama support to the PAN-OS provider.
- [x] `panorama_device_config`
- [x] `panorama_networking`
- [x] `panorama_objects`
- [x] `panorama_plugins`
- [x] `panorama_policy`

To get the support of `panos_panorama_security_rule_group`, I had to do something really tricky (https://github.com/Trois-Six/terraformer/blob/feat/add-panorama-to-panos/providers/panos/panorama_policy.go#L122-L124), due to https://github.com/PaloAltoNetworks/terraform-provider-panos/blob/master/panos/resource_panorama_security_rule_group.go#L401-L403... but it works!