### PR TITLE
nits: incorrect condition stmt for options.Excludes

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -124,7 +124,7 @@ func initOptionsAndWrapper(provider terraformutils.ProviderGenerator, options Im
 		options.Resources = providerServices(provider)
 	}
 
-	if options.Excludes != nil {
+	if len(options.Excludes) > 0 {
 		localSlice := []string{}
 		for _, r := range options.Resources {
 			remove := false


### PR DESCRIPTION
In `cmd/import.go`, there is an implementation that checks whether `Excludes` options is specified.
The default value for `options.Excludes` is `[]string{}` as you can see here:
https://github.com/GoogleCloudPlatform/terraformer/blob/a5b4b69b1cd36942ed85c1c6f8ba81e16b8b8a2b/cmd/import.go#L395-L410

However, the condition statement for checking `options.Excludes` is `if options.Excludes != nil`.
https://github.com/GoogleCloudPlatform/terraformer/blob/a5b4b69b1cd36942ed85c1c6f8ba81e16b8b8a2b/cmd/import.go#L127
As default value for `options.Excludes` is `[]string{}`, this always results true.

This should be fixed as `len(options.Excludes) > 0`
This does not cause panic when `option.Excludes` is false as you can see [here](https://go.dev/play/p/LgJNXCEBBHr)

You can see similar implementation here:
https://github.com/GoogleCloudPlatform/terraformer/blob/ceb25e24a3d93e72c6c60af1ff164a3606f89c9c/cmd/provider_cmd_aws.go#L53

