### PR TITLE
Add “Mackerel” as further provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A CLI tool that generates `tf`/`json` and `tfstate` files based on existing infr
     * Monitoring & System Management
         * [Datadog](/docs/datadog.md)
         * [New Relic](/docs/relic.md)
+        * [Mackerel](/docs/mackerel.md)
         * [PagerDuty](/docs/pagerduty.md)
     * Community
         * [Keycloak](/docs/keycloak.md)
@@ -276,6 +277,7 @@ Links to download Terraform Providers:
 * Monitoring & System Management
     * Datadog provider >2.1.0 - [here](https://releases.hashicorp.com/terraform-provider-datadog/)
     * New Relic provider >2.0.0 - [here](https://releases.hashicorp.com/terraform-provider-newrelic/)
+    * Mackerel provider > 0.0.6 - [here](https://github.com/mackerelio-labs/terraform-provider-mackerel)
     * Pagerduty >=1.9 - [here](https://releases.hashicorp.com/terraform-provider-pagerduty/)
 * Community
     * Keycloak provider >=1.19.0 - [here](https://github.com/mrparkers/terraform-provider-keycloak/)

--- a/cmd/provider_cmd_mackerel.go
+++ b/cmd/provider_cmd_mackerel.go
@@ -1,0 +1,46 @@
+// Copyright 2021 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	mackerel_terraforming "github.com/GoogleCloudPlatform/terraformer/providers/mackerel"
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMackerelImporter(options ImportOptions) *cobra.Command {
+	var apiKey string
+	cmd := &cobra.Command{
+		Use:   "mackerel",
+		Short: "Import current state to Terraform configuration from Mackerel",
+		Long:  "Import current state to Terraform configuration from Mackerel",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			provider := newMackerelProvider()
+			err := Import(provider, options, []string{apiKey})
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	cmd.AddCommand(listCmd(newMackerelProvider()))
+	baseProviderFlags(cmd.PersistentFlags(), &options, "service,role,aws_integration", "aws_integration=id1:id2:id4")
+	cmd.PersistentFlags().StringVarP(&apiKey, "api-key", "", "", "YOUR_MACKEREL_API_KEY or env param MACKEREL_API_KEY")
+	return cmd
+}
+
+func newMackerelProvider() terraformutils.ProviderGenerator {
+	return &mackerel_terraforming.MackerelProvider{}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,6 +69,7 @@ func providerImporterSubcommands() []func(options ImportOptions) *cobra.Command 
 		// Monitoring & System Management
 		newCmdDatadogImporter,
 		newCmdNewRelicImporter,
+		newCmdMackerelImporter,
 		newCmdGrafanaImporter,
 		newCmdPagerDutyImporter,
 		// Community

--- a/docs/mackerel.md
+++ b/docs/mackerel.md
@@ -1,0 +1,30 @@
+### Use with Mackerel
+
+Example:
+
+```bash
+ ./terraformer import mackerel --resources=service --api-key=YOUR_MACKEREL_API_KEY // or MACKEREL_API_KEY in env --app-key=YOUR_MACKEREL_API_KEY
+ ./terraformer import mackerel --resources=service --filter=service=name1:name2:name4 --api-key=YOUR_MACKEREL_API_KEY // or MACKEREL_API_KEY in env --app-key=YOUR_MACKEREL_API_KEY
+ ./terraformer import mackerel --resources=aws_integration --filter=aws_integration=id1:id2:id4 --api-key=YOUR_MACKEREL_API_KEY // or MACKEREL_API_KEY in env --app-key=YOUR_MACKEREL_API_KEY
+```
+
+List of supported Mackerel services:
+
+*   `alert_group_setting`
+    * `mackerel_alert_group_setting`
+*   `aws_integration`
+    * `mackerel_aws_integration`
+        * Sensitive field `secret_key` is not generated and needs to be manually set
+        * Sensitive field `external_id` is not generated and needs to be manually set
+*   `channel`
+    * `mackerel_channel`
+*   `downtime`
+    * `mackerel_downtime`
+*   `monitor`
+    * `mackerel_monitor`
+*   `notification_group`
+    * `mackerel_notification_group`
+*   `role`
+    * `mackerel_role`
+*   `service`
+    * `mackerel_service`

--- a/go.mod
+++ b/go.mod
@@ -174,6 +174,7 @@ require (
 	github.com/IBM/go-sdk-core v1.1.0
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.2.2 // indirect
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
+	github.com/mackerelio/mackerel-client-go v0.19.0
 	github.com/okta/terraform-provider-okta v0.0.0-20210924173942-a5a664459d3b
 	github.com/zclconf/go-cty-yaml v1.0.2 // indirect
 )
@@ -205,8 +206,10 @@ require (
 	github.com/aws/aws-sdk-go v1.37.0 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.0.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.0.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.4.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.2.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.1.4 // indirect
+	github.com/aws/smithy-go v1.8.1 // indirect
 	github.com/beevik/etree v1.1.0 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -212,7 +212,6 @@ github.com/aws/aws-sdk-go-v2 v1.3.0/go.mod h1:hTQc/9pYq5bfFACIUY9tc/2SYWd9Vnmw+t
 github.com/aws/aws-sdk-go-v2 v1.3.1/go.mod h1:5SmWRTjN6uTRFNCc7rR69xHsdcUJnthmaRHGDsYhpTE=
 github.com/aws/aws-sdk-go-v2 v1.3.2/go.mod h1:7OaACgj2SX3XGWnrIjGlJM22h6yD6MEWKvm7levnnM8=
 github.com/aws/aws-sdk-go-v2 v1.4.0/go.mod h1:tI4KhsR5VkzlUa2DZAdwx7wCAYGwkZZ1H31PYrBFx1w=
-github.com/aws/aws-sdk-go-v2 v1.9.0 h1:+S+dSqQCN3MSU5vJRu1HqHrq00cJn6heIMU7X9hcsoo=
 github.com/aws/aws-sdk-go-v2 v1.9.0/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
 github.com/aws/aws-sdk-go-v2 v1.10.0 h1:+dCJ5W2HiZNa4UtaIc5ljKNulm0dK0vS5dxb5LdDOAA=
 github.com/aws/aws-sdk-go-v2 v1.10.0/go.mod h1:U/EyyVvKtzmFeQQcca7eBotKdlpcP2zzU6bXBYcf7CE=
@@ -309,7 +308,6 @@ github.com/aws/aws-sdk-go-v2/service/iam v1.3.0/go.mod h1:gPUYT7MBEb30j9eAsJ17LN
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.0.3 h1:iLFz4nrWkXMTFeVn0n99wRyc4Xib4SlDbtAM3h2z8P8=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.0.3/go.mod h1:g3Xw4tO/W+ae4EMzkxB6nGnJ48cLM4i1Z61WmD+IKtY=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.0.5/go.mod h1:MW0O/RpmVpS6MWKn6W03XEJmqXlG7+d3iaYLzkd2fAc=
-github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.3.0 h1:VNJ5NLBteVXEwE2F1zEXVmyIH58mZ6kIQGJoC7C+vkg=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.3.0/go.mod h1:R1KK+vY8AfalhG1AOu5e35pOD2SdoPKQCFLTvnxiohk=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.4.0 h1:/T5wKsw/po118HEDvnSE8YU7TESxvZbYM2rnn+Oi7Kk=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.4.0/go.mod h1:X5/JuOxPLU/ogICgDTtnpfaQzdQJO0yKDcpoxWLLJ8Y=
@@ -335,8 +333,6 @@ github.com/aws/aws-sdk-go-v2/service/organizations v1.2.1 h1:TvDVD1mBXP60NIHrqbP
 github.com/aws/aws-sdk-go-v2/service/organizations v1.2.1/go.mod h1:iy7PhC7Wxk3aRePrvaUU7ngXjcAedbTBeKYAYVhnvfI=
 github.com/aws/aws-sdk-go-v2/service/qldb v1.1.3 h1:mQUBlaWu2q7RftA5O8psLn2wQTIJAQEX0eIp3dZOtxQ=
 github.com/aws/aws-sdk-go-v2/service/qldb v1.1.3/go.mod h1:PgBTgxJV+wffbLmlJB/zO0/lD8+mEbUzEK0LvPkbxXM=
-github.com/aws/aws-sdk-go-v2/service/rds v1.2.1 h1:nh6V70gwG0bE6Ocz34rg5VZvmthKuDSa785CBpvY2g8=
-github.com/aws/aws-sdk-go-v2/service/rds v1.2.1/go.mod h1:QQ6pD2d3AUbZblcKzZ5aJ58mMMfcofx2j8KAXcHe8rg=
 github.com/aws/aws-sdk-go-v2/service/rds v1.10.0 h1:VgbyR1VctdsZ+EUWW+/EwHip1SdcW4MVcntV8u8NpkI=
 github.com/aws/aws-sdk-go-v2/service/rds v1.10.0/go.mod h1:FE9JK93YvpyMx4MKwkQfBsW3BZmAop7xSxKk2ey3unM=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.2.1 h1:36JI8JwGQEH5JcRXdpWucey2jr+mSLZWEvLWZLo73PI=
@@ -379,7 +375,6 @@ github.com/aws/smithy-go v1.2.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAm
 github.com/aws/smithy-go v1.3.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aws/smithy-go v1.3.1/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aws/smithy-go v1.4.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
-github.com/aws/smithy-go v1.8.0 h1:AEwwwXQZtUwP5Mz506FeXXrKBe0jA8gVM+1gEcSRooc=
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aws/smithy-go v1.8.1 h1:9Y6qxtzgEODaLNGN+oN2QvcHvKUe4jsH8w4M+8LXzGk=
 github.com/aws/smithy-go v1.8.1/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
@@ -918,6 +913,8 @@ github.com/likexian/simplejson-go v0.0.0-20190502021454-d8787b4bfa0b/go.mod h1:3
 github.com/linode/linodego v0.24.1 h1:3s7/F54z9XZfefzrFqnHMD9DIEYVyOddPm+gyTEFFzc=
 github.com/linode/linodego v0.24.1/go.mod h1:GSBKPpjoQfxEfryoCRcgkuUOCuVtGHWhzI8OMdycNTE=
 github.com/lusis/go-artifactory v0.0.0-20160115162124-7e4ce345df82/go.mod h1:y54tfGmO3NKssKveTEFFzH8C/akrSOy/iW9qEAUDV84=
+github.com/mackerelio/mackerel-client-go v0.19.0 h1:DkYVD07fmklFTMKLaHcjtkU53Nt+nhvXNUSEeKfRSZs=
+github.com/mackerelio/mackerel-client-go v0.19.0/go.mod h1:/GNOj+y1eFsd3CK8c6IQ/uS38/GT0+NWImk5YGJs5Lk=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -1535,6 +1532,7 @@ golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200601175630-2caf76543d99/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200612022331-742c5eb664c2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200624163319-25775e59acb7/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=

--- a/providers/mackerel/alert_group_setting.go
+++ b/providers/mackerel/alert_group_setting.go
@@ -1,0 +1,58 @@
+// Copyright 2021 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mackerel
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+// AlertGroupSettingGenerator ...
+type AlertGroupSettingGenerator struct {
+	MackerelService
+}
+
+func (g *AlertGroupSettingGenerator) createResources(alertGroupSettings []*mackerel.AlertGroupSetting) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, alertGroupSetting := range alertGroupSettings {
+		resources = append(resources, g.createResource(alertGroupSetting.ID))
+	}
+	return resources
+}
+
+func (g *AlertGroupSettingGenerator) createResource(alertGroupSettingID string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		alertGroupSettingID,
+		fmt.Sprintf("alert_group_setting_%s", alertGroupSettingID),
+		"mackerel_alert_group_setting",
+		"mackerel",
+		[]string{},
+	)
+}
+
+// InitResources Generate TerraformResources from Mackerel API,
+// from each alert group setting create 1 TerraformResource.
+// Need Alert Group Setting ID as ID for terraform resource
+func (g *AlertGroupSettingGenerator) InitResources() error {
+	client := g.Args["mackerelClient"].(*mackerel.Client)
+	alertGroupSettings, err := client.FindAlertGroupSettings()
+	if err != nil {
+		return err
+	}
+	g.Resources = append(g.Resources, g.createResources(alertGroupSettings)...)
+	return nil
+}

--- a/providers/mackerel/aws_integration.go
+++ b/providers/mackerel/aws_integration.go
@@ -1,0 +1,58 @@
+// Copyright 2021 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mackerel
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+// AWSIntegrationGenerator ...
+type AWSIntegrationGenerator struct {
+	MackerelService
+}
+
+func (g *AWSIntegrationGenerator) createResources(awsIntegrations []*mackerel.AWSIntegration) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, awsIntegration := range awsIntegrations {
+		resources = append(resources, g.createResource(awsIntegration.ID))
+	}
+	return resources
+}
+
+func (g *AWSIntegrationGenerator) createResource(awsIntegrationID string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		awsIntegrationID,
+		fmt.Sprintf("aws_integration_%s", awsIntegrationID),
+		"mackerel_aws_integration",
+		"mackerel",
+		[]string{},
+	)
+}
+
+// InitResources Generate TerraformResources from Mackerel API,
+// from each aws integration create 1 TerraformResource.
+// Need AWS Integration ID as ID for terraform resource
+func (g *AWSIntegrationGenerator) InitResources() error {
+	client := g.Args["mackerelClient"].(*mackerel.Client)
+	awsIntegrations, err := client.FindAWSIntegrations()
+	if err != nil {
+		return err
+	}
+	g.Resources = append(g.Resources, g.createResources(awsIntegrations)...)
+	return nil
+}

--- a/providers/mackerel/channel.go
+++ b/providers/mackerel/channel.go
@@ -1,0 +1,75 @@
+// Copyright 2021 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mackerel
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+// ChannelGenerator ...
+type ChannelGenerator struct {
+	MackerelService
+}
+
+func (g *ChannelGenerator) createResources(channels []*mackerel.Channel) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, channel := range channels {
+		if channel.Type != "email" && channel.Type != "slack" && channel.Type != "webhook" {
+			continue
+		}
+
+		if channel.Type == "email" {
+			if channel.Events != nil {
+				events := *channel.Events
+				for _, event := range events {
+					if event != "alert" && event != "alertGroup" {
+						continue
+					}
+				}
+			} else {
+				continue
+			}
+		}
+
+		resources = append(resources, g.createResource(channel.ID))
+	}
+	return resources
+}
+
+func (g *ChannelGenerator) createResource(channelID string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		channelID,
+		fmt.Sprintf("channel_%s", channelID),
+		"mackerel_channel",
+		"mackerel",
+		[]string{},
+	)
+}
+
+// InitResources Generate TerraformResources from Mackerel API,
+// from each channel create 1 TerraformResource.
+// Need Channel ID as ID for terraform resource
+func (g *ChannelGenerator) InitResources() error {
+	client := g.Args["mackerelClient"].(*mackerel.Client)
+	channels, err := client.FindChannels()
+	if err != nil {
+		return err
+	}
+	g.Resources = append(g.Resources, g.createResources(channels)...)
+	return nil
+}

--- a/providers/mackerel/downtime.go
+++ b/providers/mackerel/downtime.go
@@ -1,0 +1,58 @@
+// Copyright 2021 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mackerel
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+// DowntimeGenerator ...
+type DowntimeGenerator struct {
+	MackerelService
+}
+
+func (g *DowntimeGenerator) createResources(downtimes []*mackerel.Downtime) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, downtime := range downtimes {
+		resources = append(resources, g.createResource(downtime.ID))
+	}
+	return resources
+}
+
+func (g *DowntimeGenerator) createResource(downtimeID string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		downtimeID,
+		fmt.Sprintf("downtime_%s", downtimeID),
+		"mackerel_downtime",
+		"mackerel",
+		[]string{},
+	)
+}
+
+// InitResources Generate TerraformResources from Mackerel API,
+// from each downtime create 1 TerraformResource.
+// Need Downtime ID as ID for terraform resource
+func (g *DowntimeGenerator) InitResources() error {
+	client := g.Args["mackerelClient"].(*mackerel.Client)
+	downtimes, err := client.FindDowntimes()
+	if err != nil {
+		return err
+	}
+	g.Resources = append(g.Resources, g.createResources(downtimes)...)
+	return nil
+}

