### PR TITLE
(fix) typo in cmd/root.go (HoneycombioProvider)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -126,7 +126,7 @@ func providerGenerators() map[string]func() terraformutils.ProviderGenerator {
 		newDataDogProvider,
 		newNewRelicProvider,
 		newPagerDutyProvider,
-		newHoneycombProvider,
+		newHoneycombioProvider,
 		// Community
 		newKeycloakProvider,
 		newLogzioProvider,


### PR DESCRIPTION
Just fixed a single typo in cmd/root.go which was producing an error on build.
Sorry to submit a pull request for such a small change - please disregard if you like, was not sure about the protocol.

Brilliant project, thank you. It's going to save us so much time!