### PR TITLE
Build provider binaries for all GOOS+GOARCH combinations

### DIFF
--- a/build/multi-build/main.go
+++ b/build/multi-build/main.go
@@ -44,7 +44,7 @@ func main() {
 					GOOS = "darwin"
 					binaryName = "terraformer-" + provider + "-darwin-" + arch
 				}
-				log.Println("Build terraformer with "+provider+" provider...", "GOOS=", GOOS, " for GOARCH=",arch)
+				log.Println("Build terraformer with "+provider+" provider...", "GOOS=", GOOS, " for GOARCH=", arch)
 				deletedProvider := []string{}
 				for _, f := range files {
 					if strings.HasPrefix(f.Name(), filePrefix) {

--- a/build/multi-build/main.go
+++ b/build/multi-build/main.go
@@ -28,90 +28,93 @@ func main() {
 			allProviders = append(allProviders, providerName)
 		}
 	}
-	for _, OS := range []string{"linux", "windows", "mac"} {
-		for _, provider := range allProviders {
-			GOOS := ""
-			binaryName := ""
-			switch OS {
-			case "linux":
-				GOOS = "linux"
-				binaryName = "terraformer-" + provider + "-linux-amd64"
-			case "windows":
-				GOOS = "windows"
-				binaryName = "terraformer-" + provider + "-windows-amd64.exe"
-			case "mac":
-				GOOS = "darwin"
-				binaryName = "terraformer-" + provider + "-darwin-amd64"
-			}
-			log.Println("Build terraformer with "+provider+" provider...", "GOOS=", GOOS)
-			deletedProvider := []string{}
-			for _, f := range files {
-				if strings.HasPrefix(f.Name(), filePrefix) {
-					if !strings.HasPrefix(f.Name(), filePrefix+provider+fileSuffix) {
-						providerName := strings.ReplaceAll(f.Name(), filePrefix, "")
-						providerName = strings.ReplaceAll(providerName, fileSuffix, "")
-						deletedProvider = append(deletedProvider, providerName)
+	for _, arch := range []string{"amd64", "arm64"} {
+		for _, OS := range []string{"linux", "windows", "mac"} {
+			for _, provider := range allProviders {
+				GOOS := ""
+				binaryName := ""
+				switch OS {
+				case "linux":
+					GOOS = "linux"
+					binaryName = "terraformer-" + provider + "-linux-" + arch
+				case "windows":
+					GOOS = "windows"
+					binaryName = "terraformer-" + provider + "-windows-" + arch + ".exe"
+				case "mac":
+					GOOS = "darwin"
+					binaryName = "terraformer-" + provider + "-darwin-" + arch
+				}
+				log.Println("Build terraformer with "+provider+" provider...", "GOOS=", GOOS, " for GOARCH=",arch)
+				deletedProvider := []string{}
+				for _, f := range files {
+					if strings.HasPrefix(f.Name(), filePrefix) {
+						if !strings.HasPrefix(f.Name(), filePrefix+provider+fileSuffix) {
+							providerName := strings.ReplaceAll(f.Name(), filePrefix, "")
+							providerName = strings.ReplaceAll(providerName, fileSuffix, "")
+							deletedProvider = append(deletedProvider, providerName)
+						}
 					}
 				}
-			}
-			// move files for deleted providers
-			err := os.MkdirAll(packageCmdPath+"/tmp", os.ModePerm)
-			if err != nil {
-				log.Fatal("err:", err)
-			}
-			for _, provider := range deletedProvider {
-				err := os.Rename(packageCmdPath+"/"+filePrefix+provider+fileSuffix, packageCmdPath+"/tmp/"+filePrefix+provider+fileSuffix)
+				// move files for deleted providers
+				err := os.MkdirAll(packageCmdPath+"/tmp", os.ModePerm)
 				if err != nil {
-					log.Println(err)
+					log.Fatal("err:", err)
 				}
-			}
-
-			// comment deleted providers in code
-			rootCode, err := ioutil.ReadFile(packageCmdPath + "/root.go")
-			if err != nil {
-				log.Fatal("err:", err)
-			}
-			lines := strings.Split(string(rootCode), "\n")
-			newRootCodeLines := make([]string, len(lines))
-			for i, line := range lines {
 				for _, provider := range deletedProvider {
-					if strings.Contains(strings.ToLower(line), "newcmd"+provider+"importer") {
-						line = "// " + line
-					}
-					if strings.Contains(strings.ToLower(line), "new"+provider+"provider") {
-						line = "// " + line
+					err := os.Rename(packageCmdPath+"/"+filePrefix+provider+fileSuffix, packageCmdPath+"/tmp/"+filePrefix+provider+fileSuffix)
+					if err != nil {
+						log.Println(err)
 					}
 				}
-				newRootCodeLines[i] = line
-			}
-			newRootCode := strings.Join(newRootCodeLines, "\n")
-			err = ioutil.WriteFile(packageCmdPath+"/root.go", []byte(newRootCode), os.ModePerm)
-			if err != nil {
-				log.Fatal("err:", err)
-			}
 
-			// build....
-			cmd := exec.Command("go", "build", "-v", "-o", binaryName)
-			cmd.Env = os.Environ()
-			cmd.Env = append(cmd.Env, "GOOS="+GOOS)
-			var outb, errb bytes.Buffer
-			cmd.Stdout = &outb
-			cmd.Stderr = &errb
-			err = cmd.Run()
-			if err != nil {
-				log.Fatal("err:", errb.String())
-			}
-			fmt.Println(outb.String())
-
-			// revert code and files
-			err = ioutil.WriteFile(packageCmdPath+"/root.go", rootCode, os.ModePerm)
-			if err != nil {
-				log.Fatal("err:", err)
-			}
-			for _, provider := range deletedProvider {
-				err := os.Rename(packageCmdPath+"/tmp/"+filePrefix+provider+fileSuffix, "cmd/"+filePrefix+provider+fileSuffix)
+				// comment deleted providers in code
+				rootCode, err := ioutil.ReadFile(packageCmdPath + "/root.go")
 				if err != nil {
-					log.Println(err)
+					log.Fatal("err:", err)
+				}
+				lines := strings.Split(string(rootCode), "\n")
+				newRootCodeLines := make([]string, len(lines))
+				for i, line := range lines {
+					for _, provider := range deletedProvider {
+						if strings.Contains(strings.ToLower(line), "newcmd"+provider+"importer") {
+							line = "// " + line
+						}
+						if strings.Contains(strings.ToLower(line), "new"+provider+"provider") {
+							line = "// " + line
+						}
+					}
+					newRootCodeLines[i] = line
+				}
+				newRootCode := strings.Join(newRootCodeLines, "\n")
+				err = ioutil.WriteFile(packageCmdPath+"/root.go", []byte(newRootCode), os.ModePerm)
+				if err != nil {
+					log.Fatal("err:", err)
+				}
+
+				// build....
+				cmd := exec.Command("go", "build", "-v", "-o", binaryName)
+				cmd.Env = os.Environ()
+				cmd.Env = append(cmd.Env, "GOOS="+GOOS)
+				cmd.Env = append(cmd.Env, "GOARCH="+arch)
+				var outb, errb bytes.Buffer
+				cmd.Stdout = &outb
+				cmd.Stderr = &errb
+				err = cmd.Run()
+				if err != nil {
+					log.Fatal("err:", errb.String())
+				}
+				fmt.Println(outb.String())
+
+				// revert code and files
+				err = ioutil.WriteFile(packageCmdPath+"/root.go", rootCode, os.ModePerm)
+				if err != nil {
+					log.Fatal("err:", err)
+				}
+				for _, provider := range deletedProvider {
+					err := os.Rename(packageCmdPath+"/tmp/"+filePrefix+provider+fileSuffix, "cmd/"+filePrefix+provider+fileSuffix)
+					if err != nil {
+						log.Println(err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The "build for all providers" github action builds binaries only for the amd64 architecture. This PR changes that to allow creation of binaries across the board for all GOOS/GOARCH combinations.


While this commit registers as a rewrite (due to indentation changes), `git diff -w` gives a clearer picture of the change I've made:
```diff
samveen@zero2w:~/workspace/terraformer $ git diff -w HEAD^ HEAD |cat
diff --git a/build/multi-build/main.go b/build/multi-build/main.go
index e4dad148..8b6f3834 100644
--- a/build/multi-build/main.go
+++ b/build/multi-build/main.go
@@ -28,6 +28,7 @@ func main() {
 			allProviders = append(allProviders, providerName)
 		}
 	}
+	for _, arch :=  []string{"amd64", "arm64"} {
 		for _, OS := range []string{"linux", "windows", "mac"} {
 			for _, provider := range allProviders {
 				GOOS := ""
@@ -35,15 +36,15 @@ func main() {
 				switch OS {
 				case "linux":
 					GOOS = "linux"
-				binaryName = "terraformer-" + provider + "-linux-amd64"
+					binaryName = "terraformer-" + provider + "-linux-" + arch
 				case "windows":
 					GOOS = "windows"
-				binaryName = "terraformer-" + provider + "-windows-amd64.exe"
+					binaryName = "terraformer-" + provider + "-windows-" + arch + ".exe"
 				case "mac":
 					GOOS = "darwin"
-				binaryName = "terraformer-" + provider + "-darwin-amd64"
+					binaryName = "terraformer-" + provider + "-darwin-" + arch
 				}
-			log.Println("Build terraformer with "+provider+" provider...", "GOOS=", GOOS)
+				log.Println("Build terraformer with "+provider+" provider...", "GOOS=", GOOS, " for GOARCH=",arch)
 				deletedProvider := []string{}
 				for _, f := range files {
 					if strings.HasPrefix(f.Name(), filePrefix) {
@@ -94,6 +95,7 @@ func main() {
 				cmd := exec.Command("go", "build", "-v", "-o", binaryName)
 				cmd.Env = os.Environ()
 				cmd.Env = append(cmd.Env, "GOOS="+GOOS)
+				cmd.Env = append(cmd.Env, "GOARCH="+arch)
 				var outb, errb bytes.Buffer
 				cmd.Stdout = &outb
 				cmd.Stderr = &errb
@@ -117,3 +119,4 @@ func main() {
 			}
 		}
 	}
+}
```