### PR TITLE
Fix: no-sort on lists

### DIFF
--- a/terraformutils/hcl.go
+++ b/terraformutils/hcl.go
@@ -150,7 +150,9 @@ func (v *astSanitizer) visitObjectItem(o *ast.ObjectItem) {
 			}
 		}
 	case *ast.ListType:
-		sortHclTree(t.List)
+		if v.sort {
+			sortHclTree(t.List)
+		}
 	default:
 	}
 


### PR DESCRIPTION
Currently, the no-sort flag doesn't apply to lists. We want the no-sort flag to apply to lists as a sorted lists may trigger changes.