### PR TITLE
make output of aws_lb_target_group_attachment reproducible

### DIFF
--- a/providers/aws/alb.go
+++ b/providers/aws/alb.go
@@ -23,7 +23,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
-	"github.com/hashicorp/terraform/helper/resource"
 )
 
 var AlbAllowEmptyValues = []string{"tags.", "^condition."}
@@ -178,7 +177,7 @@ func (g *AlbGenerator) loadTargetGroupTargets(svc *elasticloadbalancingv2.Client
 		return err
 	}
 	for _, tgh := range targetHealths.TargetHealthDescriptions {
-		id := resource.PrefixedUniqueId(fmt.Sprintf("%s-", *targetGroupArn))
+		id := fmt.Sprintf("%s-%s", *targetGroupArn, *tgh.Target.Id)
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			id,
 			id,


### PR DESCRIPTION
Currently, a time-based and non-reproducible ID is being added, which may be unnecessary if we include *tgh.Target.Id to the format of resource ID