### PR TITLE
Correct application ID format in appendResource

### DIFF
--- a/providers/azuread/application.go
+++ b/providers/azuread/application.go
@@ -38,7 +38,9 @@ func (az *ApplicationServiceGenerator) listResources() ([]msgraph.Application, e
 
 func (az *ApplicationServiceGenerator) appendResource(resource *msgraph.Application) {
 	id := resource.ID
-	az.appendSimpleResource(*id, *resource.DisplayName, "azuread_application")
+	// Prepend "/applications/" to the application ID
+	fullID := "/applications/" + *id
+	az.appendSimpleResource(fullID, *resource.DisplayName, "azuread_application")
 }
 
 func (az *ApplicationServiceGenerator) InitResources() error {


### PR DESCRIPTION
fixes issue #1902 

fix(azuread): Correct application ID format in appendResource

Prepend "/applications/" to the application ID in the appendResource function to match the expected format of "/applications/{applicationId}". This resolves the parsing error during resource import for Azure AD applications.
