### PR TITLE
workflows: remove windows for ci and release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,8 +26,6 @@ jobs:
         run: GOOS=darwin go build -o terraformer-all-darwin-amd64
       - name: Build for mac Apple Silicon
         run: GOOS=darwin GOARCH=arm64 go build -o terraformer-all-darwin-arm64
-      - name: Build for windows
-        run: GOOS=windows go build -o terraformer-all-windows-amd64
       - name: Build for all providers
         run: go run build/multi-build/main.go
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
fixes #1741 

Right now the windows build is completely broken due to the OOM issue, and it now blocks the new releases for 0.8.23 and 0.8.24. I would recommend removing the windows builds for now and we can always add them back later. (first report in https://github.com/GoogleCloudPlatform/terraformer/issues/1542)

cc @sergeylanzman 