### PR TITLE
Octopus deploy docs and provider argument name

### DIFF
--- a/docs/octopus.md
+++ b/docs/octopus.md
@@ -19,9 +19,9 @@ terraformer import octopusdeploy --resources=tagsets
   * `octopusdeploy_feed`
 * `libraryvariablesets`
   * `octopusdeploy_library_variable_set`
-* `lifecycle`
+* `lifecycles`
   * `octopusdeploy_lifecycle`
-* `project`
+* `projects`
   * `octopusdeploy_project`
 * `projectgroups`
   * `octopusdeploy_project_group`

--- a/providers/octopusdeploy/octopusdeploy_provider.go
+++ b/providers/octopusdeploy/octopusdeploy_provider.go
@@ -76,14 +76,14 @@ func (p *OctopusDeployProvider) GetSupportedService() map[string]terraformutils.
 func (p *OctopusDeployProvider) InitService(serviceName string, verbose bool) error {
 	var isSupported bool
 	if _, isSupported = p.GetSupportedService()[serviceName]; !isSupported {
-		return errors.New("octopusdeploy: " + serviceName + " not supported service")
+		return errors.New("octopusdeploy: " + serviceName + " not supported service, see list sub-command")
 	}
 	p.Service = p.GetSupportedService()[serviceName]
 	p.Service.SetName(serviceName)
 	p.Service.SetVerbose(verbose)
 	p.Service.SetProviderName(p.GetName())
 	p.Service.SetArgs(map[string]interface{}{
-		"apikey":  p.apiKey,
+		"api_key": p.apiKey,
 		"address": p.address,
 	})
 
@@ -93,7 +93,7 @@ func (p *OctopusDeployProvider) InitService(serviceName string, verbose bool) er
 // GetConfig return map of provider config for OctopusDeployProvider
 func (p *OctopusDeployProvider) GetConfig() cty.Value {
 	return cty.ObjectVal(map[string]cty.Value{
-		"apikey":  cty.StringVal(p.apiKey),
+		"api_key": cty.StringVal(p.apiKey),
 		"address": cty.StringVal(p.address),
 	})
 }

--- a/providers/octopusdeploy/octopusdeploy_service.go
+++ b/providers/octopusdeploy/octopusdeploy_service.go
@@ -14,7 +14,7 @@ type OctopusDeployService struct { //nolint
 
 func (s *OctopusDeployService) Client() (*octopusdeploy.Client, error) {
 	octopusURL := s.Args["address"].(string)
-	octopusAPIKey := s.Args["apikey"].(string)
+	octopusAPIKey := s.Args["api_key"].(string)
 
 	if octopusURL == "" || octopusAPIKey == "" {
 		err := errors.New("Please make sure to set the env variables 'OCTOPUS_CLI_SERVER' and 'OCTOPUS_CLI_API_KEY'")


### PR DESCRIPTION
The doc didn't match the [supported services](https://github.com/GoogleCloudPlatform/terraformer/blob/master/providers/octopusdeploy/octopusdeploy_provider.go#L59).

The [official provider](https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy#readme) expects `api_key` with the underscore.  It returns an "unexpected argument apikey" error otherwise.