### PR TITLE
fix: importing aws_batch_job_definition

### DIFF
--- a/providers/aws/batch.go
+++ b/providers/aws/batch.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
 
@@ -72,7 +73,7 @@ func (g *BatchGenerator) loadJobDefinitions(batchClient *batch.Client) error {
 			return err
 		}
 		for _, jobDefinition := range page.JobDefinitions {
-			jobDefinitionName := StringValue(jobDefinition.JobDefinitionName)
+			jobDefinitionName := StringValue(jobDefinition.JobDefinitionName) + ":" + fmt.Sprint(jobDefinition.Revision)
 			g.Resources = append(g.Resources, terraformutils.NewResource(
 				jobDefinitionName,
 				jobDefinitionName,


### PR DESCRIPTION
I tried to import AWS Batch job definition and got the following error.

```
2023/06/08 12:54:57 ERROR: Read resource response is null for resource aws_batch_job_definition.tfer--job_definition_name
2023/06/08 12:54:58 ERROR: Unable to refresh resource tfer--job_definition_name
```

It seems that `jobDefinitions` parameter in DescribeJobDefinitions API needs to include the revision of the job definition.

https://docs.aws.amazon.com/batch/latest/APIReference/API_DescribeJobDefinitions.html

This fix worked for me locally.