### PR TITLE
Issue #962 add Hashicorp Vault provider partial support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ A CLI tool that generates `tf`/`json` and `tfstate` files based on existing infr
         * [Xen Orchestra](/docs/xen.md)
         * [GmailFilter](/docs/gmailfilter.md)
         * [Grafana](/docs/grafana.md)
+        * [Vault](/docs/vault.md)
 - [Contributing](#contributing)
 - [Developing](#developing)
 - [Infrastructure](#infrastructure)
@@ -277,6 +278,7 @@ Links to download Terraform Providers:
     * Mikrotik provider >= 0.2.2 - [here](https://github.com/ddelnano/terraform-provider-mikrotik)
     * Xen Orchestra provider >= 0.18.0 - [here](https://github.com/ddelnano/terraform-provider-xenorchestra)
     * GmailFilter provider >= 1.0.1 - [here](https://github.com/yamamoto-febc/terraform-provider-gmailfilter)
+    * Vault provider - [here](https://github.com/hashicorp/terraform-provider-vault)
 
 Information on provider plugins:
 https://www.terraform.io/docs/configuration/providers.html

--- a/cmd/provider_cmd_vault.go
+++ b/cmd/provider_cmd_vault.go
@@ -1,0 +1,48 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cmd
+
+import (
+	vault_terraforming "github.com/GoogleCloudPlatform/terraformer/providers/vault"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/spf13/cobra"
+)
+
+func newCmdVaultImporter(options ImportOptions) *cobra.Command {
+	var token, address string
+	cmd := &cobra.Command{
+		Use:   "vault",
+		Short: "Import current state to Terraform configuration from Vault",
+		Long:  "Import current state to Terraform configuration from Vault",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			provider := newVaultProvider()
+			err := Import(provider, options, []string{address, token})
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.AddCommand(listCmd(newVaultProvider()))
+	cmd.PersistentFlags().StringVarP(&address, "address", "a", "", "env param VAULT_ADDR")
+	cmd.PersistentFlags().StringVarP(&token, "token", "t", "", "env param VAULT_TOKEN")
+	baseProviderFlags(cmd.PersistentFlags(), &options, "", "")
+	return cmd
+}
+
+func newVaultProvider() terraformutils.ProviderGenerator {
+	return &vault_terraforming.VaultProvider{}
+}

--- a/cmd/provider_cmd_vault.go
+++ b/cmd/provider_cmd_vault.go
@@ -44,5 +44,5 @@ func newCmdVaultImporter(options ImportOptions) *cobra.Command {
 }
 
 func newVaultProvider() terraformutils.ProviderGenerator {
-	return &vault_terraforming.VaultProvider{}
+	return &vault_terraforming.Provider{}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,6 +76,7 @@ func providerImporterSubcommands() []func(options ImportOptions) *cobra.Command 
 		newCmdMikrotikImporter,
 		newCmdXenorchestraImporter,
 		newCmdGmailfilterImporter,
+		newCmdVaultImporter,
 	}
 }
 
@@ -117,6 +118,7 @@ func providerGenerators() map[string]func() terraformutils.ProviderGenerator {
 		newMikrotikProvider,
 		newXenorchestraProvider,
 		newGmailfilterProvider,
+		newVaultProvider,
 	} {
 		list[providerGen().GetName()] = providerGen
 	}

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -1,0 +1,85 @@
+### Use with Vault
+
+Example:
+
+```
+ ./terraformer import vault --resources=aws_secret_backend_role --token=YOUR_VAULT_TOKEN // or VAULT_TOKEN in env --address=YOUR_VAULT_ADDRESS // or VAULT_ADDR in env
+ ./terraformer import vault --resources=policy --filter=policy=id1:id2:id4 --token=YOUR_VAULT_TOKEN // or VAULT_TOKEN in env --address=YOUR_VAULT_ADDRESS // or VAULT_ADDR in env
+```
+
+List of supported Datadog services:
+
+* `ad_secret_backend`
+    * `ad_secret_backend`
+* `ad_secret_backend_role`
+    * `ad_secret_backend_role`
+* `alicloud_auth_backend_role`
+    * `alicloud_auth_backend_role`
+* `approle_auth_backend_role`
+    * `approle_auth_backend_role`
+* `aws_auth_backend_role`
+    * `aws_auth_backend_role`
+* `aws_secret_backend`
+    * `aws_secret_backend`
+* `aws_secret_backend_role`
+    * `aws_secret_backend_role`
+* `azure_auth_backend_role`
+    * `azure_auth_backend_role`
+* `azure_secret_backend`
+    * `azure_secret_backend`
+* `azure_secret_backend_role`
+    * `azure_secret_backend_role`
+* `cert_auth_backend_role`
+    * `cert_auth_backend_role`
+* `consul_secret_backend`
+    * `consul_secret_backend`
+* `consul_secret_backend_role`
+    * `consul_secret_backend_role`
+* `database_secret_backend_role`
+    * `database_secret_backend_role`
+* `gcp_auth_backend`
+    * `gcp_auth_backend`
+* `gcp_auth_backend_role`
+    * `gcp_auth_backend_role`
+* `gcp_secret_backend`
+    * `gcp_secret_backend`
+* `github_auth_backend`
+    * `github_auth_backend`
+* `jwt_auth_backend`
+    * `jwt_auth_backend`
+* `jwt_auth_backend_role`
+    * `jwt_auth_backend_role`
+* `kubernetes_auth_backend_role`
+    * `kubernetes_auth_backend_role`
+* `ldap_auth_backend`
+    * `ldap_auth_backend`
+* `ldap_auth_backend_group`
+    * `ldap_auth_backend_group`
+* `ldap_auth_backend_user`
+    * `ldap_auth_backend_user`
+* `nomad_secret_backend`
+    * `nomad_secret_backend`
+* `okta_auth_backend`
+    * `okta_auth_backend`
+* `okta_auth_backend_group`
+    * `okta_auth_backend_group`
+* `okta_auth_backend_user`
+    * `okta_auth_backend_user`
+* `pki_secret_backend`
+    * `pki_secret_backend`
+* `pki_secret_backend_role`
+    * `pki_secret_backend_role`
+* `policy`
+    * `policy`
+* `rabbitmq_secret_backend`
+    * `rabbitmq_secret_backend`
+* `rabbitmq_secret_backend_role`
+    * `rabbitmq_secret_backend_role`
+* `ssh_secret_backend_role`
+    * `ssh_secret_backend_role`
+* `terraform_cloud_secret_backend`
+    * `terraform_cloud_secret_backend`
+* `token_auth_backend_role`
+    * `token_auth_backend_role`
+
+[1]: https://github.com/GoogleCloudPlatform/terraformer/blob/master/README.md#filtering

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -43,6 +43,8 @@ List of supported Datadog services:
     * `gcp_auth_backend_role`
 * `gcp_secret_backend`
     * `gcp_secret_backend`
+* `generic_secret`
+    * `generic_secret`
 * `github_auth_backend`
     * `github_auth_backend`
 * `jwt_auth_backend`

--- a/go.mod
+++ b/go.mod
@@ -112,6 +112,7 @@ require (
 	github.com/hashicorp/go-plugin v1.4.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/terraform v0.12.31
+	github.com/hashicorp/vault v0.10.4
 	github.com/heimweh/go-pagerduty v0.0.0-20210412205347-cc0e5d3c14d4
 	github.com/heroku/heroku-go/v5 v5.1.0
 	github.com/hokaccha/go-prettyjson v0.0.0-20210113012101-fb4e108d2519 // indirect
@@ -126,6 +127,7 @@ require (
 	github.com/packethost/packngo v0.9.0
 	github.com/paultyng/go-newrelic/v4 v4.10.0
 	github.com/pkg/errors v0.9.1
+	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/tencentcloud/tencentcloud-sdk-go v3.0.233+incompatible

--- a/go.sum
+++ b/go.sum
@@ -540,6 +540,7 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -647,11 +648,13 @@ github.com/hashicorp/go-retryablehttp v0.6.2/go.mod h1:gEx6HMUGxYYhJScX7W1Il64m6
 github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-retryablehttp v0.6.7 h1:8/CAEZt/+F7kR7GevNHulKkUjLht3CPmn7egmhieNKo=
 github.com/hashicorp/go-retryablehttp v0.6.7/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-rootcerts v1.0.0 h1:Rqb66Oo1X/eSV1x66xbDccZjhJigjg0+e82kpwzSwCI=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
 github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
+github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-tfe v0.8.1/go.mod h1:XAV72S4O1iP8BDaqiaPLmL2B4EE6almocnOn8E8stHc=
@@ -688,6 +691,7 @@ github.com/hashicorp/terraform-plugin-sdk v1.6.0 h1:Um5hsAL7kKsfTHtan8lybY/d03F2
 github.com/hashicorp/terraform-plugin-sdk v1.6.0/go.mod h1:H5QLx/uhwfxBZ59Bc5SqT19M4i+fYt7LZjHTpbLZiAg=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 h1:hjyO2JsNZUKT1ym+FAdlBEkGPevazYsmVgIMw7dVELg=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
+github.com/hashicorp/vault v0.10.4 h1:4x0lHxui/ZRp/B3E0Auv1QNBJpzETqHR2kQD3mHSBJU=
 github.com/hashicorp/vault v0.10.4/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bAbosPMpP0=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
@@ -929,6 +933,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
+github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=

--- a/providers/vault/types.go
+++ b/providers/vault/types.go
@@ -1,5 +1,0 @@
-package vault
-
-type secretBackend struct {
-	t string
-}

--- a/providers/vault/types.go
+++ b/providers/vault/types.go
@@ -1,0 +1,5 @@
+package vault
+
+type secretBackend struct {
+	t string
+}

--- a/providers/vault/vault_provider.go
+++ b/providers/vault/vault_provider.go
@@ -1,0 +1,102 @@
+package vault
+
+import (
+	"errors"
+	"fmt"
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/zclconf/go-cty/cty"
+	"os"
+	"strings"
+)
+
+type VaultProvider struct {
+	terraformutils.Provider
+	token   string
+	address string
+}
+
+func (p *VaultProvider) Init(args []string) error {
+
+	if address := os.Getenv("VAULT_ADDR"); address != "" {
+		p.address = os.Getenv("VAULT_ADDR")
+	}
+
+	if token := os.Getenv("VAULT_TOKEN"); token != "" {
+		p.token = os.Getenv("VAULT_TOKEN")
+	}
+
+	if len(args) > 0 && args[0] != "" {
+		p.address = args[0]
+	}
+
+	if len(args) > 1 && args[1] != "" {
+		p.token = args[1]
+	}
+
+	return nil
+}
+
+func (p *VaultProvider) GetConfig() cty.Value {
+	return cty.ObjectVal(map[string]cty.Value{
+		"token":   cty.StringVal(p.token),
+		"address": cty.StringVal(p.address),
+	})
+}
+
+func (p *VaultProvider) GetName() string {
+	return "vault"
+}
+
+func (p *VaultProvider) InitService(serviceName string, verbose bool) error {
+	if service, ok := p.GetSupportedService()[serviceName]; ok {
+		p.Service = service
+		p.Service.SetName(serviceName)
+		p.Service.SetVerbose(verbose)
+		p.Service.SetProviderName(p.GetName())
+		p.Service.SetArgs(map[string]interface{}{
+			"token":   p.token,
+			"address": p.address,
+		})
+		if err := service.(*ServiceGenerator).setVaultClient(); err != nil {
+			return err
+		}
+		return nil
+	}
+	return errors.New(p.GetName() + ": " + serviceName + " not supported service")
+}
+
+func getSupportedEngineServices() []string {
+	var services []string
+	mapping := map[string][]string{
+		"secret_backend": {"ad", "aws", "azure", "consul", "gcp", "nomad", "pki", "rabbitmq", "terraform_cloud"},
+		"secret_backend_role": {"ad", "aws", "azure", "consul", "database", "pki", "rabbitmq", "ssh"},
+		"auth_backend": {"gcp", "github", "jwt", "ldap", "okta"},
+		"auth_backend_role": {"alicloud", "approle", "aws", "azure", "cert", "gcp", "jwt", "kubernetes", "token"},
+		"auth_backend_user": {"ldap", "okta"},
+		"auth_backend_group": {"ldap", "okta"},
+	}
+	for resource, mountTypes := range mapping {
+		for _, mountType := range mountTypes {
+			services = append(services, fmt.Sprintf("%s_%s", mountType, resource))
+		}
+	}
+	return services
+}
+
+func (p *VaultProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
+	generators := make(map[string]terraformutils.ServiceGenerator)
+	for _, service := range getSupportedEngineServices() {
+		split := strings.SplitN(service, "_", 2)
+		generators[service] = &ServiceGenerator{mountType: split[0], resource: split[1]}
+	}
+	generators["policy"] = &ServiceGenerator{resource: "policy"}
+	return generators
+}
+
+func (VaultProvider) GetResourceConnections() map[string]map[string][]string {
+	return map[string]map[string][]string{}
+}
+
+func (VaultProvider) GetProviderData(_ ...string) map[string]interface{} {
+	return map[string]interface{}{}
+}

--- a/providers/vault/vault_provider.go
+++ b/providers/vault/vault_provider.go
@@ -3,9 +3,10 @@ package vault
 import (
 	"errors"
 	"fmt"
+	"os"
+
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
 	"github.com/zclconf/go-cty/cty"
-	"os"
 )
 
 type Provider struct {
@@ -63,8 +64,6 @@ func (p *Provider) InitService(serviceName string, verbose bool) error {
 	}
 	return errors.New(p.GetName() + ": " + serviceName + " not supported service")
 }
-
-
 
 func getSupportedMountServices() map[string]terraformutils.ServiceGenerator {
 	services := make(map[string]terraformutils.ServiceGenerator)

--- a/providers/vault/vault_provider.go
+++ b/providers/vault/vault_provider.go
@@ -3,19 +3,20 @@ package vault
 import (
 	"errors"
 	"fmt"
-	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
-	"github.com/zclconf/go-cty/cty"
 	"os"
 	"strings"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/zclconf/go-cty/cty"
 )
 
-type VaultProvider struct {
+type Provider struct {
 	terraformutils.Provider
 	token   string
 	address string
 }
 
-func (p *VaultProvider) Init(args []string) error {
+func (p *Provider) Init(args []string) error {
 
 	if address := os.Getenv("VAULT_ADDR"); address != "" {
 		p.address = os.Getenv("VAULT_ADDR")
@@ -36,18 +37,18 @@ func (p *VaultProvider) Init(args []string) error {
 	return nil
 }
 
-func (p *VaultProvider) GetConfig() cty.Value {
+func (p *Provider) GetConfig() cty.Value {
 	return cty.ObjectVal(map[string]cty.Value{
 		"token":   cty.StringVal(p.token),
 		"address": cty.StringVal(p.address),
 	})
 }
 
-func (p *VaultProvider) GetName() string {
+func (p *Provider) GetName() string {
 	return "vault"
 }
 
-func (p *VaultProvider) InitService(serviceName string, verbose bool) error {
+func (p *Provider) InitService(serviceName string, verbose bool) error {
 	if service, ok := p.GetSupportedService()[serviceName]; ok {
 		p.Service = service
 		p.Service.SetName(serviceName)
@@ -68,12 +69,12 @@ func (p *VaultProvider) InitService(serviceName string, verbose bool) error {
 func getSupportedEngineServices() []string {
 	var services []string
 	mapping := map[string][]string{
-		"secret_backend": {"ad", "aws", "azure", "consul", "gcp", "nomad", "pki", "rabbitmq", "terraform_cloud"},
+		"secret_backend":      {"ad", "aws", "azure", "consul", "gcp", "nomad", "pki", "rabbitmq", "terraform_cloud"},
 		"secret_backend_role": {"ad", "aws", "azure", "consul", "database", "pki", "rabbitmq", "ssh"},
-		"auth_backend": {"gcp", "github", "jwt", "ldap", "okta"},
-		"auth_backend_role": {"alicloud", "approle", "aws", "azure", "cert", "gcp", "jwt", "kubernetes", "token"},
-		"auth_backend_user": {"ldap", "okta"},
-		"auth_backend_group": {"ldap", "okta"},
+		"auth_backend":        {"gcp", "github", "jwt", "ldap", "okta"},
+		"auth_backend_role":   {"alicloud", "approle", "aws", "azure", "cert", "gcp", "jwt", "kubernetes", "token"},
+		"auth_backend_user":   {"ldap", "okta"},
+		"auth_backend_group":  {"ldap", "okta"},
 	}
 	for resource, mountTypes := range mapping {
 		for _, mountType := range mountTypes {
@@ -83,7 +84,7 @@ func getSupportedEngineServices() []string {
 	return services
 }
 
-func (p *VaultProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
+func (p *Provider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
 	generators := make(map[string]terraformutils.ServiceGenerator)
 	for _, service := range getSupportedEngineServices() {
 		split := strings.SplitN(service, "_", 2)
@@ -93,10 +94,10 @@ func (p *VaultProvider) GetSupportedService() map[string]terraformutils.ServiceG
 	return generators
 }
 
-func (VaultProvider) GetResourceConnections() map[string]map[string][]string {
+func (Provider) GetResourceConnections() map[string]map[string][]string {
 	return map[string]map[string][]string{}
 }
 
-func (VaultProvider) GetProviderData(_ ...string) map[string]interface{} {
+func (Provider) GetProviderData(_ ...string) map[string]interface{} {
 	return map[string]interface{}{}
 }

--- a/providers/vault/vault_service_generator.go
+++ b/providers/vault/vault_service_generator.go
@@ -114,25 +114,27 @@ func (g *ServiceGenerator) mountsByType() ([]string, error) {
 			continue
 		}
 		id := strings.ReplaceAll(name, "/", "")
-		add := true
-		for _, filter := range g.Filter {
+		if g.filterAllow(fmt.Sprintf("%s_secret_backend", mount.Type), id) {
+			typeMounts = append(typeMounts, id)
+		}
+	}
+	return typeMounts, nil
+}
+
+func(g *ServiceGenerator) filterAllow(serviceName, id string) bool {
+	add := true
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" &&
+			filter.IsApplicable(serviceName) {
 			for _, value := range filter.AcceptableValues {
 				add = value == id
 				if add {
 					break
 				}
 			}
-			add = add && filter.FieldPath == "id" &&
-				filter.IsApplicable(fmt.Sprintf("%s_secret_backend", mount.Type))
-			if add {
-				break
-			}
-		}
-		if add {
-			typeMounts = append(typeMounts, id)
 		}
 	}
-	return typeMounts, nil
+	return add
 }
 
 func (g *ServiceGenerator) createAuthBackendResources() error {
@@ -197,21 +199,7 @@ func (g *ServiceGenerator) backendsByType() ([]string, error) {
 			continue
 		}
 		id := strings.ReplaceAll(name, "/", "")
-		add := true
-		for _, filter := range g.Filter {
-			for _, value := range filter.AcceptableValues {
-				add = value == id
-				if add {
-					break
-				}
-			}
-			add = add && filter.FieldPath == "id" &&
-				filter.IsApplicable(fmt.Sprintf("%s_auth_backend", authBackend.Type))
-			if add {
-				break
-			}
-		}
-		if add {
+		if g.filterAllow(fmt.Sprintf("%s_auth_backend", authBackend.Type), id) {
 			typeBackends = append(typeBackends, id)
 		}
 	}

--- a/providers/vault/vault_service_generator.go
+++ b/providers/vault/vault_service_generator.go
@@ -3,10 +3,11 @@ package vault
 import (
 	"errors"
 	"fmt"
-	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
-	vault "github.com/hashicorp/vault/api"
 	"log"
 	"strings"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	vault "github.com/hashicorp/vault/api"
 )
 
 type ServiceGenerator struct { //nolint

--- a/providers/vault/vault_service_generator.go
+++ b/providers/vault/vault_service_generator.go
@@ -1,0 +1,233 @@
+package vault
+
+import (
+	"errors"
+	"fmt"
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	vault "github.com/hashicorp/vault/api"
+	"log"
+	"strings"
+)
+
+type ServiceGenerator struct { //nolint
+	terraformutils.Service
+	client    *vault.Client
+	mountType string
+	resource  string
+}
+
+func (g *ServiceGenerator) setVaultClient() error {
+	client, err := vault.NewClient(&vault.Config{Address: g.Args["address"].(string)})
+	if err != nil {
+		return err
+	}
+	if g.Args["token"] != "" {
+		client.SetToken(g.Args["token"].(string))
+	}
+	g.client = client
+	return nil
+}
+
+func (g *ServiceGenerator) InitResources() error {
+	switch g.resource {
+	case "secret_backend":
+		return g.createSecretBackendResources()
+	case "secret_backend_role":
+		return g.createSecretBackendRoleResources()
+	case "auth_backend":
+		return g.createAuthBackendResources()
+	case "auth_backend_role":
+		return g.createAuthBackendEntityResources("role", "role")
+	case "auth_backend_user":
+		return g.createAuthBackendEntityResources("users", "user")
+	case "auth_backend_group":
+		return g.createAuthBackendEntityResources("groups", "group")
+	case "policy":
+		return g.createPolicyResources()
+	default:
+		return errors.New("unsupported service type. shouldn't ever reach here")
+	}
+}
+
+func (g *ServiceGenerator) createSecretBackendResources() error {
+	mounts, err := g.mountsByType()
+	if err != nil {
+		return err
+	}
+	for _, mount := range mounts {
+		g.Resources = append(g.Resources,
+			terraformutils.NewSimpleResource(
+				mount,
+				mount,
+				fmt.Sprintf("vault_%s_secret_backend", g.mountType),
+				g.ProviderName,
+				[]string{}))
+	}
+	return nil
+}
+
+func (g *ServiceGenerator) createSecretBackendRoleResources() error {
+	mounts, err := g.mountsByType()
+	if err != nil {
+		return err
+	}
+	for _, mount := range mounts {
+		path := fmt.Sprintf("%s/roles", mount)
+		s, err := g.client.Logical().List(path)
+		if err != nil {
+			log.Printf("error calling path %s: %s", path, err)
+			continue
+		}
+		if s == nil {
+			log.Printf("call to %s returned nil result", path)
+			continue
+		}
+		roles, ok := s.Data["keys"]
+		if !ok {
+			log.Printf("no keys in call to %s", path)
+			continue
+		}
+		for _, role := range roles.([]interface{}) {
+			g.Resources = append(g.Resources,
+				terraformutils.NewSimpleResource(
+					fmt.Sprintf("%s/roles/%s", mount, role),
+					fmt.Sprintf("%s_%s", mount, role),
+					fmt.Sprintf("vault_%s_secret_backend_role", g.mountType),
+					g.ProviderName,
+					[]string{}))
+		}
+	}
+	return nil
+}
+
+func (g *ServiceGenerator) mountsByType() ([]string, error) {
+	mounts, err := g.client.Sys().ListMounts()
+	if err != nil {
+		return nil, err
+	}
+	var typeMounts []string
+	for name, mount := range mounts {
+		if mount.Type != g.mountType {
+			continue
+		}
+		id := strings.ReplaceAll(name, "/", "")
+		add := true
+		for _, filter := range g.Filter {
+			for _, value := range filter.AcceptableValues {
+				add = value == id
+				if add {
+					break
+				}
+			}
+			add = add && filter.FieldPath == "id" &&
+				filter.IsApplicable(fmt.Sprintf("%s_secret_backend", mount.Type))
+			if add {
+				break
+			}
+		}
+		if add {
+			typeMounts = append(typeMounts, id)
+		}
+	}
+	return typeMounts, nil
+}
+
+func (g *ServiceGenerator) createAuthBackendResources() error {
+	backends, err := g.backendsByType()
+	if err != nil {
+		return err
+	}
+	for _, backend := range backends {
+		g.Resources = append(g.Resources,
+			terraformutils.NewSimpleResource(
+				backend,
+				backend,
+				fmt.Sprintf("vault_%s_auth_backend", g.mountType),
+				g.ProviderName,
+				[]string{}))
+	}
+	return nil
+}
+
+func (g *ServiceGenerator) createAuthBackendEntityResources(apiEntity, tfEntity string) error {
+	backends, err := g.backendsByType()
+	if err != nil {
+		return err
+	}
+	for _, backend := range backends {
+		path := fmt.Sprintf("/auth/%s/%s", backend, apiEntity)
+		s, err := g.client.Logical().List(path)
+		if err != nil {
+			log.Printf("error calling path %s: %s", path, err)
+			continue
+		}
+		if s == nil {
+			log.Printf("call to %s returned nil result", path)
+			continue
+		}
+		names, ok := s.Data["keys"]
+		if !ok {
+			log.Printf("no keys in call to %s", path)
+			continue
+		}
+		for _, name := range names.([]interface{}) {
+			g.Resources = append(g.Resources,
+				terraformutils.NewSimpleResource(
+					fmt.Sprintf("auth/%s/%s/%s", backend, apiEntity, name),
+					fmt.Sprintf("%s_%s", backend, name),
+					fmt.Sprintf("vault_%s_auth_backend_%s", g.mountType, tfEntity),
+					g.ProviderName,
+					[]string{}))
+		}
+	}
+	return nil
+}
+
+func (g *ServiceGenerator) backendsByType() ([]string, error) {
+	authBackends, err := g.client.Sys().ListAuth()
+	if err != nil {
+		return nil, err
+	}
+	var typeBackends []string
+	for name, authBackend := range authBackends {
+		if authBackend.Type != g.mountType {
+			continue
+		}
+		id := strings.ReplaceAll(name, "/", "")
+		add := true
+		for _, filter := range g.Filter {
+			for _, value := range filter.AcceptableValues {
+				add = value == id
+				if add {
+					break
+				}
+			}
+			add = add && filter.FieldPath == "id" &&
+				filter.IsApplicable(fmt.Sprintf("%s_auth_backend", authBackend.Type))
+			if add {
+				break
+			}
+		}
+		if add {
+			typeBackends = append(typeBackends, id)
+		}
+	}
+	return typeBackends, nil
+}
+
+func (g *ServiceGenerator) createPolicyResources() error {
+	policies, err := g.client.Sys().ListPolicies()
+	if err != nil {
+		return err
+	}
+	for _, policy := range policies {
+		g.Resources = append(g.Resources,
+			terraformutils.NewSimpleResource(
+				policy,
+				policy,
+				"vault_policy",
+				g.ProviderName,
+				[]string{}))
+	}
+	return nil
+}

--- a/providers/vault/vault_service_generator.go
+++ b/providers/vault/vault_service_generator.go
@@ -263,7 +263,7 @@ func (g *ServiceGenerator) PostConvertHook() error {
 		switch resource.InstanceInfo.Type {
 		case "vault_aws_secret_backend_role":
 			if policyDocument, ok := resource.Item["policy_document"]; ok {
-				//borrowed from providers/aws/aws_service.go
+				// borrowed from providers/aws/aws_service.go
 				sanitizedPolicy := regexp.MustCompile(`(\${[0-9A-Za-z:]+})`).
 					ReplaceAllString(policyDocument.(string), "$$$1")
 				resource.Item["policy_document"] = fmt.Sprintf(`<<POLICY

--- a/providers/vault/vault_service_generator.go
+++ b/providers/vault/vault_service_generator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
@@ -273,6 +274,15 @@ POLICY`, sanitizedPolicy)
 		case "vault_policy":
 			if _, ok := resource.Item["policy"]; !ok {
 				resource.Item["policy"] = ""
+			}
+		case "vault_ldap_auth_backend_group":
+			if policies, ok := resource.Item["policies"]; ok {
+				var strPolicies []string
+				for _, policy := range policies.([]interface{}) {
+					strPolicies = append(strPolicies, policy.(string))
+				}
+				sort.Strings(strPolicies)
+				resource.Item["policies"] = strPolicies
 			}
 		}
 	}


### PR DESCRIPTION
This commit includes the boilerplate for the Vault provider, as well
as support for Secret Engine, Secret Engine Roles, Auth Backends, Auth
Backend Roles, Auth Backend Users, Auth Backend Groups, and Policies. This is
done by instantiating a common Vault client using its official Go client
library and leveraging the naming convention of Vault tf resources to support
most of the Secret/Auth options available in the provider itself. The
provider configuration includes only the minimum required `address` and `token`
fields. Filtering roles/users/groups by mount type is supported as well as
basic filtering by resource ids.