### PR TITLE
Clarify installation instructions to avoid issue #470

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,17 +227,18 @@ From source:
 3.  Run `go build -v` for all providers OR build with one provider
 `go run build/main.go {google,aws,azure,kubernetes,etc}`
 
-From releases:
+From releases.  This installs all providers, set `PROVIDER` to one of `google`, `aws` or `kubernetes` if you only need one.
+
 * Linux
 ```
-export PROVIDER={all,google,aws,kubernetes}
+export PROVIDER=all
 curl -LO "https://github.com/GoogleCloudPlatform/terraformer/releases/download/$(curl -s https://api.github.com/repos/GoogleCloudPlatform/terraformer/releases/latest | grep tag_name | cut -d '"' -f 4)/terraformer-${PROVIDER}-linux-amd64"
 chmod +x terraformer-${PROVIDER}-linux-amd64
 sudo mv terraformer-${PROVIDER}-linux-amd64 /usr/local/bin/terraformer
 ```
 * MacOS
 ```
-export PROVIDER={all,google,aws,kubernetes}
+export PROVIDER=all
 curl -LO "https://github.com/GoogleCloudPlatform/terraformer/releases/download/$(curl -s https://api.github.com/repos/GoogleCloudPlatform/terraformer/releases/latest | grep tag_name | cut -d '"' -f 4)/terraformer-${PROVIDER}-darwin-amd64"
 chmod +x terraformer-${PROVIDER}-darwin-amd64
 sudo mv terraformer-${PROVIDER}-darwin-amd64 /usr/local/bin/terraformer


### PR DESCRIPTION
People were copying the line `export PROVIDER={all,google,aws,kubernetes}` as is and getting confused when only the kubernetes provider is available.  This uses `PROVIDER=all` as a sensible default and provides instructions for people who only want one provider.