### PR TITLE
fix broken link tf/aws/s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ Look for S3 support in terraforming here and official S3 support
 Terraforming lacks full coverage for resources - as an example you can see that 70% of S3 options are not supported:
 
 * terraforming - https://github.com/dtan4/terraforming/blob/master/lib/terraforming/template/tf/s3.erb
-* official S3 support - https://www.terraform.io/docs/providers/aws/r/s3_bucket.html
+* official S3 support - https://www.terraform.io/docs/providers/aws/r/s3_bucket
 
 ## Stargazers over time
 


### PR DESCRIPTION
Minor, link wouldn't resolve - "Page not found"
I guess registry.terraform.io dropped the .html at some point