### PR TITLE
fix nil port error with FromPort and ToPort for aws provider sg

### DIFF
--- a/providers/aws/sg.go
+++ b/providers/aws/sg.go
@@ -359,7 +359,7 @@ func fromPort(ip types.IpPermission) int {
 	switch {
 	case *ip.IpProtocol == "icmp":
 		return -1
-	case *ip.FromPort > 0:
+	case ip.FromPort != nil && *ip.FromPort > 0:
 		return int(*ip.FromPort)
 	default:
 		return 0
@@ -370,7 +370,7 @@ func toPort(ip types.IpPermission) int {
 	switch {
 	case *ip.IpProtocol == "icmp":
 		return -1
-	case *ip.ToPort > 0:
+	case ip.ToPort != nil && *ip.ToPort > 0:
 		return int(*ip.ToPort)
 	default:
 		return 65536


### PR DESCRIPTION
This PR fixes the nil port error with FromPort and ToPort for aws provider sg