--- a/providers/mackerel/mackerel_provider.go
+++ b/providers/mackerel/mackerel_provider.go
@@ -1,0 +1,99 @@
+// Copyright 2021 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mackerel
+
+import (
+	"errors"
+	"os"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	mackerel "github.com/mackerelio/mackerel-client-go"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type MackerelProvider struct { //nolint
+	terraformutils.Provider
+	apiKey         string
+	mackerelClient *mackerel.Client
+}
+
+// Init check env params and initialize API Client
+func (p *MackerelProvider) Init(args []string) error {
+	if args[0] != "" {
+		p.apiKey = args[0]
+	} else {
+		if apiKey := os.Getenv("MACKEREL_API_KEY"); apiKey != "" {
+			p.apiKey = apiKey
+		} else {
+			return errors.New("api-key requirement")
+		}
+	}
+	// Initialize the Mackerel API client
+	p.mackerelClient = mackerel.NewClient(p.apiKey)
+	return nil
+}
+
+// InitService ...
+func (p *MackerelProvider) InitService(serviceName string, verbose bool) error {
+	var isSupported bool
+	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
+		return errors.New(p.GetName() + ": " + serviceName + " not supported service")
+	}
+	p.Service = p.GetSupportedService()[serviceName]
+	p.Service.SetName(serviceName)
+	p.Service.SetVerbose(verbose)
+	p.Service.SetProviderName(p.GetName())
+	p.Service.SetArgs(map[string]interface{}{
+		"api-key":        p.apiKey,
+		"mackerelClient": p.mackerelClient,
+	})
+	return nil
+}
+
+// GetName return string of provider name for Mackerel
+func (p *MackerelProvider) GetName() string {
+	return "mackerel"
+}
+
+// GetConfig return map of provider config for Mackerel
+func (p *MackerelProvider) GetConfig() cty.Value {
+	return cty.ObjectVal(map[string]cty.Value{
+		"api_key": cty.StringVal(p.apiKey),
+	})
+}
+
+// GetSupportedService return map of support service for Mackerel
+func (p *MackerelProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
+	return map[string]terraformutils.ServiceGenerator{
+		"alert_group_setting": &AlertGroupSettingGenerator{},
+		"aws_integration":     &AWSIntegrationGenerator{},
+		"channel":             &ChannelGenerator{},
+		"downtime":            &DowntimeGenerator{},
+		"monitor":             &MonitorGenerator{},
+		"notification_group":  &NotificationGroupGenerator{},
+		"role":                &RoleGenerator{},
+		"service":             &ServiceGenerator{},
+	}
+}
+
+// GetProviderData return map of provider data for Mackerel
+func (p MackerelProvider) GetProviderData(arg ...string) map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+// GetResourceConnections return map of resource connections for Mackerel
+func (p *MackerelProvider) GetResourceConnections() map[string]map[string][]string {
+	return map[string]map[string][]string{}
+}

