### PR TITLE
feat: Add support for AWS IAM Access Key

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -168,6 +168,7 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_glue_job`
     * `aws_glue_trigger`
 *   `iam`
+    * `aws_iam_access_key`
     * `aws_iam_group`
     * `aws_iam_group_policy`
     * `aws_iam_group_policy_attachment`


### PR DESCRIPTION
This RP is add support for AWS IAM Access Key.

## Export Example
* iam_access_key.tf
```
resource "aws_iam_access_key" "tfer--AKxxxxxxxxxxxxxxxxxx" {
  depends_on = ["aws_iam_user.tfer--AIxxxxxxxxxxxxxxxxxx"]
  status     = "Active"
  user       = "user1"
}
```

* terraform.tfstate
```
{
  "version": 4,
  "terraform_version": "0.12.31",
  "serial": 4,
  "lineage": "38301e26-7037-fef0-c3e9-e7546311de19",
  "outputs": {
    "aws_iam_access_key_tfer--AKxxxxxxxxxxxxxxxxxx_id": {
      "value": "AKxxxxxxxxxxxxxxxxxx",
      "type": "string"
    }
  },
  "resources": [
    {
      "mode": "managed",
      "type": "aws_iam_access_key",
      "name": "tfer--AKxxxxxxxxxxxxxxxxxx",
      "provider": "provider.aws",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "encrypted_secret": null,
            "id": "AKxxxxxxxxxxxxxxxxxx",
            "key_fingerprint": null,
            "pgp_key": null,
            "secret": null,
            "ses_smtp_password": null,
            "status": "Active",
            "user": "user1"
          },
          "dependencies": [
            "aws_iam_user.tfer--AIxxxxxxxxxxxxxxxxxx"
          ]
        }
      ]
    },
```

I would be happy to merge them.
If there is anything missing to merge, please let me know.