### PR TITLE
fix(aws): `concurrent_build_limit` cannot be zero

### DIFF
--- a/providers/aws/codebuild.go
+++ b/providers/aws/codebuild.go
@@ -50,3 +50,15 @@ func (g *CodeBuildGenerator) InitResources() error {
 	}
 	return nil
 }
+
+func (g *CodeBuildGenerator) PostConvertHook() error {
+	for _, r := range g.Resources {
+		if r.InstanceInfo.Type != "aws_codebuild_project" {
+			continue
+		}
+		if r.InstanceState.Attributes["concurrent_build_limit"] == "0" {
+			delete(r.Item, "concurrent_build_limit")
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Hi, I found a small bug while importing a codebuild project into terraformer, so I'm opening a PR. (Reopen)

- concurrent_build_limit value cannot be zero.  
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_project  

- Remove it from the PostConvertHook step.
Issue https://github.com/GoogleCloudPlatform/terraformer/issues/1610

