### PR TITLE
honeycombio: recipient resource support

### DIFF
--- a/docs/honeycombio.md
+++ b/docs/honeycombio.md
@@ -22,6 +22,11 @@ export HONEYCOMB_API_KEY=MYAPIKEY
   * `honeycombio_slo`
   * `honeycombio_burn_alert`
   * `honeycombio_derived_column`
+* `recipient`
+  * `honeycombio_email_recipient`
+  * `honeycombio_pagerduty_recipient`
+  * `honeycombio_slack_recipient`
+  * `honeycombio_webhook_recipient`
 
 #### A note about Environment-wide assets
 

--- a/providers/honeycombio/honeycomb_provider.go
+++ b/providers/honeycombio/honeycomb_provider.go
@@ -23,7 +23,7 @@ import (
 )
 
 const honeycombDefaultURL = "https://api.honeycomb.io"
-const honeycombTerraformerProviderVersion = "0.0.2"
+const honeycombTerraformerProviderVersion = "0.0.3"
 
 type HoneycombProvider struct { //nolint
 	terraformutils.Provider
@@ -32,7 +32,7 @@ type HoneycombProvider struct { //nolint
 	datasets []string
 }
 
-func (p HoneycombProvider) GetProviderData(arg ...string) map[string]interface{} {
+func (p HoneycombProvider) GetProviderData(_ ...string) map[string]interface{} {
 	return map[string]interface{}{
 		"provider": map[string]interface{}{
 			"honeycomb": map[string]interface{}{
@@ -131,5 +131,6 @@ func (p *HoneycombProvider) GetSupportedService() map[string]terraformutils.Serv
 		"query_annotation": &QueryAnnotationGenerator{},
 		"slo":              &SLOGenerator{},
 		"burn_alert":       &BurnAlertGenerator{},
+		"recipient":        &RecipientGenerator{},
 	}
 }

--- a/providers/honeycombio/recipient.go
+++ b/providers/honeycombio/recipient.go
@@ -1,0 +1,59 @@
+package honeycombio
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	hnyclient "github.com/honeycombio/terraform-provider-honeycombio/client"
+)
+
+type RecipientGenerator struct {
+	HoneycombService
+}
+
+func (g *RecipientGenerator) InitResources() error {
+	client, err := g.newClient()
+	if err != nil {
+		return fmt.Errorf("unable to initialize Honeycomb client: %v", err)
+	}
+
+	rcpts, err := client.Recipients.List(context.TODO())
+	if err != nil {
+		return fmt.Errorf("unable to list Honeycomb recipients: %v", err)
+	}
+
+	for _, rcpt := range rcpts {
+		var rcptResourceType string
+		var unsupportedRcpt bool
+
+		switch rcpt.Type {
+		case hnyclient.RecipientTypeEmail:
+			rcptResourceType = "honeycombio_email_recipient"
+		case hnyclient.RecipientTypePagerDuty:
+			rcptResourceType = "honeycombio_pagerduty_recipient"
+		case hnyclient.RecipientTypeSlack:
+			rcptResourceType = "honeycombio_slack_recipient"
+		case hnyclient.RecipientTypeWebhook:
+			rcptResourceType = "honeycombio_webhook_recipient"
+		default:
+			unsupportedRcpt = true
+		}
+		if unsupportedRcpt {
+			fmt.Printf("WARNING: unsupported recipient type: %s\n", rcpt.Type)
+			continue
+		}
+
+		g.Resources = append(g.Resources, terraformutils.NewResource(
+			rcpt.ID,
+			rcpt.ID,
+			rcptResourceType,
+			"honeycombio",
+			map[string]string{},
+			[]string{},
+			map[string]interface{}{},
+		))
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds support for the various `honeycombio_recipient_*` resources to the terraformer provider.