### PR TITLE
Fix aws codebuild pagination

### DIFF
--- a/providers/aws/codebuild.go
+++ b/providers/aws/codebuild.go
@@ -27,19 +27,6 @@ type CodeBuildGenerator struct {
 	AWSService
 }
 
-func (g *CodeBuildGenerator) createResources(projectList []string) []terraformutils.Resource {
-	var resources []terraformutils.Resource
-	for _, project := range projectList {
-		resources = append(resources, terraformutils.NewSimpleResource(
-			project,
-			project,
-			"aws_codebuild_project",
-			"aws",
-			codebuildAllowEmptyValues))
-	}
-	return resources
-}
-
 func (g *CodeBuildGenerator) InitResources() error {
 	config, e := g.generateConfig()
 	if e != nil {
@@ -52,7 +39,14 @@ func (g *CodeBuildGenerator) InitResources() error {
 		if e != nil {
 			return e
 		}
-		g.Resources = g.createResources(page.Projects)
+		for _, project := range page.Projects {
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				project,
+				project,
+				"aws_codebuild_project",
+				"aws",
+				codebuildAllowEmptyValues))
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
When using `--resources=codebuild` I noticed the list was incomplete. Taking a look at the code the cause was that the output list was being overwritten on each page iteration instead of being appended. After refactoring the code all codebuild projects are showing correctly.