### PR TITLE
Bugfix - AWS certificate listener id need to follow the format 'listener-arn_certificate-arn'

### DIFF
--- a/providers/aws/alb.go
+++ b/providers/aws/alb.go
@@ -125,12 +125,13 @@ func (g *AlbGenerator) loadLBListenerCertificate(svc *elasticloadbalancingv2.Cli
 	}
 	for _, lc := range lcs.Certificates {
 		certificateArn := *lc.CertificateArn
+		listenerCertificateId := *loadBalancer.ListenerArn + "_" + certificateArn
 		if certificateArn == *loadBalancer.Certificates[0].CertificateArn { // discard default certificate
 			continue
 		}
 		g.Resources = append(g.Resources, terraformutils.NewResource(
-			certificateArn,
-			certificateArn,
+			listenerCertificateId,
+			listenerCertificateId,
 			"aws_lb_listener_certificate",
 			"aws",
 			map[string]string{

--- a/providers/aws/alb.go
+++ b/providers/aws/alb.go
@@ -125,13 +125,13 @@ func (g *AlbGenerator) loadLBListenerCertificate(svc *elasticloadbalancingv2.Cli
 	}
 	for _, lc := range lcs.Certificates {
 		certificateArn := *lc.CertificateArn
-		listenerCertificateId := *loadBalancer.ListenerArn + "_" + certificateArn
+		listenerCertificateID := *loadBalancer.ListenerArn + "_" + certificateArn
 		if certificateArn == *loadBalancer.Certificates[0].CertificateArn { // discard default certificate
 			continue
 		}
 		g.Resources = append(g.Resources, terraformutils.NewResource(
-			listenerCertificateId,
-			listenerCertificateId,
+			listenerCertificateID,
+			listenerCertificateID,
 			"aws_lb_listener_certificate",
 			"aws",
 			map[string]string{


### PR DESCRIPTION
This PR corrects the certificate listener id that needs to follow the format listener-arn_certificate-arn.

The community reports this issue several times : 
https://github.com/GoogleCloudPlatform/terraformer/issues/1199
https://github.com/GoogleCloudPlatform/terraformer/issues/1416