### PR TITLE
doc: update resources example

### DIFF
--- a/docs/auth0.md
+++ b/docs/auth0.md
@@ -6,7 +6,7 @@ Example:
 $ export AUTH0_DOMAIN=<DOMAIN>
 $ export AUTH0_CLIENT_ID=<CLIENT_ID>
 $ export AUTH0_CLIENT_SECRET=<CLIENT_SECRET>
-$ terraformer import auth0 --resources=rule,user
+$ terraformer import auth0 --resources=auth0_rule,auth0_user
 ```
 
 List of supported Auth0 services:
@@ -22,11 +22,9 @@ List of supported Auth0 services:
 * `auth0_rule_config`
 * `auth0_trigger_binding`
 * `auth0_user`
-* `auth0_branding"`
+* `auth0_branding`
 * `auth0_custom_domain`
 * `auth0_email`
-* `auth0_prompt"`
+* `auth0_prompt`
 * `auth0_log_stream`
 * `auth0_tenant`
-
-    


### PR DESCRIPTION
As noted in https://github.com/GoogleCloudPlatform/terraformer/issues/1383, this change updates the import command to work correctly with terraformer v0.8.21.