### PR TITLE
Fix: Incorrect Resource Type for Direct Connect Connections

### DIFF
--- a/providers/auth0/auth0_service.go
+++ b/providers/auth0/auth0_service.go
@@ -33,7 +33,7 @@ func (s *Auth0Service) generateClient() *management.Management {
 		management.WithDebug(false),
 	)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatalf("%v", err)
 	}
 
 	return apiClient

--- a/providers/aws/aws_provider.go
+++ b/providers/aws/aws_provider.go
@@ -263,6 +263,7 @@ func (p *AWSProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"datapipeline":      &AwsFacade{service: &DataPipelineGenerator{}},
 		"devicefarm":        &AwsFacade{service: &DeviceFarmGenerator{}},
 		"docdb":             &AwsFacade{service: &DocDBGenerator{}},
+		"dx":				 &AwsFacade{service: &DirectConnectGenerator{}},
 		"dynamodb":          &AwsFacade{service: &DynamoDbGenerator{}},
 		"ebs":               &AwsFacade{service: &EbsGenerator{}},
 		"ec2_instance":      &AwsFacade{service: &Ec2Generator{}},


### PR DESCRIPTION
This PR fixes a bug where Direct Connect Connections (dxcon-*) were being incorrectly categorized as Direct Connect Gateways (aws_dx_gateway) during resource generation. This mismatch caused downstream errors in Terraform due to invalid resource ID formats.

Also adds support for aws_dx_connection as it was missing in the command list.