### PR TITLE
Additions to Datadog docs with filtering examples and setup

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -1,13 +1,87 @@
-### Use with Datadog
+# Use Terraformer with [Datadog](https://www.datadoghq.com/)
 
-Example:
+This provider uses the [terraform-provider-datadog](https://registry.terraform.io/providers/DataDog/datadog/latest).
 
+##  Usage
+### 1. Installation
+First you will need to install Terraformer with the Datadog provider. See the [README](https://github.com/GoogleCloudPlatform/terraformer#installation).
+
+### 2. Set up a template Terraform workspace
+Before you can use Terraformer, you need to create a template workspace so that Terraformer
+can access the [DataDog/datadog](https://registry.terraform.io/providers/DataDog/datadog/latest) provider.
+
+To do this, create a new directory with a basic `provider.tf` file:
+```hcl
+terraform {
+  required_providers {
+    datadog = {
+      source  = "DataDog/datadog"
+      version = "3.20.0"
+    }
+  }
+}
+
+provider "datadog" {
+  # Configuration options
+}
 ```
- ./terraformer import datadog --resources=monitor --api-key=YOUR_DATADOG_API_KEY // or DATADOG_API_KEY in env --app-key=YOUR_DATADOG_APP_KEY // or DATADOG_APP_KEY in env --api-url=DATADOG_API_URL // or DATADOG_HOST in env --validate=VALIDATE_BOOL // or DATADOG_VALIDATE in env
- ./terraformer import datadog --resources=monitor --filter=monitor=id1:id2:id4 --api-key=YOUR_DATADOG_API_KEY // or DATADOG_API_KEY in env --app-key=YOUR_DATADOG_APP_KEY // or DATADOG_APP_KEY in env --validate=VALIDATE_BOOL // or DATADOG_VALIDATE in env
+
+then run:
+```bash
+$ terraform init
+````
+
+You should see the output: `Terraform has been successfully initialized!`
+
+### 3. Run Terraformer
+
+```bash
+export DATADOG_API_KEY=Datadog API key. More information on this at https://docs.datadoghq.com/account_management/api-app-keys/ 
+export DATADOG_HOST=Datadog API host i.e. https://api.datadoghq.eu which can be found at https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
+export DATADOG_APP_KEY=Datadog APP key. More information on this at https://docs.datadoghq.com/account_management/api-app-keys/ 
+
+./terraformer import datadog --resources=* 
 ```
 
-List of supported Datadog services:
+You can also specify only certain kinds of resources to import as well, i.e. `--resources=dashboard`.
+
+### 4. Inspect the imported Terraform files
+
+You should now see a `generated/` subdirectory with generated files.
+
+You can now initialize and use your new generated resources:
+```bash
+$ terraform init
+$ terraform plan # No changes. Your infrastructure matches the configuration.
+```
+
+### Filtering Resources
+
+You can use the `filter` argument to restrict the import of Terraform resources.
+
+Filtering based on Tags follows the convention `--filter="Name=tags;Value='your tag'"`.
+
+```bash
+# Import monitors based on multiple tags
+./terraformer import datadog --resources=monitor --filter="Name=tags;Value='foo:bar'" --filter="Name=tags;Value='env:production'"
+
+# Import monitor where tag doesn't include colon
+./terraformer import datadog --resources=monitor --filter="Name=tags;Value=anExampleTag"
+```
+
+Filtering based on resource ID:
+
+```bash
+# Import dashboard based on the dashboard ID
+./terraformer import datadog --resource=dashboard --filter=dashboard=some-id
+
+# Import based on multiple resource IDs
+ ./terraformer import datadog --resource=monitor --filter=monitor=id1:id2:id4
+```
+
+Tag filters are order specific. For example, if your monitor has tags (in the order) `atag: atagvalue`, `foo:bar` but you filter for `--filter="Name=tags;Value='foo:bar'" --filter="Name=tags;Value='atag: atagvalue'"`, the monitor would not be imported.
+
+## Supported Datadog resources
 
 *   `dashboard`
     * `datadog_dashboard`
@@ -49,7 +123,7 @@ List of supported Datadog services:
     * `datadog_integration_pagerduty_service_object`
 *   `integration_slack_channel`
     * `datadog_integration_slack_channel`
-      * **_NOTE:_** Importing resource requires resource ID or `account_name` to be passed via [Filter][1] option
+        * **_NOTE:_** Importing resource requires resource ID or `account_name` to be passed via [Filter][1] option
 *   `metric_metadata`
     * `datadog_metric_metadata`
         * **_NOTE:_** Importing resource requires resource ID's to be passed via [Filter][1] option


### PR DESCRIPTION
An issue was raised (https://github.com/GoogleCloudPlatform/terraformer/issues/1605) regarding how to "_Import Datadog Monitors filtering on tags_".

This PR updates the [Datadog](https://www.datadoghq.com/) Terraformer docs with further information on:
- Installation/Setup
- Running Terraformer for importing Datadog resources
- Filtering resources