### PR TITLE
Fix ignored blocks when all attributes are ignored although it includes nested blocks

### DIFF
--- a/terraformutils/providerwrapper/provider.go
+++ b/terraformutils/providerwrapper/provider.go
@@ -151,7 +151,8 @@ func (p *ProviderWrapper) readObjBlocks(block map[string]*configschema.NestedBlo
 				}
 			}
 		}
-		if fieldCount == len(v.Block.Attributes) && fieldCount > 0 {
+		log.Println("check this", len(v.BlockTypes))
+		if fieldCount == len(v.Block.Attributes) && fieldCount > 0 && len(v.BlockTypes) == 0 {
 			readOnlyAttributes = append(readOnlyAttributes, "^"+k)
 		}
 	}

--- a/terraformutils/providerwrapper/provider.go
+++ b/terraformutils/providerwrapper/provider.go
@@ -151,7 +151,6 @@ func (p *ProviderWrapper) readObjBlocks(block map[string]*configschema.NestedBlo
 				}
 			}
 		}
-		log.Println("check this", len(v.BlockTypes))
 		if fieldCount == len(v.Block.Attributes) && fieldCount > 0 && len(v.BlockTypes) == 0 {
 			readOnlyAttributes = append(readOnlyAttributes, "^"+k)
 		}


### PR DESCRIPTION
This PR attempts to resolve: https://github.com/GoogleCloudPlatform/terraformer/issues/982

The widget schema that is currently ignored: https://github.com/DataDog/terraform-provider-datadog/blob/141501334a01ba32c14cc243d6df835087c70a76/datadog/resource_datadog_dashboard.go#L598

**Behavior**:
The above widget schema contains a single attribute `id`, which is `computed`, and many `NestedBlocks`. Hence when the `readObjBlocks` is called on the `widget` block, `if fieldCount == len(v.Block.Attributes) && fieldCount > 0` will compute to `True` and the regex `^widget` is added to the ignore list.

The logic behind this seems to be to ignore the entire block if all attributes within the block are computed. This PR adds an extra conditional to ensure that block is not ignored if it has nested blocks.