### PR TITLE
Remove filterAllow function when fetching Vault backend ids

### DIFF
--- a/providers/vault/vault_provider.go
+++ b/providers/vault/vault_provider.go
@@ -87,6 +87,7 @@ func getSupportedMountServices() map[string]terraformutils.ServiceGenerator {
 func (p *Provider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
 	generators := getSupportedMountServices()
 	generators["policy"] = &ServiceGenerator{resource: "policy"}
+	generators["mount"] = &ServiceGenerator{resource: "mount"}
 	generators["generic_secret"] = &ServiceGenerator{resource: "generic_secret", mountType: "kv"}
 	return generators
 }

--- a/providers/vault/vault_service_generator.go
+++ b/providers/vault/vault_service_generator.go
@@ -116,27 +116,9 @@ func (g *ServiceGenerator) mountsByType() ([]string, error) {
 			continue
 		}
 		id := strings.ReplaceAll(name, "/", "")
-		if g.filterAllow(fmt.Sprintf("%s_secret_backend", mount.Type), id) {
-			typeMounts = append(typeMounts, id)
-		}
+		typeMounts = append(typeMounts, id)
 	}
 	return typeMounts, nil
-}
-
-func (g *ServiceGenerator) filterAllow(serviceName, id string) bool {
-	add := true
-	for _, filter := range g.Filter {
-		if filter.FieldPath == "id" &&
-			filter.IsApplicable(serviceName) {
-			for _, value := range filter.AcceptableValues {
-				add = value == id
-				if add {
-					break
-				}
-			}
-		}
-	}
-	return add
 }
 
 func (g *ServiceGenerator) createAuthBackendResources() error {
@@ -201,9 +183,7 @@ func (g *ServiceGenerator) backendsByType() ([]string, error) {
 			continue
 		}
 		id := strings.ReplaceAll(name, "/", "")
-		if g.filterAllow(fmt.Sprintf("%s_auth_backend", authBackend.Type), id) {
-			typeBackends = append(typeBackends, id)
-		}
+		typeBackends = append(typeBackends, id)
 	}
 	return typeBackends, nil
 }

--- a/providers/vault/vault_service_generator.go
+++ b/providers/vault/vault_service_generator.go
@@ -49,6 +49,8 @@ func (g *ServiceGenerator) InitResources() error {
 		return g.createPolicyResources()
 	case "generic_secret":
 		return g.createGenericSecretResources()
+	case "mount":
+		return g.createMountResources()
 	default:
 		return errors.New("unsupported service type. shouldn't ever reach here")
 	}
@@ -112,11 +114,10 @@ func (g *ServiceGenerator) mountsByType() ([]string, error) {
 	}
 	var typeMounts []string
 	for name, mount := range mounts {
-		if mount.Type != g.mountType {
-			continue
+		if g.mountType == "" || mount.Type == g.mountType {
+			id := strings.ReplaceAll(name, "/", "")
+			typeMounts = append(typeMounts, id)
 		}
-		id := strings.ReplaceAll(name, "/", "")
-		typeMounts = append(typeMounts, id)
 	}
 	return typeMounts, nil
 }
@@ -235,6 +236,23 @@ func (g *ServiceGenerator) createGenericSecretResources() error {
 					g.ProviderName,
 					[]string{}))
 		}
+	}
+	return nil
+}
+
+func (g *ServiceGenerator) createMountResources() error {
+	mounts, err := g.mountsByType()
+	if err != nil {
+		return err
+	}
+	for _, mount := range mounts {
+		g.Resources = append(g.Resources,
+			terraformutils.NewSimpleResource(
+				mount,
+				mount,
+				"vault_mount",
+				g.ProviderName,
+				[]string{}))
 	}
 	return nil
 }


### PR DESCRIPTION
Follow up on Issue #964. Filtering by backend can be done using the regular filtering mechanism, so its unnecessary to have this filter here as well

Also adds [vault_mount](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/mount) resource