### PR TITLE
Fix dashboard widget generation

### DIFF
--- a/providers/datadog/dashboard.go
+++ b/providers/datadog/dashboard.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	// DashboardAllowEmptyValues ...
-	DashboardAllowEmptyValues = []string{"tags."}
+	DashboardAllowEmptyValues = []string{"tags.", "manage_status_definition.*.query"}
 )
 
 // DashboardGenerator ...


### PR DESCRIPTION
`Query` is a required field in the `manage_status_definition`. This PR add this attribute to the AllowEmptyValues list