### PR TITLE
Adding Extraction of IdentityStore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -375,7 +375,9 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2/service/identitystore v1.16.5
 	github.com/aws/aws-sdk-go-v2/service/medialive v1.24.2
+	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.16.5
 	github.com/opalsecurity/opal-go v1.0.9
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/as v1.0.392
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cbs v1.0.392

--- a/go.sum
+++ b/go.sum
@@ -383,6 +383,10 @@ github.com/aws/aws-sdk-go-v2/service/glue v1.34.1 h1:efK/gymVkMAu/ZPFtBhDr9XVdUw
 github.com/aws/aws-sdk-go-v2/service/glue v1.34.1/go.mod h1:kgD6fBlQEkhJlffBbS8SGYtpjboavr9e8B1ZouD84pY=
 github.com/aws/aws-sdk-go-v2/service/iam v1.3.0 h1:V95YLxbxLGlTcFR0KMMSZEaudIxYCAhycSGcO7/Favs=
 github.com/aws/aws-sdk-go-v2/service/iam v1.3.0/go.mod h1:gPUYT7MBEb30j9eAsJ17LN9KbXtD1uqKOOKesCC4tjc=
+github.com/aws/aws-sdk-go-v2/service/identitystore v1.16.5 h1:Mbz3LjbbVE6fFwYEYf2cJFcmFmIOZhSOyuTGYY0CzgQ=
+github.com/aws/aws-sdk-go-v2/service/identitystore v1.16.5/go.mod h1:ZMSJuu9//YKamgC3vArYkljfp2wjbtwdqYAwclNfhXY=
+github.com/aws/aws-sdk-go-v2/service/identitystore v1.16.6 h1:tzB5Y88Xb4//jybVjrk6ECAcUhCk1ZwV2NuBnpil+w0=
+github.com/aws/aws-sdk-go-v2/service/identitystore v1.16.6/go.mod h1:qdai9l1KfhYZ4J0HWFtN9KJ8pG+TwG9UxCHcdf0EdTE=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.0.3 h1:iLFz4nrWkXMTFeVn0n99wRyc4Xib4SlDbtAM3h2z8P8=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.0.3/go.mod h1:g3Xw4tO/W+ae4EMzkxB6nGnJ48cLM4i1Z61WmD+IKtY=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.0.5/go.mod h1:MW0O/RpmVpS6MWKn6W03XEJmqXlG7+d3iaYLzkd2fAc=
@@ -443,6 +447,8 @@ github.com/aws/aws-sdk-go-v2/service/ssm v1.33.0/go.mod h1:rEsqsZrOp9YvSGPOrcL3p
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.4/go.mod h1:yQayEbOWH75NaKFylsFocBc3yanYEGndlOaH4i/Lvno=
 github.com/aws/aws-sdk-go-v2/service/sso v1.11.17 h1:pXxu9u2z1UqSbjO9YA8kmFJBhFc1EVTDaf7A+S+Ivq8=
 github.com/aws/aws-sdk-go-v2/service/sso v1.11.17/go.mod h1:mS5xqLZc/6kc06IpXn5vRxdLaED+jEuaSRv5BxtnsiY=
+github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.16.5 h1:m6DSJuVmP10bjNecNFwMCrTwneQHrTTZYt6V2JY4wuA=
+github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.16.5/go.mod h1:4lVMiqLgfjalSs/EcVjhmDk+lD9y1hvekcUzEYGsYc8=
 github.com/aws/aws-sdk-go-v2/service/sts v1.2.1/go.mod h1:L1LH5nHMXxdkKj057ZUx7Wi50CCrkZ+9jkTnBnY2j/w=
 github.com/aws/aws-sdk-go-v2/service/sts v1.16.13 h1:dl8T0PJlN92rvEGOEUiD0+YPYdPEaCZK0TqHukvSfII=
 github.com/aws/aws-sdk-go-v2/service/sts v1.16.13/go.mod h1:Ru3QVMLygVs/07UQ3YDur1AQZZp2tUNje8wfloFttC0=

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -92,6 +92,12 @@ func (p AWSProvider) GetResourceConnections() map[string]map[string][]string {
 			"subnet": []string{"subnets", "id"},
 		},
 		"igw": {"vpc": []string{"vpc_id", "id"}},
