### PR TITLE
Adjust installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,13 +221,13 @@ Both Terraformer and a Terraform provider plugin need to be installed.
 
 #### Terraformer
 
-From source:
-1.  Run `git clone <terraformer repo> && cd terraformer/`
-2.  Run `go mod download`
-3.  Run `go build -v` for all providers OR build with one provider
-`go run build/main.go {google,aws,azure,kubernetes,etc}`
+**From a package manager**
+- [Homebrew](https://brew.sh/) users can use `brew install terraformer`.
+- [MacPorts](https://www.macports.org/) users can use `sudo port install terraformer`.
+- [Chocolatey](https://chocolatey.org/) users can use `choco install terraformer`.
 
-From releases.  This installs all providers, set `PROVIDER` to one of `google`, `aws` or `kubernetes` if you only need one.
+**From releases**
+This installs all providers, set `PROVIDER` to one of `google`, `aws` or `kubernetes` if you only need one.
 
 * Linux
 ```
@@ -248,10 +248,11 @@ sudo mv terraformer-${PROVIDER}-darwin-amd64 /usr/local/bin/terraformer
 2. Download exe file for required provider from here - https://github.com/GoogleCloudPlatform/terraformer/releases
 3. Add the exe file path to path variable
 
-From a package manager:
-- [Homebrew](https://brew.sh/) users can use `brew install terraformer`.
-- [MacPorts](https://www.macports.org/) users can use `sudo port install terraformer`.
-- [Chocolatey](https://chocolatey.org/) users can use `choco install terraformer`.
+**From source**
+1.  Run `git clone <terraformer repo> && cd terraformer/`
+2.  Run `go mod download`
+3.  Run `go build -v` for all providers OR build with one provider
+`go run build/main.go {google,aws,azure,kubernetes,etc}`
 
 #### Terraform Providers
 


### PR DESCRIPTION
Re-order the three methods, so package managers are suggested first, then "from releases", and finally "from source".