### PR TITLE
okta: fix typo for `okta_trusted_origin`

### DIFF
--- a/docs/okta.md
+++ b/docs/okta.md
@@ -53,4 +53,4 @@ List of supported Okta services:
 *    `template_sms`
      * `okta_template_sms`
 *    `trusted_origin`
-     * `okta_trusted_orgin`
+     * `okta_trusted_origin`


### PR DESCRIPTION
Fixed the typo for `okta_trusted_origin`

https://github.com/GoogleCloudPlatform/terraformer/blob/dd5512db1e7408e05e9f9a96b1f35c94ddf82587/providers/okta/trusted_origin.go#L33

https://github.com/GoogleCloudPlatform/terraformer/blob/d2916ad40b1767601537157aee36dfe6ce385503/providers/okta/okta_provider.go#L106