### PR TITLE
Support Grafana 8

### DIFF
--- a/providers/grafana/dashboard.go
+++ b/providers/grafana/dashboard.go
@@ -46,7 +46,7 @@ func (g *DashboardGenerator) createDashboardResources(client *gapi.Client) error
 
 		filename := fmt.Sprintf("dashboard-%s.json", dash.Meta.Slug)
 		resource := terraformutils.NewResource(
-			dash.Meta.Slug,
+			dashboard.UID,
 			dashboard.Title,
 			"grafana_dashboard",
 			"grafana",


### PR DESCRIPTION
This PR updates the Grafana provider to support Grafana versions >= 8.0.0.

Before Grafana 5.x, the only way to `GET` dashboards was by means of passing the dashboard slug name. With version 5.0.0, that changed to also include the ability to get by UID. Now, in version 8, the old route was deleted: https://grafana.com/docs/grafana/latest/release-notes/release-notes-8-0-0/#breaking-changes.

This change will break the provider for users of Grafana < 5.0.0, but since that release has been out for three years, and this provider is fairly new to Terraformer, we don't think that this should be a concern for us.