### PR TITLE
'fix' google/dns

### DIFF
--- a/providers/gcp/clouddns.go
+++ b/providers/gcp/clouddns.go
@@ -116,10 +116,10 @@ func (g *CloudDNSGenerator) PostConvertHook() error {
 				continue
 			}
 			if zoneID == resourceZone.InstanceState.ID {
-				g.Resources[i].Item["managed_zone"] = "google_dns_managed_zone." + resourceZone.ResourceName + ".name"
+				g.Resources[i].Item["managed_zone"] = "${google_dns_managed_zone." + resourceZone.ResourceName + ".name}"
 				name := g.Resources[i].Item["name"].(string)
 				name = strings.ReplaceAll(name, resourceZone.Item["dns_name"].(string), "")
-				g.Resources[i].Item["name"] = name + "google_dns_managed_zone." + resourceZone.ResourceName + ".dns_name"
+				g.Resources[i].Item["name"] = name + "${google_dns_managed_zone." + resourceZone.ResourceName + ".dns_name}"
 			}
 		}
 	}


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/terraformer/issues/1081
Make google/dns work. However, this will throw warnings for the managed_zone, as that syntax is deprecated (having only a template as a string).