### PR TITLE
Add CloudBuild trigger as further resource

### DIFF
--- a/docs/gcp.md
+++ b/docs/gcp.md
@@ -32,6 +32,8 @@ List of supported GCP services:
 *   `bigQuery`
     * `google_bigquery_dataset`
     * `google_bigquery_table`
+*   `cloudbuild`
+    * `google_cloudbuild_trigger` 
 *   `cloudFunctions`
     * `google_cloudfunctions_function`
 *   `cloudsql`

--- a/go.mod
+++ b/go.mod
@@ -351,6 +351,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/cloudbuild v1.2.0 // indirect
 	cloud.google.com/go/compute v1.3.0 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvf
 cloud.google.com/go/bigquery v1.5.0/go.mod h1:snEHRnqQbz117VIFhE8bmtwIDY80NLUZUMb4Nv6dBIg=
 cloud.google.com/go/bigquery v1.7.0/go.mod h1://okPTzCYNXSlb24MZs83e2Do+h+VXtc4gLoIoXIAPc=
 cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
+cloud.google.com/go/cloudbuild v1.2.0 h1:QcHyULrphpqR992Ijv1M2rcp9451aV/ffHuqlfha6Cc=
+cloud.google.com/go/cloudbuild v1.2.0/go.mod h1:RraRjYXsYxOVnaZuOETdc3boabBTy2CBgPB9lerYsL4=
 cloud.google.com/go/cloudtasks v1.3.0 h1:FKRMPbCt3gzbhTG3tg1teiS2XssAJXaHFbfxH7SPY/8=
 cloud.google.com/go/cloudtasks v1.3.0/go.mod h1:ad5eT/0rBtD752/jsZUPqgT2u3YagyVd5KAmGLrFhjk=
 cloud.google.com/go/compute v0.1.0/go.mod h1:GAesmwr110a34z04OlxYkATPBEfVhkymfTBXtfbBFow=

--- a/providers/gcp/cloudbuild.go
+++ b/providers/gcp/cloudbuild.go
@@ -1,0 +1,76 @@
+package gcp
+
+import (
+	"context"
+
+	cloudbuild "cloud.google.com/go/cloudbuild/apiv1"
+	pb "google.golang.org/genproto/googleapis/devtools/cloudbuild/v1"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+)
+
+const cbMaxPageSize = 50
+
+type CloudBuildGenerator struct {
+	GCPService
+}
+
+// InitResources generates TerraformResources from GCP API.
+func (g *CloudBuildGenerator) InitResources() error {
+	ctx := context.Background()
+
+	c, err := cloudbuild.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	var (
+		triggers      []*pb.BuildTrigger
+		nextPageToken string
+	)
+
+	for {
+		req := &pb.ListBuildTriggersRequest{
+			ProjectId: g.GetArgs()["project"].(string),
+			PageToken: nextPageToken,
+			PageSize:  cbMaxPageSize,
+		}
+
+		res, err := c.ListBuildTriggers(ctx, req)
+		if err != nil {
+			return err
+		}
+
+		triggers = append(triggers, res.Triggers...)
+		nextPageToken = res.NextPageToken
+
+		if nextPageToken == "" {
+			break
+		}
+	}
+
+	g.Resources = g.createBuildTriggers(triggers)
+	return nil
+}
+
+func (g *CloudBuildGenerator) createBuildTriggers(triggers []*pb.BuildTrigger) []terraformutils.Resource {
+	var resources []terraformutils.Resource
+
+	for _, trigger := range triggers {
+		resources = append(resources, terraformutils.NewResource(
+			trigger.GetId(),
+			trigger.GetName(),
+			"google_cloudbuild_trigger",
+			g.ProviderName,
+			map[string]string{
+				"project": g.GetArgs()["project"].(string),
+			},
+			[]string{},
+			map[string]interface{}{
+				"filename": trigger.GetFilename(),
+			},
+		))
+	}
+
+	return resources
+}

--- a/providers/gcp/gcp_provider.go
+++ b/providers/gcp/gcp_provider.go
@@ -119,6 +119,7 @@ func (p *GCPProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 	services["instances"] = &GCPFacade{service: &InstancesGenerator{}}
 	services["pubsub"] = &GCPFacade{service: &PubsubGenerator{}}
 	services["schedulerJobs"] = &GCPFacade{service: &SchedulerJobsGenerator{}}
+	services["cloudbuild"] = &GCPFacade{service: &CloudBuildGenerator{}}
 	return services
 }
 


### PR DESCRIPTION
I added GCP CloudBuild triggers as a further resource. I also would love to add/map some more additional fields like `Substitutions` but wasn't able to get them working on the first try. I mean to create special "blocks" to achieve something like that at the end:

```
resource "google_cloudbuild_trigger" "dummy-trigger" {

  substitutions = {
    _FOO = "bar"
    _BAZ = "qux"
  }

  filename = "cloudbuild.yaml"
  project  = "my-project-id"
}
```

So far imported resources looking like this:

```
resource "google_cloudbuild_trigger" "tfer-xyz-pr-check" {
  approval_config {
    approval_required = "false"
  }

  disabled = "false"
  filename = "cloudbuild.yaml"
  project  = "my-project-id"
}
```

Maybe someone can guide my here or has an example?