### PR TITLE
hcl: fix for #921: 002D printed instead of hyphen

### DIFF
--- a/terraformutils/connect_test.go
+++ b/terraformutils/connect_test.go
@@ -40,7 +40,7 @@ func TestSimpleReference(t *testing.T) {
 	resources := ConnectServices(importResources, true, resourceConnections)
 
 	if !reflect.DeepEqual(resources["type1"][0].Item, map[string]interface{}{
-		"type2_ref": "${data.terraform_remote_state.type2.outputs.type2_tfer--name-002D-type2_id}",
+		"type2_ref": "${data.terraform_remote_state.type2.outputs.type2_tfer--name-type2_id}",
 	}) {
 		t.Errorf("failed to connect %v", resources["type1"][0].Item)
 	}
@@ -69,8 +69,8 @@ func TestManyReferences(t *testing.T) {
 	resources := ConnectServices(importResources, true, resourceConnections)
 
 	if !reflect.DeepEqual(resources["type1"][0].Item, map[string]interface{}{
-		"type2_ref1": "${data.terraform_remote_state.type2.outputs.type2_tfer--name-002D-type2_id}",
-		"type2_ref2": "${data.terraform_remote_state.type2.outputs.type2_tfer--name-002D-type2_id}",
+		"type2_ref1": "${data.terraform_remote_state.type2.outputs.type2_tfer--name-type2_id}",
+		"type2_ref2": "${data.terraform_remote_state.type2.outputs.type2_tfer--name-type2_id}",
 	}) {
 		t.Errorf("failed to connect %v", resources["type1"][0].Item)
 	}
@@ -106,8 +106,8 @@ func TestResourceGroups(t *testing.T) {
 	resources := ConnectServices(importResources, true, resourceConnections)
 
 	if !reflect.DeepEqual(resources["group1"][0].Item, map[string]interface{}{
-		"type2_ref1": "${data.terraform_remote_state.group2.outputs.type2_tfer--name-002D-type2_uid}",
-		"type2_ref2": "${data.terraform_remote_state.group2.outputs.type2_tfer--name-002D-type2_uid}",
+		"type2_ref1": "${data.terraform_remote_state.group2.outputs.type2_tfer--name-type2_uid}",
+		"type2_ref2": "${data.terraform_remote_state.group2.outputs.type2_tfer--name-type2_uid}",
 	}) {
 		t.Errorf("failed to connect %v", resources["group1"][0].Item)
 	}
@@ -128,7 +128,7 @@ func TestNestedReference(t *testing.T) {
 	}
 	resources := ConnectServices(importResources, true, resourceConnections)
 
-	if !reflect.DeepEqual(resources["type1"][0].Item, mapI("nested", mapI("type2_ref", "${data.terraform_remote_state.type2.outputs.type2_tfer--name-002D-type2_id}"))) {
+	if !reflect.DeepEqual(resources["type1"][0].Item, mapI("nested", mapI("type2_ref", "${data.terraform_remote_state.type2.outputs.type2_tfer--name-type2_id}"))) {
 		t.Errorf("failed to connect %v", resources)
 	}
 }

--- a/terraformutils/hcl.go
+++ b/terraformutils/hcl.go
@@ -32,7 +32,7 @@ import (
 
 const safeChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_"
 
-var unsafeChars = regexp.MustCompile(`[^0-9A-Za-z_]`)
+var unsafeChars = regexp.MustCompile(`[^0-9A-Za-z_\-]`)
 
 // sanitizer fixes up an invalid HCL AST, as produced by the HCL parser for JSON
 type astSanitizer struct{}


### PR DESCRIPTION
### Changes

* Just a fix for the annoying bug #921
* Tested with `azurerm` provider.