--- a/providers/mackerel/mackerel_service.go
+++ b/providers/mackerel/mackerel_service.go
@@ -1,0 +1,21 @@
+// Copyright 2021 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mackerel
+
+import "github.com/GoogleCloudPlatform/terraformer/terraformutils"
+
+type MackerelService struct { // nolint
+	terraformutils.Service
+}

--- a/providers/mackerel/monitor.go
+++ b/providers/mackerel/monitor.go
@@ -1,0 +1,58 @@
+// Copyright 2021 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mackerel
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+// MonitorGenerator ...
+type MonitorGenerator struct {
+	MackerelService
+}
+
+func (g *MonitorGenerator) createResources(monitors []mackerel.Monitor) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, monitor := range monitors {
+		resources = append(resources, g.createResource(monitor.MonitorID()))
+	}
+	return resources
+}
+
+func (g *MonitorGenerator) createResource(monitorID string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		monitorID,
+		fmt.Sprintf("monitor_%s", monitorID),
+		"mackerel_monitor",
+		"mackerel",
+		[]string{},
+	)
+}
+
+// InitResources Generate TerraformResources from Mackerel API,
+// from each monitor create 1 TerraformResource.
+// Need Monitor ID as ID for terraform resource
+func (g *MonitorGenerator) InitResources() error {
+	client := g.Args["mackerelClient"].(*mackerel.Client)
+	monitors, err := client.FindMonitors()
+	if err != nil {
+		return err
+	}
+	g.Resources = append(g.Resources, g.createResources(monitors)...)
+	return nil
+}

