### PR TITLE
Fix: AWS identitystore: failed if there are no instances

### DIFF
--- a/providers/aws/identitystore.go
+++ b/providers/aws/identitystore.go
@@ -41,9 +41,9 @@ func (g *IdentityStoreGenerator) GetIdentityStoreId() (*string, error) {
 	if err != nil {
 		return nil, err
 	}
-  if len(instances.Instances) == 0 {
-    return nil, nil
-  }
+	if len(instances.Instances) == 0 {
+		return nil, nil
+	}
 	identityStoreId := StringValue(instances.Instances[0].IdentityStoreId)
 	return &identityStoreId, nil
 
@@ -173,9 +173,9 @@ func (g *IdentityStoreGenerator) InitResources() error {
 	if e != nil {
 		return e
 	}
-  if identityStoreId == nil {
-    return nil
-  }
+	if identityStoreId == nil {
+		return nil
+	}
 
 	e = g.InitUserResources(*identityStoreId)
 	if e != nil {

--- a/providers/aws/identitystore.go
+++ b/providers/aws/identitystore.go
@@ -41,6 +41,9 @@ func (g *IdentityStoreGenerator) GetIdentityStoreId() (*string, error) {
 	if err != nil {
 		return nil, err
 	}
+  if len(instances.Instances) == 0 {
+    return nil, nil
+  }
 	identityStoreId := StringValue(instances.Instances[0].IdentityStoreId)
 	return &identityStoreId, nil
 
@@ -170,6 +173,9 @@ func (g *IdentityStoreGenerator) InitResources() error {
 	if e != nil {
 		return e
 	}
+  if identityStoreId == nil {
+    return nil
+  }
 
 	e = g.InitUserResources(*identityStoreId)
 	if e != nil {


### PR DESCRIPTION
Fix crashing on importing AWS identitystore, if there are no instances, reproduced on current master.
closes https://github.com/GoogleCloudPlatform/terraformer/issues/1808

```
terraformer import aws --resources=identitystore --regions=us-west-2
....

2023/12/11 20:06:06 aws importing... identitystore
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/GoogleCloudPlatform/terraformer/providers/aws.(*IdentityStoreGenerator).GetIdentityStoreId(0xc0038b90d0?)
	/Users/sergey/temp/terraformer/providers/aws/identitystore.go:44 +0x1ce
github.com/GoogleCloudPlatform/terraformer/providers/aws.(*IdentityStoreGenerator).InitResources(0x0?)
	/Users/sergey/temp/terraformer/providers/aws/identitystore.go:169 +0x25
github.com/GoogleCloudPlatform/terraformer/providers/aws.(*AwsFacade).InitResources(0xc0020449b0?)
	/Users/sergey/temp/terraformer/providers/aws/aws_facade.go:61 +0x26
github.com/GoogleCloudPlatform/terraformer/cmd.initServiceResources({_, _}, {_, _}, {{0xc0012df800, 0x56, 0x80}, {0x12999268, 0x0, 0x0}, ...}, ...)
	/Users/sergey/temp/terraformer/cmd/import.go:209 +0x21e
github.com/GoogleCloudPlatform/terraformer/cmd.initAllServicesResources(_, {{0xc0012df800, 0x56, 0x80}, {0x12999268, 0x0, 0x0}, {0xb20575b, 0x1e}, {0xb15cdd8, ...}, ...}, ...)
	/Users/sergey/temp/terraformer/cmd/import.go:166 +0x1c5
github.com/GoogleCloudPlatform/terraformer/cmd.Import({_, _}, {{0xc0012df800, 0x56, 0x80}, {0x12999268, 0x0, 0x0}, {0xb20575b, 0x1e}, ...}, ...)
	/Users/sergey/temp/terraformer/cmd/import.go:98 +0x2a5
github.com/GoogleCloudPlatform/terraformer/cmd.importRegionResources({{0xc0008300e0, 0x1, 0x1}, {0x12999268, 0x0, 0x0}, {0xb20575b, 0x1e}, {0xb15cdd8, 0x9}, ...}, ...)
	/Users/sergey/temp/terraformer/cmd/provider_cmd_aws.go:121 +0x292
github.com/GoogleCloudPlatform/terraformer/cmd.newCmdAwsImporter.func1(0xc00131ab00?, {0xb14e4f4?, 0x2?, 0x2?})
	/Users/sergey/temp/terraformer/cmd/provider_cmd_aws.go:58 +0xa0e
github.com/spf13/cobra.(*Command).execute(0xc00131ab00, {0xc000191240, 0x2, 0x2})
	/Users/sergey/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:850 +0x67c
github.com/spf13/cobra.(*Command).ExecuteC(0xc000de58c0)
	/Users/sergey/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:958 +0x39d
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/sergey/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:895
github.com/GoogleCloudPlatform/terraformer/cmd.Execute()
	/Users/sergey/temp/terraformer/cmd/root.go:36 +0x1e
main.main()
	/Users/sergey/temp/terraformer/main.go:39 +0x50
```