### PR TITLE
add support for aws_medialive_channel and input

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -207,6 +207,10 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_media_package_channel`
 *   `media_store`
     * `aws_media_store_container`
+*   `medialive`
+    * `aws_medialive_channel`
+    * `aws_medialive_input`
+    * `aws_medialive_input_security_group`
 *   `msk`
     * `aws_msk_cluster`
 *   `nacl`

--- a/go.mod
+++ b/go.mod
@@ -375,6 +375,7 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2/service/medialive v1.24.2
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/as v1.0.392
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cbs v1.0.392
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cdb v1.0.392

--- a/go.sum
+++ b/go.sum
@@ -399,6 +399,8 @@ github.com/aws/aws-sdk-go-v2/service/kms v1.18.1 h1:y07kzPdcjuuyDVYWf1CCsQQ6kcAW
 github.com/aws/aws-sdk-go-v2/service/kms v1.18.1/go.mod h1:4PZMUkc9rXHWGVB5J9vKaZy3D7Nai79ORworQ3ASMiM=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.23.6 h1:SMjnZMwG0JwsCm7U2FIoU4aPn6Tq6xaHFTu0EU6Lfwg=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.23.6/go.mod h1:iva1fAsnjNgyNXUA3DvAkrGpVy38rHszKNJT/BfvGug=
+github.com/aws/aws-sdk-go-v2/service/medialive v1.24.2 h1:qQGI444VIllp+BlfPUAEO7igk7MnhrtZzRr2jVzU+Z8=
+github.com/aws/aws-sdk-go-v2/service/medialive v1.24.2/go.mod h1:ToDxovZoXnH2AbxzTQ26ySXjpmME5gGa7aiH2rnAVv8=
 github.com/aws/aws-sdk-go-v2/service/mediapackage v1.15.3 h1:g15aLD4lFFtmSwfN+HzgtOFrBMaPK71eEbCmDlaUAfQ=
 github.com/aws/aws-sdk-go-v2/service/mediapackage v1.15.3/go.mod h1:Kw3/17Bg+Ce7jgQCLCMUtvK2wlaAiMprDmZB3Q2XZgM=
 github.com/aws/aws-sdk-go-v2/service/mediastore v1.12.5 h1:aA1A23eOoj+HlKXPV12G/CVFLQ1DrS3JiB72wf8fHS4=

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -282,6 +282,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"logs":              &AwsFacade{service: &LogsGenerator{}},
 		"media_package":     &AwsFacade{service: &MediaPackageGenerator{}},
 		"media_store":       &AwsFacade{service: &MediaStoreGenerator{}},
+		"medialive":         &AwsFacade{service: &MediaLiveGenerator{}},
 		"msk":               &AwsFacade{service: &MskGenerator{}},
 		"nacl":              &AwsFacade{service: &NaclGenerator{}},
 		"nat":               &AwsFacade{service: &NatGatewayGenerator{}},

--- a/providers/aws/medialive.go
+++ b/providers/aws/medialive.go
@@ -1,0 +1,115 @@
+// Copyright 2020 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"context"
+	"log"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/aws/aws-sdk-go-v2/service/medialive"
+)
+
+var medialiveAllowEmptyValues = []string{"tags."}
+
+type MediaLiveGenerator struct {
+	AWSService
+}
+
+func (g *MediaLiveGenerator) InitResources() error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := medialive.NewFromConfig(config)
+	g.Resources = []terraformutils.Resource{}
+
+	if err := g.GetChannels(svc); err != nil {
+		log.Println(err)
+	}
+
+	if err := g.GetInputs(svc); err != nil {
+		log.Println(err)
+	}
+
+	if err := g.GetInputSecurityGroups(svc); err != nil {
+		log.Println(err)
+	}
+
+	return nil
+}
+
+func (g *MediaLiveGenerator) GetChannels(svc *medialive.Client) error {
+	p := medialive.NewListChannelsPaginator(svc, &medialive.ListChannelsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, channel := range page.Channels {
+			channelID := StringValue(channel.Id)
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				channelID,
+				channelID,
+				"aws_medialive_channel",
+				"aws",
+				medialiveAllowEmptyValues))
+		}
+	}
+
+	return nil
+}
+
+func (g *MediaLiveGenerator) GetInputs(svc *medialive.Client) error {
+	p := medialive.NewListInputsPaginator(svc, &medialive.ListInputsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, input := range page.Inputs {
+			inputID := StringValue(input.Id)
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				inputID,
+				inputID,
+				"aws_medialive_input",
+				"aws",
+				medialiveAllowEmptyValues))
+		}
+	}
+
+	return nil
+}
+
+func (g *MediaLiveGenerator) GetInputSecurityGroups(svc *medialive.Client) error {
+	p := medialive.NewListInputSecurityGroupsPaginator(svc, &medialive.ListInputSecurityGroupsInput{})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, inputSecurityGroup := range page.InputSecurityGroups {
+			inputSecurityGroupID := StringValue(inputSecurityGroup.Id)
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				inputSecurityGroupID,
+				inputSecurityGroupID,
+				"aws_medialive_input_security_group",
+				"aws",
+				medialiveAllowEmptyValues))
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds support for `medialive` resources:
- [aws_medialive_channel](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/medialive_channel)
- [aws_medialive_input](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/medialive_input)
- [aws_medialive_input_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/medialive_input_security_group)

In order to be able to generate terraform files for medialive resources, the aws provider needs to be `~> 4.39.0` as that is when the resources was introduced [link](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.39.0).
E.g:
```tf
terraform {
  required_version = ">= 1.3.5"
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "4.39.0"
    }
  }
}
```