### PR TITLE
fix: remove the infinite loop on sql servers virtual network rules

### DIFF
--- a/providers/azure/database.go
+++ b/providers/azure/database.go
@@ -691,9 +691,10 @@ func (g *DatabasesGenerator) createSQLVirtualNetworkRuleResources(servers []sql.
 				"azurerm_sql_virtual_network_rule",
 				g.ProviderName,
 				[]string{}))
-		}
-		if err := ruleIter.NextWithContext(ctx); err != nil {
-			return nil, err
+
+			if err := ruleIter.NextWithContext(ctx); err != nil {
+				return nil, err
+			}
 		}
 	}
 	return resources, nil


### PR DESCRIPTION
The iterator next call must be in the for loop