### PR TITLE
fix: updated deprecated resource names in azure database provider

### DIFF
--- a/providers/azure/database.go
+++ b/providers/azure/database.go
@@ -610,7 +610,7 @@ func (g *DatabasesGenerator) createSQLServerResources(servers []sql.Server) ([]t
 		resources = append(resources, terraformutils.NewResource(
 			*server.ID,
 			*server.Name,
-			"azurerm_sql_server",
+			"azurerm_mssql_server",
 			g.ProviderName,
 			map[string]string{},
 			[]string{},
@@ -646,7 +646,7 @@ func (g *DatabasesGenerator) createSQLDatabaseResources(servers []sql.Server) ([
 			resources = append(resources, terraformutils.NewSimpleResource(
 				*database.ID,
 				*database.Name+"-"+*server.Name,
-				"azurerm_sql_database",
+				"azurerm_mssql_database",
 				g.ProviderName,
 				[]string{}))
 		}
@@ -678,7 +678,7 @@ func (g *DatabasesGenerator) createSQLFirewallRuleResources(servers []sql.Server
 			resources = append(resources, terraformutils.NewSimpleResource(
 				*rule.ID,
 				*rule.Name,
-				"azurerm_sql_firewall_rule",
+				"azurerm_mssql_firewall_rule",
 				g.ProviderName,
 				[]string{}))
 		}


### PR DESCRIPTION
**Description**
This PR addresses the use of deprecated Azure resource names in the Azure database provider. The following updates have been made to align with the current resource naming standards:

Updated azurerm_sql_server to azurerm_mssql_server
Updated azurerm_sql_database to azurerm_mssql_database
Updated azurerm_sql_firewall_rule to azurerm_mssql_firewall_rule

**Motivation**
The existing resource names (azurerm_sql_) are deprecated in favor of azurerm_mssql_. This fix ensures compatibility with the latest Terraform provider updates and avoids the usage of deprecated resource names. This fix addresses the following problems: 

- panic: unknown resource type azurerm_sql_server
- panic: unknown resource type azurerm_sql_database
- panic: unknown resource type azurerm_sql_firewall_rule

**Changes Made**
Refactored resource names in createSQLServerResources, createSQLDatabaseResources, and createSQLFirewallRuleResources functions.