--- a/providers/mackerel/notification_group.go
+++ b/providers/mackerel/notification_group.go
@@ -1,0 +1,58 @@
+// Copyright 2021 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mackerel
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+// NotificationGroupGenerator ...
+type NotificationGroupGenerator struct {
+	MackerelService
+}
+
+func (g *NotificationGroupGenerator) createResources(notificationGroups []*mackerel.NotificationGroup) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, notificationGroup := range notificationGroups {
+		resources = append(resources, g.createResource(notificationGroup.ID))
+	}
+	return resources
+}
+
+func (g *NotificationGroupGenerator) createResource(notificationGroupID string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		notificationGroupID,
+		fmt.Sprintf("notification_group_%s", notificationGroupID),
+		"mackerel_notification_group",
+		"mackerel",
+		[]string{},
+	)
+}
+
+// InitResources Generate TerraformResources from Mackerel API,
+// from each notification group create 1 TerraformResource.
+// Need Notification Group ID as ID for terraform resource
+func (g *NotificationGroupGenerator) InitResources() error {
+	client := g.Args["mackerelClient"].(*mackerel.Client)
+	notificationGroups, err := client.FindNotificationGroups()
+	if err != nil {
+		return err
+	}
+	g.Resources = append(g.Resources, g.createResources(notificationGroups)...)
+	return nil
+}

