### PR TITLE
Fix GitHub repoitory_collaborator resource user login

### DIFF
--- a/providers/github/repositories.go
+++ b/providers/github/repositories.go
@@ -120,8 +120,8 @@ func (g *RepositoriesGenerator) createRepositoryCollaboratorResources(ctx contex
 	}
 	for _, collaborator := range collaborators {
 		resources = append(resources, terraformutils.NewSimpleResource(
-			repo.GetName()+":"+collaborator.GetName(),
-			repo.GetName()+":"+collaborator.GetName(),
+			repo.GetName()+":"+collaborator.GetLogin(),
+			repo.GetName()+":"+collaborator.GetLogin(),
 			"github_repository_collaborator",
 			"github",
 			[]string{},


### PR DESCRIPTION
The display name was used for GitHub users instead of the login name, leading to errors while refreshing when they are different.

Fixes part of #990, where these issues were reported.