### PR TITLE
Docs: Show Cloudflare's provider status as broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A CLI tool that generates `tf`/`json` and `tfstate` files based on existing infr
         * [OctopusDeploy](/docs/octopus.md)
         * [RabbitMQ](/docs/rabbitmq.md)
     * Network
-        * [Cloudflare](/docs/cloudflare.md)
+        * [Cloudflare](/docs/cloudflare.md) (broken, see #1761)
         * [Myrasec](/docs/myrasec.md)
         * [PAN-OS](/docs/panos.md)
     * VCS

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ https://www.terraform.io/docs/configuration/providers.html
 ## Contributing
 
 If you have improvements or fixes, we would love to have your contributions.
-Please read CONTRIBUTING.md for more information on the process we would like
+Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for more information on the process we would like
 contributors to follow.
 
 ## Developing


### PR DESCRIPTION
As shown in #1761, CF provider is broken. People approaching the tool for the first time might think CF will work, since it's in the supported providers list, only to discover later it's not the case. This is not faithful with current status.
To prevent others to stumble with this in the future, at least let's make it visible.