--- a/providers/mackerel/role.go
+++ b/providers/mackerel/role.go
@@ -1,0 +1,71 @@
+// Copyright 2021 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mackerel
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+// RoleGenerator ...
+type RoleGenerator struct {
+	MackerelService
+}
+
+func (g *RoleGenerator) createResources(serviceName string, roles []*mackerel.Role) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, role := range roles {
+		resources = append(resources, g.createResource(serviceName, role.Name))
+	}
+	return resources
+}
+
+func (g *RoleGenerator) createResource(serviceName string, roleName string) terraformutils.Resource {
+	return terraformutils.NewResource(
+		fmt.Sprintf("%s:%s", serviceName, roleName),
+		fmt.Sprintf("role_%s_%s", serviceName, roleName),
+		"mackerel_role",
+		"mackerel",
+		map[string]string{
+			"service": serviceName,
+			"name":    roleName,
+		},
+		[]string{},
+		map[string]interface{}{},
+	)
+}
+
+// InitResources Generate TerraformResources from Mackerel API,
+// from each role create 1 TerraformResource.
+// Need Service Name And Role Name as ID for terraform resource
+func (g *RoleGenerator) InitResources() error {
+	client := g.Args["mackerelClient"].(*mackerel.Client)
+
+	services, err := client.FindServices()
+	if err != nil {
+		return err
+	}
+
+	for _, service := range services {
+		roles, err := client.FindRoles(service.Name)
+		if err != nil {
+			return err
+		}
+		g.Resources = append(g.Resources, g.createResources(service.Name, roles)...)
+	}
+	return nil
+}

