### PR TITLE
Added support for non-master realms for Provider Keycloak

### DIFF
--- a/providers/keycloak/generator.go
+++ b/providers/keycloak/generator.go
@@ -57,25 +57,25 @@ func (g *RealmGenerator) InitResources() error {
 	// For each realm, get resources
 	for _, realm := range realms {
 		// Get required actions resources
-		requiredActions, err := kck.GetRequiredActions(realm.Id)
+		requiredActions, err := kck.GetRequiredActions(realm.Realm)
 		if err != nil {
-			return fmt.Errorf("keycloak: could not get required actions of realm %s in Keycloak. err: %w", realm.Id, err)
+			return fmt.Errorf("keycloak: could not get required actions of realm %s in Keycloak. err: %w", realm.Realm, err)
 		}
 		g.Resources = append(g.Resources, g.createRequiredActionResources(requiredActions)...)
 
 		// Get top-level authentication flows resources
-		authenticationFlows, err := kck.ListAuthenticationFlows(realm.Id)
+		authenticationFlows, err := kck.ListAuthenticationFlows(realm.Realm)
 		if err != nil {
-			return fmt.Errorf("keycloak: could not get authentication flows of realm %s in Keycloak. err: %w", realm.Id, err)
+			return fmt.Errorf("keycloak: could not get authentication flows of realm %s in Keycloak. err: %w", realm.Realm, err)
 		}
 		g.Resources = append(g.Resources, g.createAuthenticationFlowResources(authenticationFlows)...)
 
 		// For each authentication flow, get subFlow, execution and execution config resources
 		for _, topLevelAuthenticationFlow := range authenticationFlows {
-			authenticationSubFlowOrExecutions, err := kck.ListAuthenticationExecutions(realm.Id, topLevelAuthenticationFlow.Alias)
+			authenticationSubFlowOrExecutions, err := kck.ListAuthenticationExecutions(realm.Realm, topLevelAuthenticationFlow.Alias)
 			if err != nil {
 				return fmt.Errorf("keycloak: could not get authentication executions of authentication flow %s of realm %s in Keycloak. err: %w",
-					topLevelAuthenticationFlow.Alias, realm.Id, err)
+					topLevelAuthenticationFlow.Alias, realm.Realm, err)
 			}
 
 			var stack []*keycloak.AuthenticationExecutionInfo
@@ -109,10 +109,10 @@ func (g *RealmGenerator) InitResources() error {
 
 				switch authenticationSubFlowOrExecution.AuthenticationFlow {
 				case true:
-					authenticationSubFlow, err := kck.GetAuthenticationSubFlow(realm.Id, parentFlowAlias, authenticationSubFlowOrExecution.FlowId)
+					authenticationSubFlow, err := kck.GetAuthenticationSubFlow(realm.Realm, parentFlowAlias, authenticationSubFlowOrExecution.FlowId)
 					if err != nil {
 						return fmt.Errorf("keycloak: could not get authentication subflow %s of realm %s in Keycloak. err: %w",
-							authenticationSubFlowOrExecution.FlowId, realm.Id, err)
+							authenticationSubFlowOrExecution.FlowId, realm.Realm, err)
 					}
 
 					// Need to store the alias and parent flow alias
@@ -123,10 +123,10 @@ func (g *RealmGenerator) InitResources() error {
 					g.Resources = append(g.Resources, resource)
 
 				case false:
-					authenticationExecution, err := kck.GetAuthenticationExecution(realm.Id, parentFlowAlias, authenticationSubFlowOrExecution.Id)
+					authenticationExecution, err := kck.GetAuthenticationExecution(realm.Realm, parentFlowAlias, authenticationSubFlowOrExecution.Id)
 					if err != nil {
 						return fmt.Errorf("keycloak: could not get authentication execution %s of realm %s in Keycloak. err: %w",
-							authenticationSubFlowOrExecution.Id, realm.Id, err)
+							authenticationSubFlowOrExecution.Id, realm.Realm, err)
 					}
 
 					// Need to store the parent flow alias
@@ -137,14 +137,14 @@ func (g *RealmGenerator) InitResources() error {
 
 					if authenticationSubFlowOrExecution.AuthenticationConfig != "" {
 						authenticationExecutionConfig := &keycloak.AuthenticationExecutionConfig{
-							RealmId:     realm.Id,
+							RealmId:     realm.Realm,
 							Id:          authenticationSubFlowOrExecution.AuthenticationConfig,
 							ExecutionId: authenticationSubFlowOrExecution.Id,
 						}
 						err := kck.GetAuthenticationExecutionConfig(authenticationExecutionConfig)
 						if err != nil {
 							return fmt.Errorf("keycloak: could not get authentication execution config %s of realm %s in Keycloak. err: %w",
-								authenticationExecutionConfig.Id, realm.Id, err)
+								authenticationExecutionConfig.Id, realm.Realm, err)
 						}
 
 						g.Resources = append(g.Resources, g.createAuthenticationExecutionConfigResource(authenticationExecutionConfig))
@@ -158,11 +158,11 @@ func (g *RealmGenerator) InitResources() error {
 					if previous.AuthenticationFlow {
 						resouceType = "keycloak_authentication_subflow"
 						resouceName = "authentication_subflow_" +
-							normalizeResourceName(realm.Id) + "_" + normalizeResourceName(previous.FlowId)
+							normalizeResourceName(realm.Realm) + "_" + normalizeResourceName(previous.FlowId)
 					} else {
 						resouceType = "keycloak_authentication_execution"
 						resouceName = "authentication_execution_" +
-							normalizeResourceName(realm.Id) + "_" + normalizeResourceName(previous.Id)
+							normalizeResourceName(realm.Realm) + "_" + normalizeResourceName(previous.Id)
 					}
 					resource.AdditionalFields["depends_on"] = []string{resouceType + "." + terraformutils.TfSanitize(resouceName)}
 				}
@@ -179,49 +179,49 @@ func (g *RealmGenerator) InitResources() error {
 
 		// Get custom federations resources
 		// TODO: support kerberos user federation
-		customUserFederations, err := kck.GetCustomUserFederations(realm.Id)
+		customUserFederations, err := kck.GetCustomUserFederations(realm.Realm)
 		if err != nil {
-			return errors.New("keycloak: could not get custom user federations of realm " + realm.Id + " in Keycloak")
+			return errors.New("keycloak: could not get custom user federations of realm " + realm.Realm + " in Keycloak")
 		}
 		g.Resources = append(g.Resources, g.createCustomUserFederationResources(customUserFederations)...)
 
 		// For each custom federation, get mappers resources
 		for _, customUserFederation := range *customUserFederations {
 			if customUserFederation.ProviderId == "ldap" {
-				mappers, err := kck.GetLdapUserFederationMappers(realm.Id, customUserFederation.Id)
+				mappers, err := kck.GetLdapUserFederationMappers(realm.Realm, customUserFederation.Id)
 				if err != nil {
-					return errors.New("keycloak: could not get mappers of ldap user federation " + customUserFederation.Name + " of realm " + realm.Id + " in Keycloak")
+					return errors.New("keycloak: could not get mappers of ldap user federation " + customUserFederation.Name + " of realm " + realm.Realm + " in Keycloak")
 				}
-				g.Resources = append(g.Resources, g.createLdapMapperResources(realm.Id, customUserFederation.Name, mappers)...)
+				g.Resources = append(g.Resources, g.createLdapMapperResources(realm.Realm, customUserFederation.Name, mappers)...)
 			}
 		}
 
 		// Get groups tree and default groups resources
-		realmGroups, err := kck.GetGroups(realm.Id)
+		realmGroups, err := kck.GetGroups(realm.Realm)
 		if err != nil {
-			return errors.New("keycloak: could not get groups of realm " + realm.Id + " in Keycloak")
+			return errors.New("keycloak: could not get groups of realm " + realm.Realm + " in Keycloak")
 		}
 		realmsGroups = append(realmsGroups, realmGroups...)
-		g.Resources = append(g.Resources, g.createDefaultGroupResource(realm.Id))
+		g.Resources = append(g.Resources, g.createDefaultGroupResource(realm.Realm))
 
 		// Get users resources
-		realmUsers, err := kck.GetUsers(realm.Id)
+		realmUsers, err := kck.GetUsers(realm.Realm)
 		if err != nil {
-			return errors.New("keycloak: could not get users of realm " + realm.Id + " in Keycloak")
+			return errors.New("keycloak: could not get users of realm " + realm.Realm + " in Keycloak")
 		}
 		g.Resources = append(g.Resources, g.createUserResources(realmUsers)...)
 
 		// Get realm open id client scopes resources
-		realmScopes, err := kck.ListOpenidClientScopesWithFilter(realm.Id, func(scope *keycloak.OpenidClientScope) bool { return true })
+		realmScopes, err := kck.ListOpenidClientScopesWithFilter(realm.Realm, func(scope *keycloak.OpenidClientScope) bool { return true })
 		if err != nil {
-			return errors.New("keycloak: could not get realm scopes of realm " + realm.Id + " in Keycloak")
+			return errors.New("keycloak: could not get realm scopes of realm " + realm.Realm + " in Keycloak")
 		}
-		g.Resources = append(g.Resources, g.createScopeResources(realm.Id, realmScopes)...)
+		g.Resources = append(g.Resources, g.createScopeResources(realm.Realm, realmScopes)...)
 
 		// Get open id clients
-		realmClients, err := kck.GetOpenidClients(realm.Id, true)
+		realmClients, err := kck.GetOpenidClients(realm.Realm, true)
 		if err != nil {
-			return errors.New("keycloak: could not get open id clients of realm " + realm.Id + " in Keycloak")
+			return errors.New("keycloak: could not get open id clients of realm " + realm.Realm + " in Keycloak")
 		}
 		g.Resources = append(g.Resources, g.createOpenIDClientResources(realmClients)...)
 
@@ -234,37 +234,37 @@ func (g *RealmGenerator) InitResources() error {
 			mapContainerIDs[client.Id] = "_" + client.ClientId
 
 			// Get open id client protocol mappers resources
-			clientMappers, err := kck.GetGenericClientProtocolMappers(realm.Id, client.Id)
+			clientMappers, err := kck.GetGenericClientProtocolMappers(realm.Realm, client.Id)
 			if err != nil {
-				return errors.New("keycloak: could not get protocol mappers of open id client " + client.ClientId + " of realm " + realm.Id + " in Keycloak")
+				return errors.New("keycloak: could not get protocol mappers of open id client " + client.ClientId + " of realm " + realm.Realm + " in Keycloak")
 			}
 			g.Resources = append(g.Resources, g.createOpenIDProtocolMapperResources(client.ClientId, clientMappers)...)
 
 			// Get open id client default scopes resources
-			clientScopes, err := kck.GetOpenidDefaultClientScopes(realm.Id, client.Id)
+			clientScopes, err := kck.GetOpenidDefaultClientScopes(realm.Realm, client.Id)
 			if err != nil {
-				return errors.New("keycloak: could not get default client scopes of open id client " + client.ClientId + " of realm " + realm.Id + " in Keycloak")
+				return errors.New("keycloak: could not get default client scopes of open id client " + client.ClientId + " of realm " + realm.Realm + " in Keycloak")
 			}
 			if len(*clientScopes) > 0 {
-				g.Resources = append(g.Resources, g.createOpenidClientScopesResources(realm.Id, client.Id, client.ClientId, "default", clientScopes))
+				g.Resources = append(g.Resources, g.createOpenidClientScopesResources(realm.Realm, client.Id, client.ClientId, "default", clientScopes))
 			}
 
 			// Get open id client optional scopes resources
-			clientScopes, err = kck.GetOpenidOptionalClientScopes(realm.Id, client.Id)
+			clientScopes, err = kck.GetOpenidOptionalClientScopes(realm.Realm, client.Id)
 			if err != nil {
-				return errors.New("keycloak: could not get optional client scopes of open id client " + client.ClientId + " of realm " + realm.Id + " in Keycloak")
+				return errors.New("keycloak: could not get optional client scopes of open id client " + client.ClientId + " of realm " + realm.Realm + " in Keycloak")
 			}
 			if len(*clientScopes) > 0 {
-				g.Resources = append(g.Resources, g.createOpenidClientScopesResources(realm.Id, client.Id, client.ClientId, "optional", clientScopes))
+				g.Resources = append(g.Resources, g.createOpenidClientScopesResources(realm.Realm, client.Id, client.ClientId, "optional", clientScopes))
 			}
 
 			// Prepare a slice to be able to link roles associated to service account roles to be associated to the open id client, only if service accounts are enabled
 			if !client.ServiceAccountsEnabled {
 				continue
 			}
-			serviceAccountUser, err := kck.GetOpenidClientServiceAccountUserId(realm.Id, client.Id)
+			serviceAccountUser, err := kck.GetOpenidClientServiceAccountUserId(realm.Realm, client.Id)
 			if err != nil {
-				return errors.New("keycloak: could not get service account user associated to open id client " + client.ClientId + " of realm " + realm.Id + " in Keycloak")
+				return errors.New("keycloak: could not get service account user associated to open id client " + client.ClientId + " of realm " + realm.Realm + " in Keycloak")
 			}
 			mapServiceAccountIds[serviceAccountUser.Id] = map[string]string{}
 			mapServiceAccountIds[serviceAccountUser.Id]["Id"] = client.Id
@@ -272,20 +272,20 @@ func (g *RealmGenerator) InitResources() error {
 		}
 
 		// Get open id client roles
-		clientRoles, err := kck.GetClientRoles(realm.Id, realmClients)
+		clientRoles, err := kck.GetClientRoles(realm.Realm, realmClients)
 		if err != nil {
-			return errors.New("keycloak: could not get open id clients roles of realm " + realm.Id + " in Keycloak")
+			return errors.New("keycloak: could not get open id clients roles of realm " + realm.Realm + " in Keycloak")
 		}
 
 		// Get roles
-		realmRoles, err := kck.GetRealmRoles(realm.Id)
+		realmRoles, err := kck.GetRealmRoles(realm.Realm)
 		if err != nil {
-			return errors.New("keycloak: could not get realm roles of realm " + realm.Id + " in Keycloak")
+			return errors.New("keycloak: could not get realm roles of realm " + realm.Realm + " in Keycloak")
 		}
 
 		// Set ContainerId of the roles, for realm = "", for open id clients = "_" + client.ClientId
 		// and get roles resources
-		mapContainerIDs[realm.Id] = ""
+		mapContainerIDs[realm.Realm] = ""
 		roles := append(clientRoles, realmRoles...)
 		for _, role := range roles {
 			role.ContainerId = mapContainerIDs[role.ContainerId]
@@ -293,11 +293,11 @@ func (g *RealmGenerator) InitResources() error {
 		g.Resources = append(g.Resources, g.createRoleResources(roles)...)
 
 		// Get service account roles resources
-		usersInRole, err := kck.GetClientRoleUsers(realm.Id, clientRoles)
+		usersInRole, err := kck.GetClientRoleUsers(realm.Realm, clientRoles)
 		if err != nil {
-			return errors.New("keycloak: could not get users roles of realm " + realm.Id + " in Keycloak")
+			return errors.New("keycloak: could not get users roles of realm " + realm.Realm + " in Keycloak")
 		}
-		g.Resources = append(g.Resources, g.createServiceAccountClientRolesResources(realm.Id, clientRoles, *usersInRole, mapServiceAccountIds, mapClientIDs)...)
+		g.Resources = append(g.Resources, g.createServiceAccountClientRolesResources(realm.Realm, clientRoles, *usersInRole, mapServiceAccountIds, mapClientIDs)...)
 	}
 
 	// Parse the groups trees, and get all the groups


### PR DESCRIPTION
This commit fixes an issue that prevented the import of non-master realms for Keycloak. The current codebase uses realm ID (realm.Id) as an argument when calling the Keycloak Admin API, whereas the realm name (realm.Realm) should have been used. It did not previously affect the Master realm as its ID and name is the same, but not so for other realms.