### PR TITLE
GCP provider: adding a field mask 

### DIFF
--- a/providers/gcp/gcp_provider.go
+++ b/providers/gcp/gcp_provider.go
@@ -53,7 +53,8 @@ func getRegion(project, regionName string) *compute.Region {
 		log.Println(err)
 		return &compute.Region{}
 	}
-	region, err := computeService.Regions.Get(project, regionName).Do()
+	regionsGetCall := computeService.Regions.Get(project, regionName).Fields("name", "zones")
+	region, err := regionsGetCall.Do()
 	if err != nil {
 		log.Println(err)
 		return &compute.Region{}


### PR DESCRIPTION
adding a field mask to omit any unneeded information from regions.get response and improve latency