### PR TITLE
ci: replace golint with revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,7 +66,7 @@ linters:
   - unused
   - varcheck
   - gofmt
-  - golint
+  - revive
   - goimports
   - gocritic
   - unconvert


### PR DESCRIPTION
The golint was officially deprecated.
golang/go#38968

>  The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive."