### PR TITLE
Add Heroku `team_app` resource

### DIFF
--- a/docs/heroku.md
+++ b/docs/heroku.md
@@ -38,6 +38,8 @@ List of supported Heroku resources:
     * `heroku_pipeline`
 *   `pipeline_coupling`
     * `heroku_pipeline_coupling`
+*   `team_app`
+    * `heroku_team_app`
 *   `team_collaborator`
     * `heroku_team_collaborator`
 *   `team_member`

--- a/providers/heroku/heroku_provider.go
+++ b/providers/heroku/heroku_provider.go
@@ -25,6 +25,7 @@ type HerokuProvider struct { //nolint
 	terraformutils.Provider
 	email  string
 	apiKey string
+	team   string
 }
 
 func (p *HerokuProvider) Init(args []string) error {
@@ -37,6 +38,11 @@ func (p *HerokuProvider) Init(args []string) error {
 		return errors.New("set HEROKU_API_KEY env var")
 	}
 	p.apiKey = os.Getenv("HEROKU_API_KEY")
+
+	// optional
+	if os.Getenv("HEROKU_TEAM") != "" {
+		p.team = os.Getenv("HEROKU_TEAM")
+	}
 
 	return nil
 }
@@ -75,6 +81,7 @@ func (p *HerokuProvider) GetSupportedService() map[string]terraformutils.Service
 		"formation":              &FormationGenerator{},
 		"pipeline":               &PipelineGenerator{},
 		"pipeline_coupling":      &PipelineCouplingGenerator{},
+		"team_app":               &TeamAppGenerator{},
 		"team_collaborator":      &TeamCollaboratorGenerator{},
 		"team_member":            &TeamMemberGenerator{},
 	}
@@ -92,6 +99,7 @@ func (p *HerokuProvider) InitService(serviceName string, verbose bool) error {
 	p.Service.SetArgs(map[string]interface{}{
 		"email":   p.email,
 		"api_key": p.apiKey,
+		"team":    p.team,
 	})
 	return nil
 }

--- a/providers/heroku/team_app.go
+++ b/providers/heroku/team_app.go
@@ -1,0 +1,81 @@
+// Copyright 2022 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package heroku
+
+import (
+	"context"
+	"log"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	heroku "github.com/heroku/heroku-go/v5"
+)
+
+type TeamAppGenerator struct {
+	HerokuService
+}
+
+func (g *TeamAppGenerator) InitResources() error {
+	svc := g.generateService()
+	ctx := context.Background()
+
+	// ensure HEROKU_TEAM is set
+	team := g.Args["team"].(string)
+	if team == "" {
+		log.Fatalln("missing exported value for HEROKU_TEAM")
+		return nil
+	}
+
+	// filter if necessary
+	if len(g.Filter) > 0 {
+		var teamApps []heroku.TeamApp
+		for _, filter := range g.Filter {
+			if filter.IsApplicable("team_app") {
+				for _, app_id := range filter.AcceptableValues {
+					app, err := svc.TeamAppInfo(ctx, app_id)
+					if err != nil {
+						return err
+					}
+
+					teamApps = append(teamApps, *app)
+				}
+			}
+		}
+
+		g.Resources = g.createResources(ctx, teamApps)
+		return nil
+	}
+
+	// otherwise, return all team apps
+	allTeamApps, err := svc.TeamAppListByTeam(ctx, team, &heroku.ListRange{Field: "id", Max: 1000})
+	if err != nil {
+		return err
+	}
+
+	g.Resources = g.createResources(ctx, allTeamApps)
+	return nil
+}
+
+func (g TeamAppGenerator) createResources(ctx context.Context, appList []heroku.TeamApp) []terraformutils.Resource {
+	var resources []terraformutils.Resource
+	for _, app := range appList {
+		resources = append(resources, terraformutils.NewSimpleResource(
+			app.ID,
+			app.Name,
+			"heroku_app",
+			"heroku",
+			[]string{}))
+	}
+	return resources
+}


### PR DESCRIPTION
This adds a new resource for a Heroku `team_app`, as well as adding support for filtering team_apps that are selected as sources for Terraform generation.

If I can get this PR pushed through, I'd like to address https://github.com/GoogleCloudPlatform/terraformer/issues/1226 next.

FWIW, I'm part of Heroku, and I have some cycles I can spare to improve the Heroku provider, assuming I can get some eyes on my PRs to help get them in good shape for this project.

CC: @sergeylanzman