### PR TITLE
fix: some hcl keys must be quoted

### DIFF
--- a/terraformutils/hcl.go
+++ b/terraformutils/hcl.go
@@ -99,6 +99,9 @@ func (v *astSanitizer) visitObjectItem(o *ast.ObjectItem) {
 						break
 					}
 				}
+				if strings.HasPrefix(v, "--") { // if the key starts with "--", we must quote it. Seen in aws_glue_job.default_arguments parameter
+					v = fmt.Sprintf(`"%s"`, v)
+				}
 				if safe {
 					k.Token.Text = v
 				}


### PR DESCRIPTION
During an import for aws glue resources, I had this error: `At 8:5: expected: IDENT | STRING | ASSIGN | LBRACE got: SUB`
The root cause is in aws_glue_job, default_parameters block can take keys that starts with `--`:
```
  default_arguments = {
    "--job-language" = "scala"
  }
```
See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_job

Fixes #1208