### PR TITLE
Fix for Palo Alto network panos_ipsec_tunnel_proxy_id_ipv4 resource #…

### DIFF
--- a/providers/panos/firewall_networking.go
+++ b/providers/panos/firewall_networking.go
@@ -705,9 +705,9 @@ func (g *FirewallNetworkingGenerator) PostConvertHook() error {
 			}
 		}
 
-                if r.InstanceInfo.Type == "panos_ipsec_tunnel_proxy_id_ipv4" {
-                        r.Item["ipsec_tunnel"] = "${panos_ipsec_tunnel." + normalizeResourceName(r.Item["panos_ipsec_tunnel"].(string)) + ".name}"
-                }
+		if r.InstanceInfo.Type == "panos_ipsec_tunnel_proxy_id_ipv4" {
+			r.Item["ipsec_tunnel"] = "${panos_ipsec_tunnel." + normalizeResourceName(r.Item["panos_ipsec_tunnel"].(string)) + ".name}"
+		}
 
 		if r.InstanceInfo.Type == "panos_layer2_subinterface" {
 			if _, ok := mapInterfaceModes[r.Item["parent_interface"].(string)]; ok {


### PR DESCRIPTION
Fixed issue: #1085.

Script should get a panos_ipsec_tunnel instead of tunnel interface.