### PR TITLE
deps: bump to go1.20

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
       - name: Test
         run: go build -v && go test ./...
       - name: Build for linux/amd64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.20
     - name: Go Mod Tidy
       run: go mod tidy
     - name: Test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/terraformer
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go v0.100.2 // indirect


### PR DESCRIPTION
Bump to use the latest go, go1.20

go1.20 release notes, https://tip.golang.org/doc/go1.20