### PR TITLE
fix: updated deprecated alicloud_dns resources 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/terraformer
 
-go 1.22
+go 1.22.0
 
 require (
 	cloud.google.com/go v0.110.2 // indirect

--- a/providers/alicloud/dns.go
+++ b/providers/alicloud/dns.go
@@ -30,7 +30,7 @@ func resourceFromDomain(domain alidns.DomainInDescribeDomains) terraformutils.Re
 	return terraformutils.NewResource(
 		domain.DomainName,                      // id
 		domain.DomainId+"__"+domain.DomainName, // nolint
-		"alicloud_dns",
+		"alicloud_alidns_domain",
 		"alicloud",
 		map[string]string{},
 		[]string{},
@@ -40,9 +40,9 @@ func resourceFromDomain(domain alidns.DomainInDescribeDomains) terraformutils.Re
 
 func resourceFromDomainRecord(record alidns.Record) terraformutils.Resource {
 	return terraformutils.NewResource(
-		record.RecordId, // nolint
+		record.RecordId,                        // id
 		record.RecordId+"__"+record.DomainName, // nolint
-		"alicloud_dns_record",
+		"alicloud_alidns_record",
 		"alicloud",
 		map[string]string{},
 		[]string{},


### PR DESCRIPTION
Using terraform alidns resource instead of dns resource because of deprecation of dns resource in terraform provider