+		"identitystore": {
+			"identitystore": []string{
+				"group_id", "id",
+				"member_id", "id",
+			},
+		},
 		"msk": {
 			"subnet": []string{"broker_node_group_info.client_subnets", "id"},
 			"sg":     []string{"broker_node_group_info.security_groups", "id"},
@@ -274,6 +280,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"firehose":          &AwsFacade{service: &FirehoseGenerator{}},
 		"glue":              &AwsFacade{service: &GlueGenerator{}},
 		"iam":               &AwsFacade{service: &IamGenerator{}},
+		"identitystore":     &AwsFacade{service: &IdentityStoreGenerator{}},
 		"igw":               &AwsFacade{service: &IgwGenerator{}},
 		"iot":               &AwsFacade{service: &IotGenerator{}},
 		"kinesis":           &AwsFacade{service: &KinesisGenerator{}},

--- a/providers/aws/identitystore.go
+++ b/providers/aws/identitystore.go
@@ -1,0 +1,185 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/aws/aws-sdk-go-v2/service/identitystore"
+	"github.com/aws/aws-sdk-go-v2/service/identitystore/types"
+	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
+)
+
+var identityStoreAllowEmptyValues = []string{"tags."}
+
+type IdentityStoreGenerator struct {
+	AWSService
+}
+
+func (g *IdentityStoreGenerator) GetIdentityStoreId() (*string, error) {
+	config, e := g.generateConfig()
+	if e != nil {
+		return nil, e
+	}
+	svc := ssoadmin.NewFromConfig(config)
+	instances, err := svc.ListInstances(context.TODO(), &ssoadmin.ListInstancesInput{})
+	if err != nil {
+		return nil, err
+	}
+	identityStoreId := StringValue(instances.Instances[0].IdentityStoreId)
+	return &identityStoreId, nil
+
+}
+
+func (g *IdentityStoreGenerator) InitGroupResources(identityStoreId string) error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := identitystore.NewFromConfig(config)
+	p := identitystore.NewListGroupsPaginator(svc, &identitystore.ListGroupsInput{
+		IdentityStoreId: aws.String(identityStoreId),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, group := range page.Groups {
+			groupId := StringValue(group.GroupId)
+			displayName := StringValue(group.DisplayName)
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				identityStoreId+"/"+groupId,
+				displayName,
+				"aws_identitystore_group",
+				"aws",
+				map[string]string{
+					"identity_store_id": identityStoreId,
+					"description":       StringValue(group.Description),
+				},
+				identityStoreAllowEmptyValues,
+				map[string]interface{}{},
+			))
+			err = g.InitGroupMembershipResources(identityStoreId, groupId)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (g *IdentityStoreGenerator) InitGroupMembershipResources(identityStoreId string, groupId string) error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := identitystore.NewFromConfig(config)
+	p := identitystore.NewListGroupMembershipsPaginator(svc, &identitystore.ListGroupMembershipsInput{
+		GroupId:         aws.String(groupId),
+		IdentityStoreId: aws.String(identityStoreId),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, user := range page.GroupMemberships {
+			var memberId string
+			switch v := user.MemberId.(type) {
+			case *types.MemberIdMemberUserId:
+				memberId = v.Value // Value is string
+			case *types.UnknownUnionMember:
+				memberId = v.Tag
+			default:
+				memberId = ""
+			}
+			membershipId := StringValue(user.MembershipId)
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				identityStoreId+"/"+membershipId,
+				"m-"+groupId+"-"+memberId,
+				"aws_identitystore_group_membership",
+				"aws",
+				map[string]string{
+					"identity_store_id": identityStoreId,
+					"group_id":          groupId,
+					"member_id":         memberId,
+				},
+				identityStoreAllowEmptyValues,
+				map[string]interface{}{},
+			))
+		}
+	}
+	return nil
+}
+
+func (g *IdentityStoreGenerator) InitUserResources(identityStoreId string) error {
+	config, e := g.generateConfig()
+	if e != nil {
+		return e
+	}
+	svc := identitystore.NewFromConfig(config)
+	p := identitystore.NewListUsersPaginator(svc, &identitystore.ListUsersInput{
+		IdentityStoreId: aws.String(identityStoreId),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(context.TODO())
+		if err != nil {
+			return err
+		}
+		for _, user := range page.Users {
+			userId := StringValue(user.UserId)
+			displayName := StringValue(user.DisplayName)
+			//			name := StringValue(user.Name)
+			userName := StringValue(user.UserName)
+			g.Resources = append(g.Resources, terraformutils.NewResource(
+				identityStoreId+"/"+userId,
+				userName,
+				"aws_identitystore_user",
+				"aws",
+				map[string]string{
+					"identity_store_id": identityStoreId,
+					"display_name":      displayName,
+					"use_name":          userName,
+				},
+				identityStoreAllowEmptyValues,
+				map[string]interface{}{},
+			))
+		}
+	}
+	return nil
+}
+
+func (g *IdentityStoreGenerator) InitResources() error {
+	identityStoreId, e := g.GetIdentityStoreId()
+	if e != nil {
+		return e
+	}
+
+	e = g.InitUserResources(*identityStoreId)
+	if e != nil {
+		return e
+	}
+
+	e = g.InitGroupResources(*identityStoreId)
+	if e != nil {
+		return e
+	}
+
+	return nil
+}


### PR DESCRIPTION
*Description*:

Update AWS provider to add support for resources [`aws_identitystore_*`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/identitystore_group).

Please note that it would be nice to use references in the `aws_identitystore_group_membership` resource toward the corresponding `aws_identitystore_group`  and `aws_identitystore_user`. However I do not know how to do that. Advice are welcome.
