### PR TITLE
Fix the following panic in aws security_group 

### DIFF
--- a/providers/aws/sg.go
+++ b/providers/aws/sg.go
@@ -359,6 +359,8 @@ func fromPort(ip types.IpPermission) int {
 	switch {
 	case *ip.IpProtocol == "icmp":
 		return -1
+	case *ip.IpProtocol == "-1":
+		return -1
 	case ip.FromPort != nil && *ip.FromPort > 0:
 		return int(*ip.FromPort)
 	default:
@@ -369,6 +371,8 @@ func fromPort(ip types.IpPermission) int {
 func toPort(ip types.IpPermission) int {
 	switch {
 	case *ip.IpProtocol == "icmp":
+		return -1
+	case *ip.IpProtocol == "-1":
 		return -1
 	case ip.ToPort != nil && *ip.ToPort > 0:
 		return int(*ip.ToPort)


### PR DESCRIPTION
`IpPermission.IpProtocol` can get the value "-1"
https://github.com/aws/aws-sdk-go-v2/blob/main/service/ec2/types/types.go#L7263-L7270

But when `IpPermission.IpProtocol` is "-1" then, the following panic occurs
```
2022/09/29 18:34:28 aws importing... sg
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4d70abf]

goroutine 1 [running]:
github.com/GoogleCloudPlatform/terraformer/providers/aws.fromPort(...)
        /home/runner/work/terraformer/terraformer/providers/aws/sg.go:362
```