### PR TITLE
Fix duplicate resource found error in aws_api_gateway_rest_api

### DIFF
--- a/providers/aws/api_gateway.go
+++ b/providers/aws/api_gateway.go
@@ -64,7 +64,7 @@ func (g *APIGatewayGenerator) loadRestApis(svc *apigateway.Client) error {
 			}
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 				*restAPI.Id,
-				*restAPI.Name,
+				*restAPI.Id+"_"+*restAPI.Name,
 				"aws_api_gateway_rest_api",
 				"aws",
 				apiGatewayAllowEmptyValues))


### PR DESCRIPTION
Fix the following error
`2022/09/08 06:24:56 [ERR]: duplicate resource found: aws_api_gateway_rest_api.tfer--SomeName`