### PR TITLE
fix to accept PAGERDUTY_TOKEN in env for PagerDuty

### DIFF
--- a/providers/pagerduty/pagerduty_provider.go
+++ b/providers/pagerduty/pagerduty_provider.go
@@ -31,7 +31,7 @@ func (p *PagerDutyProvider) Init(args []string) error {
 	if token := os.Getenv("PAGERDUTY_TOKEN"); token != "" {
 		p.token = os.Getenv("PAGERDUTY_TOKEN")
 	}
-	if len(args) > 0 {
+	if len(args) > 0 && args[0] != "" {
 		p.token = args[0]
 	}
 	return nil


### PR DESCRIPTION
**Problem**
Although [Docs](https://github.com/GoogleCloudPlatform/terraformer/blob/e31a0f68a8fc8be9385d0c615d924bd95bd50b2d/docs/pagerduty.md) say `PAGERDUTY_TOKEN` in env is available, terraformer ignored the token when I tried the below:
```
$ export PAGERDUTY_TOKEN=hogehoge
$ terraformer import pagerduty -r user
```

**Cause**
`args[0]==TOKEN` if I specify `-t TOKEN` otherwise `args[0]==""`.
When `PAGERDUTY_TOKEN` in env is set and `-t TOKEN` is not specified, p.token (assigned `$PAGERDUTY_TOKEN` at l.32) is overwritten as "" in l.34.