### PR TITLE
Workaround for issues #1166, #1130 import using aws provider fails

### DIFF
--- a/terraformutils/walk.go
+++ b/terraformutils/walk.go
@@ -99,8 +99,12 @@ func walkAndOverride(pathSegments []string, oldValue, newValue string, data inte
 					case isArray(v.Interface()):
 						valss := v.Interface().([]interface{})
 						for idx, currentValue := range valss {
-							if oldValue == currentValue.(string) {
+							curValString, ok := currentValue.(string)
+							if ok && oldValue == curValString {
 								valss[idx] = newValue
+							}
+							if !ok {
+								fmt.Printf("Warning: expected string at path: %s, but found: %+v\n", e.String(), currentValue)
 							}
 						}
 					case isStringArray(v.Interface()):

--- a/terraformutils/walk_test.go
+++ b/terraformutils/walk_test.go
@@ -162,6 +162,20 @@ func TestNestedArrayWalkAndOverride(t *testing.T) {
 	}
 }
 
+func TestNestedMapWalkAndOverride(t *testing.T) {
+	structure := mapI("x", []interface{}{
+		mapI("y", mapI("z", "42")),
+	})
+	WalkAndOverride("z.y", "z", "newValue", structure)
+
+	expected := mapI("x", []interface{}{
+		mapI("y", mapI("z", "42")),
+	})
+	if !reflect.DeepEqual(structure, expected) {
+		t.Errorf("failed to set value")
+	}
+}
+
 func TestEmptyWalkAndCheckField(t *testing.T) {
 	structure := map[string]interface{}{}
 	value := WalkAndCheckField("attr1", structure)


### PR DESCRIPTION
Workaround for panic caused by an unexpected nested map instead of string.

Issues:

- #1166
- #1130

Workaround (not a solution, see note below):

- Add warning when nested element is map instead of string
- Add condition to prevent panic

Note: this is not a fix (as aws structure was updated and this needs to be reflected in code), but a workaround instead that only adds warning and prevents panic.