### PR TITLE
Fix: Add aws direct connect resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/aliyun/alibaba-cloud-sdk-go v1.61.1247
 	github.com/aliyun/aliyun-tablestore-go-sdk v4.1.2+incompatible
 	github.com/apache/openwhisk-client-go v0.0.0-20210106144548-17d556327cd3
-	github.com/aws/aws-sdk-go-v2 v1.24.0
+	github.com/aws/aws-sdk-go-v2 v1.32.6
 	github.com/aws/aws-sdk-go-v2/config v1.26.1
 	github.com/aws/aws-sdk-go-v2/credentials v1.16.12
 	github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.26.5
@@ -216,8 +216,8 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.5.4 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.10 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.9 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.9 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.25 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.25 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.2.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.2.9 // indirect
@@ -226,7 +226,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.16.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.18.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.21.5 // indirect
-	github.com/aws/smithy-go v1.19.0
+	github.com/aws/smithy-go v1.22.1
 	github.com/beevik/etree v1.1.0 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
@@ -393,6 +393,7 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2/service/directconnect v1.30.1
 	github.com/gofrs/uuid/v3 v3.1.2
 	github.com/ionos-cloud/sdk-go-cert-manager v1.0.0
 	github.com/ionos-cloud/sdk-go-container-registry v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -372,6 +372,8 @@ github.com/aws/aws-sdk-go v1.44.122 h1:p6mw01WBaNpbdP2xrisz5tIkcNwzj/HysobNoaAHj
 github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go-v2 v1.24.0 h1:890+mqQ+hTpNuw0gGP6/4akolQkSToDJgHfQE7AwGuk=
 github.com/aws/aws-sdk-go-v2 v1.24.0/go.mod h1:LNh45Br1YAkEKaAqvmE1m8FUx6a5b/V0oAKV7of29b4=
+github.com/aws/aws-sdk-go-v2 v1.32.6 h1:7BokKRgRPuGmKkFMhEg/jSul+tB9VvXhcViILtfG8b4=
+github.com/aws/aws-sdk-go-v2 v1.32.6/go.mod h1:P5WJBrYqqbWVaOxgH0X/FYYD47/nooaPOZPlQdmiN2U=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.5.4 h1:OCs21ST2LrepDfD3lwlQiOqIGp6JiEUqG84GzTDoyJs=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.5.4/go.mod h1:usURWEKSNNAcAZuzRn/9ZYPT8aZQkR7xcCtunK/LkJo=
 github.com/aws/aws-sdk-go-v2/config v1.26.1 h1:z6DqMxclFGL3Zfo+4Q0rLnAZ6yVkzCRxhRMsiRQnD1o=
@@ -382,8 +384,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.10 h1:w98BT5w+ao1/r5sUuiH6Jk
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.10/go.mod h1:K2WGI7vUvkIv1HoNbfBA1bvIZ+9kL3YVmWxeKuLQsiw=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.9 h1:v+HbZaCGmOwnTTVS86Fleq0vPzOd7tnJGbFhP0stNLs=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.9/go.mod h1:Xjqy+Nyj7VDLBtCMkQYOw1QYfAEZCVLrfI0ezve8wd4=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.25 h1:s/fF4+yDQDoElYhfIVvSNyeCydfbuTKzhxSXDXCPasU=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.25/go.mod h1:IgPfDv5jqFIzQSNbUEMoitNooSMXjRSDkhXv8jiROvU=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.9 h1:N94sVhRACtXyVcjXxrwK1SKFIJrA9pOJ5yu2eSHnmls=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.9/go.mod h1:hqamLz7g1/4EJP+GH5NBhcUMLjW+gKLQabgyz6/7WAU=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.25 h1:ZntTCl5EsYnhN/IygQEUugpdwbhdkom9uHcbCftiGgA=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.25/go.mod h1:DBdPrgeocww+CSl1C8cEV8PN1mHMBhuCDLpXezyvWkE=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.7.2 h1:GrSw8s0Gs/5zZ0SX+gX4zQjRnRsMJDJ2sLur1gRBhEM=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.7.2/go.mod h1:6fQQgfuGmw8Al/3M2IgIllycxV7ZW7WCdVSqfBeUiCY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.2.9 h1:ugD6qzjYtB7zM5PN/ZIeaAIyefPaD82G8+SJopgvUpw=
@@ -436,6 +442,8 @@ github.com/aws/aws-sdk-go-v2/service/datapipeline v1.19.5 h1:zkIKbco/gM4fmbU90aj
 github.com/aws/aws-sdk-go-v2/service/datapipeline v1.19.5/go.mod h1:+G+TF84SIgMdGDjZKKYPpx6LwXSN4QcywQGa8e2vJ1U=
 github.com/aws/aws-sdk-go-v2/service/devicefarm v1.20.5 h1:Qb3OR2IpH29EkESNmUtsyuj6DDfdM4X3Qnv7UmW4xOA=
 github.com/aws/aws-sdk-go-v2/service/devicefarm v1.20.5/go.mod h1:O66Kiw8O4IS2V4GQOv8CUDDsAWiRoENYyQXWSXBuvTw=
