### PR TITLE
Feat: update Mackerel provider

### DIFF
--- a/cmd/provider_cmd_mackerel.go
+++ b/cmd/provider_cmd_mackerel.go
@@ -21,14 +21,14 @@ import (
 )
 
 func newCmdMackerelImporter(options ImportOptions) *cobra.Command {
-	var apiKey string
+	var apiKey, apiBase, serviceName string
 	cmd := &cobra.Command{
 		Use:   "mackerel",
 		Short: "Import current state to Terraform configuration from Mackerel",
 		Long:  "Import current state to Terraform configuration from Mackerel",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			provider := newMackerelProvider()
-			err := Import(provider, options, []string{apiKey})
+			err := Import(provider, options, []string{apiKey, apiBase, serviceName})
 			if err != nil {
 				return err
 			}
@@ -38,6 +38,8 @@ func newCmdMackerelImporter(options ImportOptions) *cobra.Command {
 	cmd.AddCommand(listCmd(newMackerelProvider()))
 	baseProviderFlags(cmd.PersistentFlags(), &options, "service,role,aws_integration", "aws_integration=id1:id2:id4")
 	cmd.PersistentFlags().StringVarP(&apiKey, "api-key", "", "", "YOUR_MACKEREL_API_KEY or env param MACKEREL_API_KEY")
+	cmd.PersistentFlags().StringVarP(&apiBase, "api-base", "", "", "YOUR_MACKEREL_API_BASE or env param MACKEREL_API_BASE")
+	cmd.PersistentFlags().StringVarP(&serviceName, "service-name", "", "", "target mackerel service name")
 	return cmd
 }
 

--- a/docs/mackerel.md
+++ b/docs/mackerel.md
@@ -1,30 +1,80 @@
 ### Use with Mackerel
 
+- https://registry.terraform.io/providers/mackerelio-labs/mackerel
+
+### Getting started
+
+- terraformer doesn't support `source` at provider directive, you should replace by-hand
+
+```
+# initialize for terraformer
+vi init.tf
+====
+terraform {
+  required_providers {
+    mackerel = {
+      source  = "mackerelio-labs/mackerel"
+      version = "~> 0.0.1"
+    }
+  }
+}
+====
+
+terraform init
+
+# run terraformer
+terraformer import mackerel --api-key=XXXXXXXXXX --resources=service,role,monitor,downtime,notification_group,channel,alert_group_setting,service_metadata,role_metadata --service-name=my-test-service --path-pattern {output}/{provider}/my-test-service/
+
+# edit provider and replace provider source
+vi provider.tf
+====
++ source  = "mackerelio-labs/mackerel"
+version = "~> 0.0.1"
+====
+
+rm init.tf
+terraform state replace-provider registry.terraform.io/-/mackerel registry.terraform.io/mackerelio-labs/mackerel
+terraform fmt
+terraform plan
+```
+
 Example:
 
 ```bash
- ./terraformer import mackerel --resources=service --api-key=YOUR_MACKEREL_API_KEY // or MACKEREL_API_KEY in env --app-key=YOUR_MACKEREL_API_KEY
- ./terraformer import mackerel --resources=service --filter=service=name1:name2:name4 --api-key=YOUR_MACKEREL_API_KEY // or MACKEREL_API_KEY in env --app-key=YOUR_MACKEREL_API_KEY
- ./terraformer import mackerel --resources=aws_integration --filter=aws_integration=id1:id2:id4 --api-key=YOUR_MACKEREL_API_KEY // or MACKEREL_API_KEY in env --app-key=YOUR_MACKEREL_API_KEY
+ terraformer import mackerel --resources=service --api-key=YOUR_MACKEREL_API_KEY // or MACKEREL_API_KEY in env --app-key=YOUR_MACKEREL_API_KEY
+ terraformer import mackerel --resources=service --filter=service=name1:name2:name4 --api-key=YOUR_MACKEREL_API_KEY // or MACKEREL_API_KEY in env --app-key=YOUR_MACKEREL_API_KEY
+ terraformer import mackerel --resources=aws_integration --filter=aws_integration=id1:id2:id4 --api-key=YOUR_MACKEREL_API_KEY // or MACKEREL_API_KEY in env --app-key=YOUR_MACKEREL_API_KEY
+
+terraformer import mackerel --api-key=XXXXXXXXXX --resources=service,role,monitor,downtime,notification_group,channel,alert_group_setting,service_metadata,role_metadata --service-name=my-test-service --path-pattern {output}/{provider}/my-test-service/
+MACKEREL_API_KEY=XXXXXXXXXX terraformer import mackerel --resources=service,role,monitor,downtime,notification_group,channel,alert_group_setting,service_metadata,role_metadata --service-name=my-test-service --path-pattern {output}/{provider}/my-test-service/
 ```
+
+- all of resources are specified by mackerel service name
+  - https://mackerel.io/api-docs/entry/services
 
 List of supported Mackerel services:
 
-*   `alert_group_setting`
-    * `mackerel_alert_group_setting`
-*   `aws_integration`
-    * `mackerel_aws_integration`
-        * Sensitive field `secret_key` is not generated and needs to be manually set
-        * Sensitive field `external_id` is not generated and needs to be manually set
-*   `channel`
-    * `mackerel_channel`
-*   `downtime`
-    * `mackerel_downtime`
-*   `monitor`
-    * `mackerel_monitor`
-*   `notification_group`
-    * `mackerel_notification_group`
-*   `role`
-    * `mackerel_role`
-*   `service`
-    * `mackerel_service`
+- `alert_group_setting`
+  - `mackerel_alert_group_setting`
+- `aws_integration`
+  - `mackerel_aws_integration`
+    - Sensitive field `secret_key` is not generated and needs to be manually set
+    - Sensitive field `external_id` is not generated and needs to be manually set
+- `channel`
+  - `mackerel_channel`
+- `downtime`
+  - `mackerel_downtime`
+- `monitor`
+  - `mackerel_monitor`
+- `notification_group`
+  - `mackerel_notification_group`
+- `role`
+  - `mackerel_role`
+- `role_metadata`
+  - `mackerel_role_metadata`
+- `service`
+  - `mackerel_service`
+- `service_metadata`
+  - `mackerel_service_metadata`
+
+[1]: https://github.com/GoogleCloudPlatform/terraformer/blob/master/README.md#filtering

--- a/providers/mackerel/mackerel_service.go
+++ b/providers/mackerel/mackerel_service.go
@@ -14,8 +14,25 @@
 
 package mackerel
 
-import "github.com/GoogleCloudPlatform/terraformer/terraformutils"
+import (
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/mackerelio/mackerel-client-go"
+)
 
-type MackerelService struct { // nolint
+type MackerelService struct { //nolint
 	terraformutils.Service
+}
+
+func (s *MackerelService) Client() (*mackerel.Client, error) {
+	apiKey := s.GetArgs()["api_key"].(string)
+	apiBase := s.GetArgs()["api_base"].(string)
+	if apiBase == "" {
+		return mackerel.NewClient(apiKey), nil
+	}
+
+	c, err := mackerel.NewClientWithOptions(apiKey, apiBase, false)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
 }

--- a/providers/mackerel/role_metadata.go
+++ b/providers/mackerel/role_metadata.go
@@ -1,0 +1,89 @@
+// Copyright 2021 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mackerel
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+type RoleMetadataGenerator struct {
+	serviceName string
+	MackerelService
+}
+
+func (g *RoleMetadataGenerator) createRoleMetadataGeneratorResources(client *mackerel.Client) error {
+	roles, err := client.FindRoles(g.serviceName)
+	if err != nil {
+		return err
+	}
+
+	for _, role := range roles {
+		namespaces, err := client.GetRoleMetaDataNameSpaces(g.serviceName, role.Name)
+		if err != nil {
+			return err
+		}
+
+		for _, namespace := range namespaces {
+			metadata, err := client.GetRoleMetaData(g.serviceName, role.Name, namespace)
+			if err != nil {
+				return err
+			}
+
+			b, err := json.Marshal(metadata)
+			if err != nil {
+				return err
+			}
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				role.Name+"."+namespace,
+				fmt.Sprintf("role_metadata_%s", role.Name),
+				"mackerel_role_metadata",
+				g.ProviderName,
+				map[string]string{
+					"metadata_json": string(b),
+				},
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+	}
+	return nil
+}
+
+// InitResources Generate TerraformResources from Mackerel API,
+// from each role metadata create 1 TerraformResource.
+// Need RoleMetadata Name as ID for terraform resource
+func (g *RoleMetadataGenerator) InitResources() error {
+	client, err := g.Client()
+	if err != nil {
+		return err
+	}
+
+	funcs := []func(*mackerel.Client) error{
+		g.createRoleMetadataGeneratorResources,
+	}
+
+	for _, f := range funcs {
+		err := f(client)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/providers/mackerel/service_metadata.go
+++ b/providers/mackerel/service_metadata.go
@@ -1,0 +1,95 @@
+// Copyright 2021 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mackerel
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+type ServiceMetadataGenerator struct {
+	serviceName string
+	MackerelService
+}
+
+func (g *ServiceMetadataGenerator) createServiceMetadataGeneratorResources(client *mackerel.Client) error {
+	services, err := client.FindServices()
+	if err != nil {
+		return err
+	}
+
+	for _, service := range services {
+		if service.Name != g.serviceName {
+			continue
+		}
+
+		namespaces, err := client.GetServiceMetaDataNameSpaces(g.serviceName)
+		if err != nil {
+			return err
+		}
+
+		for _, namespace := range namespaces {
+			metadata, err := client.GetServiceMetaData(g.serviceName, namespace)
+			if err != nil {
+				return err
+			}
+
+			b, err := json.Marshal(metadata.ServiceMetaData)
+			if err != nil {
+				return err
+			}
+
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				g.serviceName+"."+namespace,
+				fmt.Sprintf("service_metadata_%s", service.Name),
+				"mackerel_service_metadata",
+				g.ProviderName,
+				map[string]string{
+					"metadata_json": string(b),
+				},
+				[]string{},
+				map[string]interface{}{},
+			))
+		}
+	}
+
+	return nil
+}
+
+// InitResources Generate TerraformResources from Mackerel API,
+// from each service metadata create 1 TerraformResource.
+// Need ServiceMetadata Name as ID for terraform resource
+func (g *ServiceMetadataGenerator) InitResources() error {
+	client, err := g.Client()
+	if err != nil {
+		return err
+	}
+
+	funcs := []func(*mackerel.Client) error{
+		g.createServiceMetadataGeneratorResources,
+	}
+
+	for _, f := range funcs {
+		err := f(client)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Feature

I add the following features:
- support apiBase
    - https://mackerel.io/docs/entry/howto/install-agent
- add service_metadata and role_metadata
    - https://mackerel.io/api-docs/entry/metadata
- enable to import by service
    - I think it is convenient when an organization has a lot of services
- update document
    - add parameter `service-name`
    - add `Getting started` section