### PR TITLE
search generic secrets engine recursively

### DIFF
--- a/providers/vault/vault_service_generator.go
+++ b/providers/vault/vault_service_generator.go
@@ -239,7 +239,7 @@ func (g *ServiceGenerator) createGenericSecretResourcesPerMount(path string) {
 	for _, secret := range secrets.([]interface{}) {
 		secretStr := secret.(string)
 		secretLen := len(secretStr)
-		newPath := path+secretStr
+		newPath := path + secretStr
 		// Folders are suffixed with `/`: https://www.vaultproject.io/api-docs/secret/kv/kv-v1#list-secrets
 		if secretStr[secretLen-1:secretLen] == "/" {
 			g.createGenericSecretResourcesPerMount(newPath)
@@ -248,7 +248,7 @@ func (g *ServiceGenerator) createGenericSecretResourcesPerMount(path string) {
 		g.Resources = append(g.Resources,
 			terraformutils.NewSimpleResource(
 				newPath,
-				strings.Replace(newPath, "/", "_", -1),
+				strings.ReplaceAll(newPath, "/", "_"),
 				"vault_generic_secret",
 				g.ProviderName,
 				[]string{}))

--- a/providers/vault/vault_service_generator.go
+++ b/providers/vault/vault_service_generator.go
@@ -216,31 +216,43 @@ func (g *ServiceGenerator) createGenericSecretResources() error {
 	}
 	for _, mount := range mounts {
 		path := fmt.Sprintf("%s/", mount)
-		s, err := g.client.Logical().List(path)
-		if err != nil {
-			log.Printf("error calling path %s: %s", path, err)
-			continue
-		}
-		if s == nil {
-			log.Printf("call to %s returned nil result", path)
-			continue
-		}
-		secrets, ok := s.Data["keys"]
-		if !ok {
-			log.Printf("no keys in call to %s", path)
-			continue
-		}
-		for _, secret := range secrets.([]interface{}) {
-			g.Resources = append(g.Resources,
-				terraformutils.NewSimpleResource(
-					fmt.Sprintf("%s/%s", mount, secret),
-					fmt.Sprintf("%s_%s", mount, secret),
-					"vault_generic_secret",
-					g.ProviderName,
-					[]string{}))
-		}
+		g.createGenericSecretResourcesPerMount(path)
 	}
 	return nil
+}
+
+func (g *ServiceGenerator) createGenericSecretResourcesPerMount(path string) {
+	s, err := g.client.Logical().List(path)
+	if err != nil {
+		log.Printf("error calling path %s: %s", path, err)
+		return
+	}
+	if s == nil {
+		log.Printf("call to %s returned nil result", path)
+		return
+	}
+	secrets, ok := s.Data["keys"]
+	if !ok {
+		log.Printf("no keys in call to %s", path)
+		return
+	}
+	for _, secret := range secrets.([]interface{}) {
+		secretStr := secret.(string)
+		secretLen := len(secretStr)
+		newPath := path+secretStr
+		// Folders are suffixed with `/`: https://www.vaultproject.io/api-docs/secret/kv/kv-v1#list-secrets
+		if secretStr[secretLen-1:secretLen] == "/" {
+			g.createGenericSecretResourcesPerMount(newPath)
+			continue
+		}
+		g.Resources = append(g.Resources,
+			terraformutils.NewSimpleResource(
+				newPath,
+				strings.Replace(newPath, "/", "_", -1),
+				"vault_generic_secret",
+				g.ProviderName,
+				[]string{}))
+	}
 }
 
 func (g *ServiceGenerator) createMountResources() error {

--- a/providers/vault/vault_service_generator.go
+++ b/providers/vault/vault_service_generator.go
@@ -296,8 +296,8 @@ POLICY`, sanitizedPolicy)
 		case "vault_generic_secret":
 			if data, ok := resource.Item["data_json"]; ok {
 				dataStr := data.(string)
-				strings.ReplaceAll(dataStr, "%{", "%%{")
-				strings.ReplaceAll(dataStr, "${", "$${")
+				dataStr = strings.ReplaceAll(dataStr, "%{", "%%{")
+				dataStr = strings.ReplaceAll(dataStr, "${", "$${")
 				resource.Item["data_json"] = dataStr
 			}
 		}

--- a/providers/vault/vault_service_generator.go
+++ b/providers/vault/vault_service_generator.go
@@ -293,6 +293,13 @@ POLICY`, sanitizedPolicy)
 				sort.Strings(strPolicies)
 				resource.Item["policies"] = strPolicies
 			}
+		case "vault_generic_secret":
+			if data, ok := resource.Item["data_json"]; ok {
+				dataStr := data.(string)
+				strings.ReplaceAll(dataStr, "%{", "%%{")
+				strings.ReplaceAll(dataStr, "${", "$${")
+				resource.Item["data_json"] = dataStr
+			}
 		}
 	}
 	return nil

--- a/terraformutils/json.go
+++ b/terraformutils/json.go
@@ -18,9 +18,9 @@ func jsonPrint(data interface{}) ([]byte, error) {
 		return []byte{}, fmt.Errorf("error marshalling terraform data to json: %v", err)
 	}
 	// We don't need to escape > or <
-	s := strings.ReplaceAll(string(dataJSONBytes), "\\u003c", "<")
+	s := strings.ReplaceAll(string(dataJSONBytes), "\\\\u003c", "<")
 	s = OpeningBracketRegexp.ReplaceAllStringFunc(s, escapingBackslashReplacer("<"))
-	s = strings.ReplaceAll(s, "\\u003e", ">")
+	s = strings.ReplaceAll(s, "\\\\u003e", ">")
 	s = ClosingBracketRegexp.ReplaceAllStringFunc(s, escapingBackslashReplacer(">"))
 	return []byte(s), nil
 }


### PR DESCRIPTION
In the Vault KV Secret Backend, the code was not scanning recursively properly, so only secrets that weren't in nested paths were being imported be Terraformer. This PR fixes this by recursively scanning the whole secrets backend to pull all secrets