+github.com/aws/aws-sdk-go-v2/service/directconnect v1.30.1 h1:U2VtqwmOzP7sZYWmrnapl3j3KLxIntWyK0RU3uGBIPk=
+github.com/aws/aws-sdk-go-v2/service/directconnect v1.30.1/go.mod h1:IVHMPfXzPHdq2JuZmnyreo2Dhhlu84Vel/tochYKgh8=
 github.com/aws/aws-sdk-go-v2/service/docdb v1.29.5 h1:txsajy47TIyoL7/BQt0VwqmzLPIsfAT/RWI9iD4q5vU=
 github.com/aws/aws-sdk-go-v2/service/docdb v1.29.5/go.mod h1:8d1RpdlgxFU6VO2aWru1ckR0Vsm4EgqCZgOamw5OHpw=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.26.6 h1:kSdpnPOZL9NG5QHoKL5rTsdY+J+77hr+vqVMsPeyNe0=
@@ -554,6 +562,8 @@ github.com/aws/aws-sdk-go-v2/service/xray v1.23.5 h1:uCqKSGx5Esj9ZW6/zZ7tslkM65a
 github.com/aws/aws-sdk-go-v2/service/xray v1.23.5/go.mod h1:VmWKTNu6V1qRG+skNKkYt7VOFohYdtOp7B2OSvpBZac=
 github.com/aws/smithy-go v1.19.0 h1:KWFKQV80DpP3vJrrA9sVAHQ5gc2z8i4EzrLhLlWXcBM=
 github.com/aws/smithy-go v1.19.0/go.mod h1:NukqUGpCZIILqqiV0NIjeFh24kd/FAa4beRb6nbIUPE=
+github.com/aws/smithy-go v1.22.1 h1:/HPHZQ0g7f4eUeK6HKglFz8uwVfZKgoI25rb/J+dnro=
+github.com/aws/smithy-go v1.22.1/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=

--- a/providers/aws/dx.go
+++ b/providers/aws/dx.go
@@ -1,0 +1,136 @@
+// Copyright 2020 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"context"
+	"log"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+
+	"github.com/aws/aws-sdk-go-v2/service/directconnect"
+)
+
+var dxAllowEmptyValues = []string{"tags."}
+
+type DirectConnectGenerator struct {
+	AWSService
+}
+
+func (g *DirectConnectGenerator) getDirectConnectGateways(svc *directconnect.Client) error {
+	input := &directconnect.DescribeDirectConnectGatewaysInput{}
+	for {
+				  // Fetch a page of results
+		output, err := svc.DescribeDirectConnectGateways(context.TODO(), input)
+		if     err  != nil {
+			return err
+		}
+
+				  // Process each DirectConnect Gateway
+		for _, dx := range output.DirectConnectGateways {
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				*dx.DirectConnectGatewayId,  // Dereference the pointer
+				*dx.DirectConnectGatewayId,
+				"aws_dx_gateway",
+				"aws",
+				dxAllowEmptyValues,
+			))
+		}
+
+				  // Check if there are more pages
+		if output.NextToken == nil {
+			break
+		}
+
+				  // Update the input token for the next page
+		input.NextToken = output.NextToken
+	}
+	return nil
+}
+
+func (g *DirectConnectGenerator) getDirectConnectConnections(svc *directconnect.Client) error {
+	input := &directconnect.DescribeConnectionsInput{}
+		output, err := svc.DescribeConnections(context.TODO(), input)
+		if     err  != nil {
+			return err
+		}
+
+		for _, dx := range output.Connections {
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				*dx.ConnectionId,  // Dereference the pointer
+				*dx.ConnectionName,
+				"aws_dx_gateway",
+				"aws",
+				dxAllowEmptyValues,
+			))
+		}
+	return nil
+}
+
+func (g *DirectConnectGenerator) getDirectConnectVritualInterfaces(svc *directconnect.Client) error {
+	input := &directconnect.DescribeVirtualInterfacesInput{}
+		output, err := svc.DescribeVirtualInterfaces(context.TODO(), input)
+		if     err  != nil {
+			return err
+		}
+
+		for _, vif := range output.VirtualInterfaces {
+			var resourceType string
+
+			if *vif.VirtualInterfaceType == "private" {
+			  resourceType                       = "aws_dx_private_virtual_interface"
+			} else if *vif.VirtualInterfaceType == "public" {
+				resourceType = "aws_dx_public_virtual_interface"
+			} else {
+				log.Printf("Unknown Virtual Interface Type: %s for ID: %s", *vif.VirtualInterfaceType, *vif.VirtualInterfaceId)
+				continue
+			}
+
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				*vif.VirtualInterfaceId,
+				*vif.VirtualInterfaceName,
+				resourceType,
+				"aws",
+				dxAllowEmptyValues,
+			))
+		}
+		
+	return nil
+
+}
+
+func (g *DirectConnectGenerator) InitResources() error {
+	config, err := g.generateConfig()
+	if     err  != nil {
+		return err
+	}
+	   svc := directconnect.NewFromConfig(config)
+	if err := g.getDirectConnectGateways(svc); err != nil {
+		log.Println(err)
+		return err
+	}
+
+	   err  = g.getDirectConnectVritualInterfaces(svc)
+	if err != nil {
+		log.Println(err)
+	}
+
+	err  = g.getDirectConnectConnections(svc)
+	if err != nil {
+		log.Println(err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This pull request adds support for AWS Direct Connect resources in Terraformer, The following resources have been implemented:
	1.	aws_dx_gateway: Direct Connect Gateways.
	2.	aws_dx_private_virtual_interface: Private Virtual Interfaces.
	3.	aws_dx_public_virtual_interface: Public Virtual Interfaces.
	
	
Fixes #1959 