--- a/providers/mackerel/service.go
+++ b/providers/mackerel/service.go
@@ -1,0 +1,58 @@
+// Copyright 2021 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mackerel
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+// ServiceGenerator ...
+type ServiceGenerator struct {
+	MackerelService
+}
+
+func (g *ServiceGenerator) createResources(services []*mackerel.Service) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, service := range services {
+		resources = append(resources, g.createResource(service.Name))
+	}
+	return resources
+}
+
+func (g *ServiceGenerator) createResource(serviceName string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		serviceName,
+		fmt.Sprintf("service_%s", serviceName),
+		"mackerel_service",
+		"mackerel",
+		[]string{},
+	)
+}
+
+// InitResources Generate TerraformResources from Mackerel API,
+// from each service create 1 TerraformResource.
+// Need Service Name as ID for terraform resource
+func (g *ServiceGenerator) InitResources() error {
+	client := g.Args["mackerelClient"].(*mackerel.Client)
+	services, err := client.FindServices()
+	if err != nil {
+		return err
+	}
+	g.Resources = append(g.Resources, g.createResources(services)...)
+	return nil
+}


### PR DESCRIPTION
This PR adds [Mackerel](https://en.mackerel.io/) as further provider. 

**Supported Services**
- [alert_group_setting](https://registry.terraform.io/providers/mackerelio-labs/mackerel/latest/docs/resources/alert_group_setting)
- [aws_integration](https://registry.terraform.io/providers/mackerelio-labs/mackerel/latest/docs/resources/aws_integration)
- [channel](https://registry.terraform.io/providers/mackerelio-labs/mackerel/latest/docs/resources/channel)
- [downtime](https://registry.terraform.io/providers/mackerelio-labs/mackerel/latest/docs/resources/downtime)
- [monitor](https://registry.terraform.io/providers/mackerelio-labs/mackerel/latest/docs/resources/monitor)
- [notification_group](https://registry.terraform.io/providers/mackerelio-labs/mackerel/latest/docs/resources/notification_group)
- [role](https://registry.terraform.io/providers/mackerelio-labs/mackerel/latest/docs/resources/role)
- [service](https://registry.terraform.io/providers/mackerelio-labs/mackerel/latest/docs/resources/service)