### PR TITLE
Add "Opsgenie" as further provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A CLI tool that generates `tf`/`json` and `tfstate` files based on existing infr
         * [Datadog](/docs/datadog.md)
         * [New Relic](/docs/relic.md)
         * [PagerDuty](/docs/pagerduty.md)
+        * [Opsgenie](/docs/opsgenie.md)
     * Community
         * [Keycloak](/docs/keycloak.md)
         * [Logz.io](/docs/logz.md)
@@ -277,6 +278,7 @@ Links to download Terraform Providers:
     * Datadog provider >2.1.0 - [here](https://releases.hashicorp.com/terraform-provider-datadog/)
     * New Relic provider >2.0.0 - [here](https://releases.hashicorp.com/terraform-provider-newrelic/)
     * Pagerduty >=1.9 - [here](https://releases.hashicorp.com/terraform-provider-pagerduty/)
+    * Opsgenie >= 0.6.0 [here](https://releases.hashicorp.com/terraform-provider-opsgenie/)
 * Community
     * Keycloak provider >=1.19.0 - [here](https://github.com/mrparkers/terraform-provider-keycloak/)
     * Logz.io provider >=1.1.1 - [here](https://github.com/jonboydell/logzio_terraform_provider/)

--- a/cmd/provider_cmd_opsgenie.go
+++ b/cmd/provider_cmd_opsgenie.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	opsgenie_terraforming "github.com/GoogleCloudPlatform/terraformer/providers/opsgenie"
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+)
+
+func newCmdOpsgenieImporter(options ImportOptions) *cobra.Command {
+	var apiKey string
+	cmd := &cobra.Command{
+		Use:   "opsgenie",
+		Short: "Import current state to Terraform configuration from Opsgenie",
+		Long:  "Import current state to Terraform configuration from Opsgenie",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			provider := newOpsgenieProvider()
+			err := Import(provider, options, []string{apiKey})
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	cmd.AddCommand(listCmd(newOpsgenieProvider()))
+	baseProviderFlags(cmd.PersistentFlags(), &options, "user,team", "")
+	cmd.PersistentFlags().StringVarP(&apiKey, "api-key", "", "", "YOUR_OPSGENIE_API_KEY or env param OPSGENIE_API_KEY")
+	return cmd
+}
+
+func newOpsgenieProvider() terraformutils.ProviderGenerator {
+	return &opsgenie_terraforming.OpsgenieProvider{}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,6 +71,7 @@ func providerImporterSubcommands() []func(options ImportOptions) *cobra.Command 
 		newCmdNewRelicImporter,
 		newCmdGrafanaImporter,
 		newCmdPagerDutyImporter,
+		newCmdOpsgenieImporter,
 		// Community
 		newCmdKeycloakImporter,
 		newCmdLogzioImporter,

--- a/docs/opsgenie.md
+++ b/docs/opsgenie.md
@@ -1,0 +1,14 @@
+### Use with Opsgenie
+
+Example:
+
+```
+ terraformer import opsgenie --resources=team,user --api-key=YOUR_API_KEY // or OPSGENIE_API_KEY in env
+```
+
+List of supported Opsgenie services:
+
+*   `team`
+    * `opsgenie_team`
+*   `user`
+    * `opsgenie_user`

--- a/go.mod
+++ b/go.mod
@@ -205,8 +205,10 @@ require (
 	github.com/aws/aws-sdk-go v1.37.0 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.0.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.0.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.4.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.2.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.1.4 // indirect
+	github.com/aws/smithy-go v1.8.1 // indirect
 	github.com/beevik/etree v1.1.0 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
@@ -282,6 +284,7 @@ require (
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.8 // indirect
 	github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627 // indirect
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pelletier/go-toml v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -212,7 +212,6 @@ github.com/aws/aws-sdk-go-v2 v1.3.0/go.mod h1:hTQc/9pYq5bfFACIUY9tc/2SYWd9Vnmw+t
 github.com/aws/aws-sdk-go-v2 v1.3.1/go.mod h1:5SmWRTjN6uTRFNCc7rR69xHsdcUJnthmaRHGDsYhpTE=
 github.com/aws/aws-sdk-go-v2 v1.3.2/go.mod h1:7OaACgj2SX3XGWnrIjGlJM22h6yD6MEWKvm7levnnM8=
 github.com/aws/aws-sdk-go-v2 v1.4.0/go.mod h1:tI4KhsR5VkzlUa2DZAdwx7wCAYGwkZZ1H31PYrBFx1w=
-github.com/aws/aws-sdk-go-v2 v1.9.0 h1:+S+dSqQCN3MSU5vJRu1HqHrq00cJn6heIMU7X9hcsoo=
 github.com/aws/aws-sdk-go-v2 v1.9.0/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
 github.com/aws/aws-sdk-go-v2 v1.10.0 h1:+dCJ5W2HiZNa4UtaIc5ljKNulm0dK0vS5dxb5LdDOAA=
 github.com/aws/aws-sdk-go-v2 v1.10.0/go.mod h1:U/EyyVvKtzmFeQQcca7eBotKdlpcP2zzU6bXBYcf7CE=
@@ -309,7 +308,6 @@ github.com/aws/aws-sdk-go-v2/service/iam v1.3.0/go.mod h1:gPUYT7MBEb30j9eAsJ17LN
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.0.3 h1:iLFz4nrWkXMTFeVn0n99wRyc4Xib4SlDbtAM3h2z8P8=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.0.3/go.mod h1:g3Xw4tO/W+ae4EMzkxB6nGnJ48cLM4i1Z61WmD+IKtY=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.0.5/go.mod h1:MW0O/RpmVpS6MWKn6W03XEJmqXlG7+d3iaYLzkd2fAc=
-github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.3.0 h1:VNJ5NLBteVXEwE2F1zEXVmyIH58mZ6kIQGJoC7C+vkg=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.3.0/go.mod h1:R1KK+vY8AfalhG1AOu5e35pOD2SdoPKQCFLTvnxiohk=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.4.0 h1:/T5wKsw/po118HEDvnSE8YU7TESxvZbYM2rnn+Oi7Kk=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.4.0/go.mod h1:X5/JuOxPLU/ogICgDTtnpfaQzdQJO0yKDcpoxWLLJ8Y=
@@ -335,8 +333,6 @@ github.com/aws/aws-sdk-go-v2/service/organizations v1.2.1 h1:TvDVD1mBXP60NIHrqbP
 github.com/aws/aws-sdk-go-v2/service/organizations v1.2.1/go.mod h1:iy7PhC7Wxk3aRePrvaUU7ngXjcAedbTBeKYAYVhnvfI=
 github.com/aws/aws-sdk-go-v2/service/qldb v1.1.3 h1:mQUBlaWu2q7RftA5O8psLn2wQTIJAQEX0eIp3dZOtxQ=
 github.com/aws/aws-sdk-go-v2/service/qldb v1.1.3/go.mod h1:PgBTgxJV+wffbLmlJB/zO0/lD8+mEbUzEK0LvPkbxXM=
-github.com/aws/aws-sdk-go-v2/service/rds v1.2.1 h1:nh6V70gwG0bE6Ocz34rg5VZvmthKuDSa785CBpvY2g8=
-github.com/aws/aws-sdk-go-v2/service/rds v1.2.1/go.mod h1:QQ6pD2d3AUbZblcKzZ5aJ58mMMfcofx2j8KAXcHe8rg=
 github.com/aws/aws-sdk-go-v2/service/rds v1.10.0 h1:VgbyR1VctdsZ+EUWW+/EwHip1SdcW4MVcntV8u8NpkI=
 github.com/aws/aws-sdk-go-v2/service/rds v1.10.0/go.mod h1:FE9JK93YvpyMx4MKwkQfBsW3BZmAop7xSxKk2ey3unM=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.2.1 h1:36JI8JwGQEH5JcRXdpWucey2jr+mSLZWEvLWZLo73PI=
@@ -379,7 +375,6 @@ github.com/aws/smithy-go v1.2.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAm
 github.com/aws/smithy-go v1.3.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aws/smithy-go v1.3.1/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aws/smithy-go v1.4.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
-github.com/aws/smithy-go v1.8.0 h1:AEwwwXQZtUwP5Mz506FeXXrKBe0jA8gVM+1gEcSRooc=
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aws/smithy-go v1.8.1 h1:9Y6qxtzgEODaLNGN+oN2QvcHvKUe4jsH8w4M+8LXzGk=
 github.com/aws/smithy-go v1.8.1/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
@@ -752,6 +747,7 @@ github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn
 github.com/hashicorp/go-plugin v1.3.0/go.mod h1:F9eH4LrE/ZsRdbwhfjs9k9HoDUwAHnYtXdgmf1AVNs0=
 github.com/hashicorp/go-plugin v1.4.1 h1:6UltRQlLN9iZO513VveELp5xyaFxVD2+1OVylE+2E+w=
 github.com/hashicorp/go-plugin v1.4.1/go.mod h1:5fGEH17QVwTTcR0zV7yhDPLLmFX9YSZ38b18Udy6vYQ=
+github.com/hashicorp/go-retryablehttp v0.5.1/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-retryablehttp v0.5.2/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-retryablehttp v0.6.2/go.mod h1:gEx6HMUGxYYhJScX7W1Il64m6cc2C1mDaW3NQ9sY1FY=
 github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
@@ -1048,6 +1044,8 @@ github.com/opencontainers/runc v1.0.1 h1:G18PGckGdAm3yVQRWDVQ1rLSLntiniKJ0cNRT2T
 github.com/opencontainers/runc v1.0.1/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
+github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.8 h1:qF/rRi8GSU2mjBXfJIyMj9GGmjedsV3Gm1uYbiGlCRk=
+github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.8/go.mod h1:4OjcxgwdXzezqytxN534MooNmrxRD50geWZxTD7845s=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
 github.com/packer-community/winrmcp v0.0.0-20180102160824-81144009af58/go.mod h1:f6Izs6JvFTdnRbziASagjZ2vmf55NSIkC/weStxCHqk=

--- a/providers/opsgenie/opsgenie_provider.go
+++ b/providers/opsgenie/opsgenie_provider.go
@@ -1,0 +1,70 @@
+package opsgenie
+
+import (
+	"errors"
+	"os"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+)
+
+type OpsgenieProvider struct { //nolint
+	terraformutils.Provider
+
+	APIKey string
+}
+
+func (p *OpsgenieProvider) Init(args []string) error {
+	if apiKey := os.Getenv("OPSGENIE_API_KEY"); apiKey != "" {
+		p.APIKey = os.Getenv("OPSGENIE_API_KEY")
+	}
+	if args[0] != "" {
+		p.APIKey = args[0]
+	}
+	if p.APIKey == "" {
+		return errors.New("required API Key missing")
+	}
+
+	return nil
+}
+
+func (p *OpsgenieProvider) InitService(serviceName string, verbose bool) error {
+	var isSupported bool
+	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
+	}
+	p.Service = p.GetSupportedService()[serviceName]
+	p.Service.SetName(serviceName)
+	p.Service.SetVerbose(verbose)
+	p.Service.SetProviderName(p.GetName())
+	p.Service.SetArgs(map[string]interface{}{
+		"api-key": p.APIKey,
+	})
+	return nil
+}
+
+func (p *OpsgenieProvider) GetConfig() cty.Value {
+	return cty.ObjectVal(map[string]cty.Value{
+		"api_key": cty.StringVal(p.APIKey),
+	})
+}
+
+func (p *OpsgenieProvider) GetProviderData(arg ...string) map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+func (p *OpsgenieProvider) GetResourceConnections() map[string]map[string][]string {
+	return map[string]map[string][]string{}
+}
+
+func (p *OpsgenieProvider) GetName() string {
+	return "opsgenie"
+}
+
+func (p *OpsgenieProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
+	return map[string]terraformutils.ServiceGenerator{
+		"user": &UserGenerator{},
+		"team": &TeamGenerator{},
+	}
+}

--- a/providers/opsgenie/opsgenie_service.go
+++ b/providers/opsgenie/opsgenie_service.go
@@ -1,0 +1,21 @@
+package opsgenie
+
+import (
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+	"github.com/opsgenie/opsgenie-go-sdk-v2/team"
+	"github.com/opsgenie/opsgenie-go-sdk-v2/user"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+)
+
+type OpsgenieService struct { //nolint
+	terraformutils.Service
+}
+
+func (s *OpsgenieService) UserClient() (*user.Client, error) {
+	return user.NewClient(&client.Config{ApiKey: s.GetArgs()["api-key"].(string)})
+}
+
+func (s *OpsgenieService) TeamClient() (*team.Client, error) {
+	return team.NewClient(&client.Config{ApiKey: s.GetArgs()["api-key"].(string)})
+}

--- a/providers/opsgenie/team.go
+++ b/providers/opsgenie/team.go
@@ -1,0 +1,50 @@
+package opsgenie
+
+import (
+	"context"
+	"time"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/team"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+)
+
+type TeamGenerator struct {
+	OpsgenieService
+}
+
+func (g *TeamGenerator) InitResources() error {
+	client, err := g.TeamClient()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelFunc()
+
+	result, err := client.List(ctx, &team.ListTeamRequest{})
+	if err != nil {
+		return err
+	}
+
+	g.Resources = g.createResources(result.Teams)
+	return nil
+}
+
+func (g *TeamGenerator) createResources(teams []team.ListedTeams) []terraformutils.Resource {
+	var resources []terraformutils.Resource
+
+	for _, t := range teams {
+		resources = append(resources, terraformutils.NewResource(
+			t.Id,
+			t.Name,
+			"opsgenie_team",
+			g.ProviderName,
+			map[string]string{},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+
+	return resources
+}

--- a/providers/opsgenie/user.go
+++ b/providers/opsgenie/user.go
@@ -1,0 +1,68 @@
+package opsgenie
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/user"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+)
+
+type UserGenerator struct {
+	OpsgenieService
+}
+
+func (g *UserGenerator) InitResources() error {
+	client, err := g.UserClient()
+	if err != nil {
+		return err
+	}
+
+	limit := 50
+	offset := 0
+
+	var users []user.User
+
+	for {
+		result, err := func(limit, offset int) (*user.ListResult, error) {
+			ctx, cancelFunc := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancelFunc()
+
+			return client.List(ctx, &user.ListRequest{Limit: limit, Offset: offset})
+		}(limit, offset)
+
+		if err != nil {
+			return err
+		}
+
+		users = append(users, result.Users...)
+		offset += limit
+
+		if offset >= result.TotalCount {
+			break
+		}
+	}
+
+	g.Resources = g.createResources(users)
+	return nil
+}
+
+func (g *UserGenerator) createResources(users []user.User) []terraformutils.Resource {
+	var resources []terraformutils.Resource
+
+	for _, u := range users {
+		resources = append(resources, terraformutils.NewResource(
+			u.Id,
+			fmt.Sprintf("%s-%s", u.Id, u.Username),
+			"opsgenie_user",
+			g.ProviderName,
+			map[string]string{},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+
+	return resources
+}


### PR DESCRIPTION
This PR adds [Opsgenie](https://www.atlassian.com/software/opsgenie) as further provider with support of two basic resources/services for now:

* [opsgenie_team](https://registry.terraform.io/providers/opsgenie/opsgenie/latest/docs/resources/team)
* [opsgenie_user](https://registry.terraform.io/providers/opsgenie/opsgenie/latest/docs/resources/user)