### PR TITLE
Fix duplicate resource errors in aws_cognito_*

### DIFF
--- a/providers/aws/cognito.go
+++ b/providers/aws/cognito.go
@@ -33,7 +33,7 @@ func (g *CognitoGenerator) loadIdentityPools(svc *cognitoidentity.Client) error 
 			var resourceName = *pool.IdentityPoolName
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 				id,
-				resourceName,
+				resourceName+"_"+id,
 				"aws_cognito_identity_pool",
 				"aws",
 				[]string{}))
@@ -59,7 +59,7 @@ func (g *CognitoGenerator) loadUserPools(svc *cognitoidentityprovider.Client) ([
 			resourceName := *pool.Name
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 				id,
-				resourceName,
+				resourceName+"_"+id,
 				"aws_cognito_user_pool",
 				"aws",
 				[]string{}))
@@ -87,7 +87,7 @@ func (g *CognitoGenerator) loadUserPoolClients(svc *cognitoidentityprovider.Clie
 				resourceName := *poolClient.ClientName
 				g.Resources = append(g.Resources, terraformutils.NewResource(
 					id,
-					resourceName,
+					resourceName+"_"+id,
 					"aws_cognito_user_pool_client",
 					"aws",
 					map[string]string{


### PR DESCRIPTION
Fix the duplicate resource error like the following,
```
[ERR]: duplicate resource found: aws_cognito_user_pool_client.tfer--XXXXX
```

`pool.IdentityPoolName`, `pool.Name` and `poolClient.ClientName` can be duplicated. This PR makes those values unique.