### PR TITLE
Added codecommit approval rule template

### DIFF
--- a/providers/aws/codecommit.go
+++ b/providers/aws/codecommit.go
@@ -73,11 +73,12 @@ func (g *CodeCommitGenerator) InitResources() error {
 		return e
 	}
 	svc := codecommit.NewFromConfig(config)
-
-	if err := g.loadRepository(svc); err != nil {
+	err := g.loadRepository(svc)
+	if err != nil {
 		return err
 	}
-	if err := g.loadApprovalRuleTemplate(svc); err != nil {
+	err = g.loadApprovalRuleTemplate(svc)
+	if err != nil {
 		return err
 	}
 

--- a/providers/aws/codecommit.go
+++ b/providers/aws/codecommit.go
@@ -16,6 +16,7 @@ package aws
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
 	"github.com/aws/aws-sdk-go-v2/service/codecommit"
@@ -80,5 +81,18 @@ func (g *CodeCommitGenerator) InitResources() error {
 		return err
 	}
 
+	return nil
+}
+
+func (g *CodeCommitGenerator) PostConvertHook() error {
+	for i, resource := range g.Resources {
+		if resource.InstanceInfo.Type == "aws_codecommit_approval_rule_template" {
+			if content, ok := g.Resources[i].Item["content"]; ok {
+				g.Resources[i].Item["content"] = fmt.Sprintf(`<<CONTENT
+%s
+CONTENT`, content)
+			}
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
This PR adds support to `aws_codecommit_approval_rule_template`

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codecommit_approval_rule_template#last_modified_user

Exported example:

```
resource "aws_codecommit_approval_rule_template" "tfer--codecommit_template_test" {
  content = <<CONTENT
{
  "DestinationReferences": [
    "ref/master"
  ],
  "Statements": [
    {
      "ApprovalPoolMembers": [
        "CodeCommitApprovers:ss2"
      ],
      "NumberOfApprovalsNeeded": 3,
      "Type": "Approvers"
    }
  ],
  "Version": "2018-11-08"
}
CONTENT

  description = "codecommit_template_test_Template"
  name        = "codecommit_template_test"
}
```