### PR TITLE
Add Support for Datadog Powerpacks

### DIFF
--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -129,6 +129,8 @@ Tag filters are order specific. For example, if your monitor has tags (in the or
         * **_NOTE:_** Importing resource requires resource ID's to be passed via [Filter][1] option
 *   `monitor`
     * `datadog_monitor`
+*   `powerpack`
+    * `datadog_powerpack`
 *   `role`
     * `datadog_role`
 *   `security_monitoring_default_rule`

--- a/go.mod
+++ b/go.mod
@@ -353,7 +353,7 @@ require (
 	cloud.google.com/go/cloudtasks v1.13.2
 	cloud.google.com/go/iam v1.2.2
 	cloud.google.com/go/monitoring v1.21.2
-	github.com/DataDog/datadog-api-client-go/v2 v2.11.0
+	github.com/DataDog/datadog-api-client-go/v2 v2.25.0
 	github.com/Myra-Security-GmbH/myrasec-go/v2 v2.28.0
 	github.com/bradleyfalzon/ghinstallation/v2 v2.1.0
 	github.com/manicminer/hamilton v0.44.0

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
-github.com/DataDog/datadog-api-client-go/v2 v2.11.0 h1:7KCEQ3S90PIH1GcqFHcnwDpNfZbqa2BsiF8OYmLb4Jk=
-github.com/DataDog/datadog-api-client-go/v2 v2.11.0/go.mod h1:kntOqXEh1SmjwSDzW/eJkr9kS7EqttvEkelglWtJRbg=
+github.com/DataDog/datadog-api-client-go/v2 v2.25.0 h1:9Zq42D6M3U///VDxjx2SS1g+EW55WhZYZFHtzM+cO4k=
+github.com/DataDog/datadog-api-client-go/v2 v2.25.0/go.mod h1:QKOu6vscsh87fMY1lHfLEmNSunyXImj8BUaUWJXOehc=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0 h1:3c8yed4lgqTt+oTQ+JNMDo+F4xprBf+O/il4ZC0nRLw=

--- a/providers/datadog/datadog_provider.go
+++ b/providers/datadog/datadog_provider.go
@@ -171,6 +171,7 @@ func (p *DatadogProvider) GetSupportedService() map[string]terraformutils.Servic
 		"logs_integration_pipeline":            &LogsIntegrationPipelineGenerator{},
 		"logs_metric":                          &LogsMetricGenerator{},
 		"logs_pipeline_order":                  &LogsPipelineOrderGenerator{},
+		"powerpack":                            &PowerpackGenerator{},
 		"integration_aws":                      &IntegrationAWSGenerator{},
 		"integration_aws_lambda_arn":           &IntegrationAWSLambdaARNGenerator{},
 		"integration_aws_log_collection":       &IntegrationAWSLogCollectionGenerator{},

--- a/providers/datadog/powerpack.go
+++ b/providers/datadog/powerpack.go
@@ -66,7 +66,6 @@ func (g *PowerpackGenerator) InitResources() error {
 	for _, filter := range g.Filter {
 		if filter.FieldPath == "id" && filter.IsApplicable("powerpack") {
 			for _, value := range filter.AcceptableValues {
-				// fixme: how to get a powerpack id? dashboard json?
 				powerpack, _, err := api.GetPowerpack(auth, value)
 				if err != nil {
 					return err

--- a/providers/datadog/powerpack.go
+++ b/providers/datadog/powerpack.go
@@ -81,10 +81,21 @@ func (g *PowerpackGenerator) InitResources() error {
 		return nil
 	}
 
-	powerpacks, _, err := api.ListPowerpacks(auth)
-	if err != nil {
-		return err
+	var powerpacks []datadogV2.PowerpackData
+	optionalParameters := &datadogV2.ListPowerpacksOptionalParameters{}
+	paginationChan, _ := api.ListPowerpacksWithPagination(auth,
+		*optionalParameters.WithPageLimit(1000))
+	for {
+		pageResult, more := <-paginationChan
+		if !more {
+			break
+		}
+		if pageResult.Error != nil {
+			return pageResult.Error
+		}
+		powerpacks = append(powerpacks, pageResult.Item)
 	}
-	g.Resources = g.createResources(powerpacks.GetData())
+
+	g.Resources = g.createResources(powerpacks)
 	return nil
 }

--- a/providers/datadog/powerpack.go
+++ b/providers/datadog/powerpack.go
@@ -1,0 +1,91 @@
+// Copyright 2018 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datadog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+)
+
+var (
+	// PowerpackAllowEmptyValues ...
+	PowerpackAllowEmptyValues = []string{}
+)
+
+// PowerpackGenerator ...
+type PowerpackGenerator struct {
+	DatadogService
+}
+
+func (g *PowerpackGenerator) createResources(powerpacks []datadogV2.PowerpackData) []terraformutils.Resource {
+	resources := []terraformutils.Resource{}
+	for _, powerpack := range powerpacks {
+		resourceName := powerpack.GetId()
+		resources = append(resources, g.createResource(resourceName))
+	}
+
+	return resources
+}
+
+func (g *PowerpackGenerator) createResource(powerpackName string) terraformutils.Resource {
+	return terraformutils.NewSimpleResource(
+		powerpackName,
+		fmt.Sprintf("powerpack_%s", powerpackName),
+		"datadog_powerpack",
+		"datadog",
+		PowerpackAllowEmptyValues,
+	)
+}
+
+// InitResources Generate TerraformResources from Datadog API,
+// from each powerpack create 1 TerraformResource.
+// Need Powerpack Name as ID for terraform resource
+func (g *PowerpackGenerator) InitResources() error {
+	datadogClient := g.Args["datadogClient"].(*datadog.APIClient)
+	auth := g.Args["auth"].(context.Context)
+	api := datadogV2.NewPowerpackApi(datadogClient)
+
+	resources := []terraformutils.Resource{}
+	for _, filter := range g.Filter {
+		if filter.FieldPath == "id" && filter.IsApplicable("powerpack") {
+			for _, value := range filter.AcceptableValues {
+				// fixme: how to get a powerpack id? dashboard json?
+				powerpack, _, err := api.GetPowerpack(auth, value)
+				if err != nil {
+					return err
+				}
+
+				resources = append(resources, g.createResource(powerpack.Data.GetId()))
+			}
+		}
+	}
+
+	if len(resources) > 0 {
+		g.Resources = resources
+		return nil
+	}
+
+	powerpacks, _, err := api.ListPowerpacks(auth)
+	if err != nil {
+		return err
+	}
+	g.Resources = g.createResources(powerpacks.GetData())
+	return nil
+}


### PR DESCRIPTION
Adds support for generating `datadog_powerpack` resources via. `powerpack`. `datadog_powerpack` is documented [here](https://registry.terraform.io/providers/datadog/datadog/latest/docs/resources/powerpack). 

I've had the best luck either filtering for a specific set of powerpack ids (visible in dashboard json) like the following...

```
terraformer import datadog \
  --resources=powerpack \
  --filter powerpack="<id1>:...:<idN>"
```

... or by filtering down using the "Search Categories". Example, if I configure search category "process", I can filter down to powerpacks  with that search category with this filter...

```
terraformer import datadog --resources=powerpack --filter="Name=tags;Value='tag:<search category>'"
```

I chose to use ListPowerpacksWithPagination, as I noticed that ListPowerpacks appears to set a default to 25 records. I don't see where this is configured. ListPowerpacksWithPagination seemed cleaner to use to me, as it manages page offsets.

This feature was requested in https://github.com/GoogleCloudPlatform/terraformer/issues/1841.