### PR TITLE
Removed deprecated redshift resource

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -247,6 +247,13 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_db_option_group`
     * `aws_db_event_subscription`
     * `aws_rds_global_cluster`
+* `redshift`
+    * `aws_redshift_cluster`
+    * `aws_redshift_event_subscription`
+    * `aws_redshift_parameter_group`
+    * `aws_redshift_snapshot_schedule`
+    * `aws_redshift_snapshot_schedule_association`
+    * `aws_redshift_subnet_group`
 *   `resourcegroups`
     * `aws_resourcegroups_group`
 *   `route53`

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -247,7 +247,7 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_db_option_group`
     * `aws_db_event_subscription`
     * `aws_rds_global_cluster`
-* `redshift`
+*   `redshift`
     * `aws_redshift_cluster`
     * `aws_redshift_event_subscription`
     * `aws_redshift_parameter_group`

--- a/go.mod
+++ b/go.mod
@@ -378,9 +378,7 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2/service/identitystore v1.16.5
 	github.com/aws/aws-sdk-go-v2/service/medialive v1.24.2
-
 	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.16.5
-	github.com/opalsecurity/opal-go v1.0.9
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/as v1.0.392
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cbs v1.0.392
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cdb v1.0.392

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,6 @@ github.com/aws/aws-sdk-go-v2/service/iam v1.3.0 h1:V95YLxbxLGlTcFR0KMMSZEaudIxYC
 github.com/aws/aws-sdk-go-v2/service/iam v1.3.0/go.mod h1:gPUYT7MBEb30j9eAsJ17LN9KbXtD1uqKOOKesCC4tjc=
 github.com/aws/aws-sdk-go-v2/service/identitystore v1.16.5 h1:Mbz3LjbbVE6fFwYEYf2cJFcmFmIOZhSOyuTGYY0CzgQ=
 github.com/aws/aws-sdk-go-v2/service/identitystore v1.16.5/go.mod h1:ZMSJuu9//YKamgC3vArYkljfp2wjbtwdqYAwclNfhXY=
-github.com/aws/aws-sdk-go-v2/service/identitystore v1.16.6 h1:tzB5Y88Xb4//jybVjrk6ECAcUhCk1ZwV2NuBnpil+w0=
-github.com/aws/aws-sdk-go-v2/service/identitystore v1.16.6/go.mod h1:qdai9l1KfhYZ4J0HWFtN9KJ8pG+TwG9UxCHcdf0EdTE=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.0.3 h1:iLFz4nrWkXMTFeVn0n99wRyc4Xib4SlDbtAM3h2z8P8=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.0.3/go.mod h1:g3Xw4tO/W+ae4EMzkxB6nGnJ48cLM4i1Z61WmD+IKtY=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.0.5/go.mod h1:MW0O/RpmVpS6MWKn6W03XEJmqXlG7+d3iaYLzkd2fAc=

--- a/providers/aws/redshift.go
+++ b/providers/aws/redshift.go
@@ -97,27 +97,6 @@ func (g *RedshiftGenerator) loadSubnetGroups(svc *redshift.Client) error {
 	return nil
 }
 
-func (g *RedshiftGenerator) loadSecurityGroups(svc *redshift.Client) error {
-	p := redshift.NewDescribeClusterSecurityGroupsPaginator(svc, &redshift.DescribeClusterSecurityGroupsInput{})
-	for p.HasMorePages() {
-		page, err := p.NextPage(context.TODO())
-		if err != nil {
-			return err
-		}
-		for _, sg := range page.ClusterSecurityGroups {
-			resourceName := StringValue(sg.ClusterSecurityGroupName)
-			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
-				resourceName,
-				resourceName,
-				"aws_redshift_security_group",
-				"aws",
-				RedshiftAllowEmptyValues,
-			))
-		}
-	}
-	return nil
-}
-
 func (g *RedshiftGenerator) loadEventSubscription(svc *redshift.Client) error {
 	p := redshift.NewDescribeEventSubscriptionsPaginator(svc, &redshift.DescribeEventSubscriptionsInput{})
 	for p.HasMorePages() {
@@ -189,9 +168,6 @@ func (g *RedshiftGenerator) InitResources() error {
 		return err
 	}
 	if err := g.loadSubnetGroups(svc); err != nil {
-		return err
-	}
-	if err := g.loadSecurityGroups(svc); err != nil {
 		return err
 	}
 	if err := g.loadEventSubscription(svc); err != nil {


### PR DESCRIPTION
In version `5.0.0` of the `terraform-provider-aws` the `aws_redshift_security_group` resource got deprecated.
In this PR the resource got removed and documentation got updated.

https://github.com/hashicorp/terraform-provider-aws/pull/30966
https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0

This will also solve https://github.com/GoogleCloudPlatform/terraformer/issues/1718