### PR TITLE
Honor AWS_PROFILE environment variable

### DIFF
--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -201,13 +201,13 @@ func (p *AWSProvider) Init(args []string) error {
 		}
 	}
 
-	if p.profile != "default" && p.profile != "" {
+	if p.profile != "" && p.profile != "default" {
+		envVar := "AWS_PROFILE"
 		if enableSharedConfig {
-			err = os.Setenv("AWS_DEFAULT_PROFILE", p.profile)
-		} else {
-			err = os.Setenv("AWS_PROFILE", p.profile)
+			envVar = "AWS_DEFAULT_PROFILE"
 		}
-		if err != nil {
+
+		if err := os.Setenv(envVar, p.profile); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This fixes issue number 1767 where terraformer
doesn't respect the AWS_PROFILE environment
variable when it is set.

[1]:https://github.com/GoogleCloudPlatform/terraformer/issues/1767