### PR TITLE
Add aws_lambda_permission support

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -198,6 +198,7 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_lambda_function`
     * `aws_lambda_function_event_invoke_config`
     * `aws_lambda_layer_version`
+    * `aws_lambda_permission`
 *   `logs`
     * `aws_cloudwatch_log_group`
 *   `media_package`

--- a/providers/aws/lambda.go
+++ b/providers/aws/lambda.go
@@ -16,8 +16,10 @@ package aws
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 )
 
@@ -25,6 +27,16 @@ var lambdaAllowEmptyValues = []string{"tags."}
 
 type LambdaGenerator struct {
 	AWSService
+}
+
+type Statement struct {
+	Sid string `json:"Sid"`
+}
+
+type Policy struct {
+	Version string `json:"Version"`
+	Id string `json:"Id"`
+	Statement []*Statement `json:"Statement"`
 }
 
 func (g *LambdaGenerator) InitResources() error {
@@ -88,6 +100,37 @@ func (g *LambdaGenerator) addFunctions(svc *lambda.Client) error {
 				lambdaAllowEmptyValues,
 				map[string]interface{}{},
 			))
+
+		gp, err := svc.GetPolicy(context.TODO(), &lambda.GetPolicyInput{
+			FunctionName: aws.String(*function.FunctionArn),
+		});
+
+		if err != nil {
+			return err
+		}
+
+		outputPolicy := *gp.Policy;
+		var policy Policy;
+		err = json.Unmarshal([]byte(outputPolicy), &policy);
+
+		if err != nil {
+			return err
+		}
+
+		for _, statement := range policy.Statement {
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				statement.Sid,
+				statement.Sid,
+				"aws_lambda_permission",
+				"aws",
+				map[string]string{
+					"statement_id": statement.Sid,
+					"function_name": *function.FunctionArn,
+				},
+				lambdaAllowEmptyValues,
+				map[string]interface{}{},
+			));
+		}
 
 			pi := lambda.NewListFunctionEventInvokeConfigsPaginator(svc,
 				&lambda.ListFunctionEventInvokeConfigsInput{

--- a/providers/aws/lambda.go
+++ b/providers/aws/lambda.go
@@ -35,7 +35,7 @@ type Statement struct {
 
 type Policy struct {
 	Version   string       `json:"Version"`
-	Id        string       `json:"Id"`
+	ID        string       `json:"Id"`
 	Statement []*Statement `json:"Statement"`
 }
 

--- a/providers/aws/lambda.go
+++ b/providers/aws/lambda.go
@@ -34,8 +34,8 @@ type Statement struct {
 }
 
 type Policy struct {
-	Version string `json:"Version"`
-	Id string `json:"Id"`
+	Version   string       `json:"Version"`
+	Id        string       `json:"Id"`
 	Statement []*Statement `json:"Statement"`
 }
 
@@ -101,36 +101,36 @@ func (g *LambdaGenerator) addFunctions(svc *lambda.Client) error {
 				map[string]interface{}{},
 			))
 
-		gp, err := svc.GetPolicy(context.TODO(), &lambda.GetPolicyInput{
-			FunctionName: aws.String(*function.FunctionArn),
-		});
+			gp, err := svc.GetPolicy(context.TODO(), &lambda.GetPolicyInput{
+				FunctionName: aws.String(*function.FunctionArn),
+			})
 
-		if err != nil {
-			return err
-		}
+			if err != nil {
+				return err
+			}
 
-		outputPolicy := *gp.Policy;
-		var policy Policy;
-		err = json.Unmarshal([]byte(outputPolicy), &policy);
+			outputPolicy := *gp.Policy
+			var policy Policy
+			err = json.Unmarshal([]byte(outputPolicy), &policy)
 
-		if err != nil {
-			return err
-		}
+			if err != nil {
+				return err
+			}
 
-		for _, statement := range policy.Statement {
-			g.Resources = append(g.Resources, terraformutils.NewResource(
-				statement.Sid,
-				statement.Sid,
-				"aws_lambda_permission",
-				"aws",
-				map[string]string{
-					"statement_id": statement.Sid,
-					"function_name": *function.FunctionArn,
-				},
-				lambdaAllowEmptyValues,
-				map[string]interface{}{},
-			));
-		}
+			for _, statement := range policy.Statement {
+				g.Resources = append(g.Resources, terraformutils.NewResource(
+					statement.Sid,
+					statement.Sid,
+					"aws_lambda_permission",
+					"aws",
+					map[string]string{
+						"statement_id":  statement.Sid,
+						"function_name": *function.FunctionArn,
+					},
+					lambdaAllowEmptyValues,
+					map[string]interface{}{},
+				))
+			}
 
 			pi := lambda.NewListFunctionEventInvokeConfigsPaginator(svc,
 				&lambda.ListFunctionEventInvokeConfigsInput{


### PR DESCRIPTION
This PR adds ability to import AWS Lambda permission resource (aws_lambda_permission).
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission

# Exported sample
The exported HCL and state file will look like following:

```
resource "aws_lambda_permission" "tfer--lambda-aea1751c-e528-4a3d-877f-08e371f42135" {
  action        = "lambda:InvokeFunction"
  function_name = "arn:aws:lambda:us-east-1:11111111111111:function:test"
  principal     = "events.amazonaws.com"
  source_arn    = "arn:aws:events:us-east-1:1111111111111:rule/rule"
  statement_id  = "lambda-aea1751c-e528-4a3d-877f-08e371f42135"
}
```

terraform.tfstate


```
"aws_lambda_permission.tfer--lambda-aea1751c-e528-4a3d-877f-08e371f42135": {
  "type": "aws_lambda_permission",
  "depends_on": [],
  "primary": {
      "id": "lambda-aea1751c-e528-4a3d-877f-08e371f42135",
      "attributes": {
          "action": "lambda:InvokeFunction",
          "function_name": "arn:aws:lambda:us-east-1:1111111111111:function:test",
          "id": "lambda-aea1751c-e528-4a3d-877f-08e371f42135",
          "principal": "events.amazonaws.com",
          "qualifier": "",
          "source_arn": "arn:aws:events:us-east-1:1111111111111:rule/rule",
          "statement_id": "lambda-aea1751c-e528-4a3d-877f-08e371f42135",
          "statement_id_prefix": ""
      },
      "meta": {
          "schema_version": 0
      },
      "tainted": false
  },
  "deposed": [],
  "provider": "provider.aws"
}
```
