### PR TITLE
Add --no-sort flag to import

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -52,7 +52,7 @@ type ImportOptions struct {
 	Filter        []string
 	Plan          bool `json:"-"`
 	Output        string
-	Sort          bool
+	NoSort        bool
 	RetryCount    int
 	RetrySleepMs  int
 }
@@ -253,7 +253,7 @@ func printService(provider terraformutils.ProviderGenerator, serviceName string,
 	log.Println(provider.GetName() + " save " + serviceName)
 	// Print HCL files for Resources
 	path := Path(options.PathPattern, provider.GetName(), serviceName, options.PathOutput)
-	err := terraformoutput.OutputHclFiles(resources, provider, path, serviceName, options.Compact, options.Output, !options.Sort)
+	err := terraformoutput.OutputHclFiles(resources, provider, path, serviceName, options.Compact, options.Output, !options.NoSort)
 	if err != nil {
 		return err
 	}
@@ -271,7 +271,7 @@ func printService(provider terraformutils.ProviderGenerator, serviceName string,
 			return err
 		}
 		// create Bucket file
-		if bucketStateDataFile, err := terraformutils.Print(bucket.BucketGetTfData(path), map[string]struct{}{}, options.Output, !options.Sort); err == nil {
+		if bucketStateDataFile, err := terraformutils.Print(bucket.BucketGetTfData(path), map[string]struct{}{}, options.Output, !options.NoSort); err == nil {
 			terraformoutput.PrintFile(path+"/bucket.tf", bucketStateDataFile)
 		}
 	} else {
@@ -318,7 +318,7 @@ func printService(provider terraformutils.ProviderGenerator, serviceName string,
 			}
 			// create variables file
 			if len(provider.GetResourceConnections()[serviceName]) > 0 && options.Connect && len(variables["data"]["terraform_remote_state"]) > 0 {
-				variablesFile, err := terraformutils.Print(variables, map[string]struct{}{"config": {}}, options.Output, !options.Sort)
+				variablesFile, err := terraformutils.Print(variables, map[string]struct{}{"config": {}}, options.Output, !options.NoSort)
 				if err != nil {
 					return err
 				}
@@ -348,7 +348,7 @@ func printService(provider terraformutils.ProviderGenerator, serviceName string,
 			}
 			// create variables file
 			if options.Connect {
-				variablesFile, err := terraformutils.Print(variables, map[string]struct{}{"config": {}}, options.Output, !options.Sort)
+				variablesFile, err := terraformutils.Print(variables, map[string]struct{}{"config": {}}, options.Output, !options.NoSort)
 				if err != nil {
 					return err
 				}
@@ -404,7 +404,7 @@ func baseProviderFlags(flag *pflag.FlagSet, options *ImportOptions, sampleRes, s
 	flag.StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
 	flag.StringSliceVarP(&options.Filter, "filter", "f", []string{}, sampleFilters)
 	flag.BoolVarP(&options.Verbose, "verbose", "v", false, "")
-	flag.BoolVarP(&options.Sort, "no-sort", "S", false, "set to disable sorting of HCL")
+	flag.BoolVarP(&options.NoSort, "no-sort", "S", false, "set to disable sorting of HCL")
 	flag.StringVarP(&options.Output, "output", "O", "hcl", "output format hcl or json")
 	flag.IntVarP(&options.RetryCount, "retry-number", "n", 5, "number of retries to perform when refresh fails")
 	flag.IntVarP(&options.RetrySleepMs, "retry-sleep-ms", "m", 300, "time in ms to sleep between retries")

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -52,6 +52,7 @@ type ImportOptions struct {
 	Filter        []string
 	Plan          bool `json:"-"`
 	Output        string
+	Sort          bool
 	RetryCount    int
 	RetrySleepMs  int
 }
@@ -72,6 +73,11 @@ func newImportCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newCmdPlanImporter(options))
+	cmd.AddCommand(&cobra.Command{
+		Use:   "no-sort",
+		Short: "Don't sort resources",
+		Long:  "Don't sort resources",
+	})
 	for _, subcommand := range providerImporterSubcommands() {
 		providerCommand := subcommand(options)
 		_ = providerCommand.MarkPersistentFlagRequired("resources")
@@ -247,7 +253,7 @@ func printService(provider terraformutils.ProviderGenerator, serviceName string,
 	log.Println(provider.GetName() + " save " + serviceName)
 	// Print HCL files for Resources
 	path := Path(options.PathPattern, provider.GetName(), serviceName, options.PathOutput)
-	err := terraformoutput.OutputHclFiles(resources, provider, path, serviceName, options.Compact, options.Output)
+	err := terraformoutput.OutputHclFiles(resources, provider, path, serviceName, options.Compact, options.Output, !options.Sort)
 	if err != nil {
 		return err
 	}
@@ -265,7 +271,7 @@ func printService(provider terraformutils.ProviderGenerator, serviceName string,
 			return err
 		}
 		// create Bucket file
-		if bucketStateDataFile, err := terraformutils.Print(bucket.BucketGetTfData(path), map[string]struct{}{}, options.Output); err == nil {
+		if bucketStateDataFile, err := terraformutils.Print(bucket.BucketGetTfData(path), map[string]struct{}{}, options.Output, !options.Sort); err == nil {
 			terraformoutput.PrintFile(path+"/bucket.tf", bucketStateDataFile)
 		}
 	} else {
@@ -312,7 +318,7 @@ func printService(provider terraformutils.ProviderGenerator, serviceName string,
 			}
 			// create variables file
 			if len(provider.GetResourceConnections()[serviceName]) > 0 && options.Connect && len(variables["data"]["terraform_remote_state"]) > 0 {
-				variablesFile, err := terraformutils.Print(variables, map[string]struct{}{"config": {}}, options.Output)
+				variablesFile, err := terraformutils.Print(variables, map[string]struct{}{"config": {}}, options.Output, !options.Sort)
 				if err != nil {
 					return err
 				}
@@ -342,7 +348,7 @@ func printService(provider terraformutils.ProviderGenerator, serviceName string,
 			}
 			// create variables file
 			if options.Connect {
-				variablesFile, err := terraformutils.Print(variables, map[string]struct{}{"config": {}}, options.Output)
+				variablesFile, err := terraformutils.Print(variables, map[string]struct{}{"config": {}}, options.Output, !options.Sort)
 				if err != nil {
 					return err
 				}
@@ -398,6 +404,7 @@ func baseProviderFlags(flag *pflag.FlagSet, options *ImportOptions, sampleRes, s
 	flag.StringVarP(&options.Bucket, "bucket", "b", "", "gs://terraform-state")
 	flag.StringSliceVarP(&options.Filter, "filter", "f", []string{}, sampleFilters)
 	flag.BoolVarP(&options.Verbose, "verbose", "v", false, "")
+	flag.BoolVarP(&options.Sort, "no-sort", "S", false, "set to disable sorting of HCL")
 	flag.StringVarP(&options.Output, "output", "O", "hcl", "output format hcl or json")
 	flag.IntVarP(&options.RetryCount, "retry-number", "n", 5, "number of retries to perform when refresh fails")
 	flag.IntVarP(&options.RetrySleepMs, "retry-sleep-ms", "m", 300, "time in ms to sleep between retries")

--- a/terraformutils/hcl_test.go
+++ b/terraformutils/hcl_test.go
@@ -43,7 +43,7 @@ func TestPrintResource(t *testing.T) {
 	resources = append(resources, importResource)
 	providerData := map[string]interface{}{}
 	output := "hcl"
-	data, _ := HclPrintResource(resources, providerData, output)
+	data, _ := HclPrintResource(resources, providerData, output, true)
 
 	if strings.Count(string(data), "map1 = ") != 1 {
 		t.Errorf("failed to parse data %s", string(data))

--- a/terraformutils/terraformoutput/hcl.go
+++ b/terraformutils/terraformoutput/hcl.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func OutputHclFiles(resources []terraformutils.Resource, provider terraformutils.ProviderGenerator, path string, serviceName string, isCompact bool, output string) error {
+func OutputHclFiles(resources []terraformutils.Resource, provider terraformutils.ProviderGenerator, path string, serviceName string, isCompact bool, output string, sort bool) error {
 	if err := os.MkdirAll(path, os.ModePerm); err != nil {
 		return err
 	}
@@ -39,7 +39,7 @@ func OutputHclFiles(resources []terraformutils.Resource, provider terraformutils
 		}},
 	}
 
-	providerDataFile, err := terraformutils.Print(providerData, map[string]struct{}{}, output)
+	providerDataFile, err := terraformutils.Print(providerData, map[string]struct{}{}, output, sort)
 	if err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func OutputHclFiles(resources []terraformutils.Resource, provider terraformutils
 	}
 	if len(outputsByResource) > 0 {
 		outputs["output"] = outputsByResource
-		outputsFile, err := terraformutils.Print(outputs, map[string]struct{}{}, output)
+		outputsFile, err := terraformutils.Print(outputs, map[string]struct{}{}, output, sort)
 		if err != nil {
 			return err
 		}
@@ -95,14 +95,14 @@ func OutputHclFiles(resources []terraformutils.Resource, provider terraformutils
 		typeOfServices[r.InstanceInfo.Type] = append(typeOfServices[r.InstanceInfo.Type], r)
 	}
 	if isCompact {
-		err := printFile(resources, "resources", path, output)
+		err := printFile(resources, "resources", path, output, sort)
 		if err != nil {
 			return err
 		}
 	} else {
 		for k, v := range typeOfServices {
 			fileName := strings.ReplaceAll(k, strings.Split(k, "_")[0]+"_", "")
-			err := printFile(v, fileName, path, output)
+			err := printFile(v, fileName, path, output, sort)
 			if err != nil {
 				return err
 			}
@@ -111,7 +111,7 @@ func OutputHclFiles(resources []terraformutils.Resource, provider terraformutils
 	return nil
 }
 
-func printFile(v []terraformutils.Resource, fileName, path, output string) error {
+func printFile(v []terraformutils.Resource, fileName, path, output string, sort bool) error {
 	for _, res := range v {
 		if res.DataFiles == nil {
 			continue
@@ -127,7 +127,7 @@ func printFile(v []terraformutils.Resource, fileName, path, output string) error
 		}
 	}
 
-	tfFile, err := terraformutils.HclPrintResource(v, map[string]interface{}{}, output)
+	tfFile, err := terraformutils.HclPrintResource(v, map[string]interface{}{}, output, sort)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Disables sorting of resource lists, which is useful for cases where
remote order matters.