### PR TITLE
Fix ibm instance groups missing mutex

### DIFF
--- a/docs/ibmcloud.md
+++ b/docs/ibmcloud.md
@@ -60,6 +60,34 @@ List of supported IBM Cloud resources:
     * `ibm_container_vpc_cluster`
     * `ibm_container_vpc_worker_pool`
 *   `ibm_continuous_delivery`
+* `ibm_cd_toolchain`
+    * `ibm_cd_tekton_pipeline`
+    * `ibm_cd_tekton_pipeline_definition`
+    * `ibm_cd_tekton_pipeline_property`
+    * `ibm_cd_tekton_pipeline_trigger`
+    * `ibm_cd_tekton_pipeline_trigger_property`
+    * `ibm_cd_toolchain_tool_appconfig`
+    * `ibm_cd_toolchain_tool_artifactory`
+    * `ibm_cd_toolchain_tool_bitbucketgit`
+    * `ibm_cd_toolchain_tool_custom`
+    * `ibm_cd_toolchain_tool_devopsinsights`
+    * `ibm_cd_toolchain_tool_eventnotifications`
+    * `ibm_cd_toolchain_tool_githubconsolidated`
+    * `ibm_cd_toolchain_tool_gitlab`
+    * `ibm_cd_toolchain_tool_hashicorpvault`
+    * `ibm_cd_toolchain_tool_hostedgit`
+    * `ibm_cd_toolchain_tool_jenkins`
+    * `ibm_cd_toolchain_tool_jira`
+    * `ibm_cd_toolchain_tool_keyprotect`
+    * `ibm_cd_toolchain_tool_nexus`
+    * `ibm_cd_toolchain_tool_pagerduty`
+    * `ibm_cd_toolchain_tool_pipeline`
+    * `ibm_cd_toolchain_tool_privateworker`
+    * `ibm_cd_toolchain_tool_saucelabs`
+    * `ibm_cd_toolchain_tool_secretsmanager`
+    * `ibm_cd_toolchain_tool_securitycompliance`
+    * `ibm_cd_toolchain_tool_slack`
+    * `ibm_cd_toolchain_tool_sonarqube`
 *   `ibm_cos`
     * `ibm_cos_bucket`
     * `ibm_resource_instance`

--- a/go.mod
+++ b/go.mod
@@ -242,8 +242,8 @@ require (
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
-	github.com/go-openapi/errors v0.21.0 // indirect
-	github.com/go-openapi/strfmt v0.22.1 // indirect
+	github.com/go-openapi/errors v0.22.0 // indirect
+	github.com/go-openapi/strfmt v0.23.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48 // indirect
@@ -371,6 +371,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.48.1 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.1 // indirect
+	github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.2 // indirect
 	github.com/Myra-Security-GmbH/signature v1.0.0 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect

--- a/go.mod
+++ b/go.mod
@@ -371,7 +371,6 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.48.1 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.1 // indirect
-	github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.2 // indirect
 	github.com/Myra-Security-GmbH/signature v1.0.0 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
@@ -425,6 +424,7 @@ require (
 )
 
 require (
+	github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.2
 	github.com/aws/aws-sdk-go v1.44.122
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.30.1
 	github.com/gofrs/uuid/v3 v3.1.2

--- a/go.sum
+++ b/go.sum
@@ -278,6 +278,8 @@ github.com/IBM-Cloud/bluemix-go v0.0.0-20220624043500-d538cb4fd9be h1:PTW3J9z39t
 github.com/IBM-Cloud/bluemix-go v0.0.0-20220624043500-d538cb4fd9be/go.mod h1:tfNN3lCKuA2+SQvndt0+5CjPr2qn/wdNLjrue1GrOhY=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62 h1:MOkcr6qQGk4tY542ZJ1DggVh2WUP72EEyLB79llFVH8=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20210705152127-41ca00fc9a62/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
+github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.2 h1:yCJJnSLNYkpF7v9n0tw8CpQbSy43E/NbFOopRf1PgoM=
+github.com/IBM/continuous-delivery-go-sdk/v2 v2.0.2/go.mod h1:2MajFr6C5H2jyj7qtjBxAPnZAjbPiK4CAJNk3fKNnPo=
 github.com/IBM/go-sdk-core v1.1.0 h1:pV73lZqr9r1xKb3h08c1uNG3AphwoV5KzUzhS+pfEqY=
 github.com/IBM/go-sdk-core v1.1.0/go.mod h1:2pcx9YWsIsZ3I7kH+1amiAkXvLTZtAq9kbxsfXilSoY=
 github.com/IBM/go-sdk-core/v3 v3.3.1 h1:DoXjP1+Wm8Yd4XJsvBMRcYLvQwSLFnzKlMjSrg3Rzpw=
@@ -758,6 +760,8 @@ github.com/go-openapi/errors v0.19.2/go.mod h1:qX0BLWsyaKfvhluLejVpVNwNRdXZhEbTA
 github.com/go-openapi/errors v0.19.8/go.mod h1:cM//ZKUKyO06HSwqAelJ5NsEMMcpa6VpXe8DOa1Mi1M=
 github.com/go-openapi/errors v0.21.0 h1:FhChC/duCnfoLj1gZ0BgaBmzhJC2SL/sJr8a2vAobSY=
 github.com/go-openapi/errors v0.21.0/go.mod h1:jxNTMUxRCKj65yb/okJGEtahVd7uvWnuWfj53bse4ho=
+github.com/go-openapi/errors v0.22.0 h1:c4xY/OLxUBSTiepAg3j/MHuAv5mJhnf53LLMWFB+u/w=
+github.com/go-openapi/errors v0.22.0/go.mod h1:J3DmZScxCDufmIMsdOuDHxJbdOGC0xtUynjIx092vXE=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
@@ -771,6 +775,8 @@ github.com/go-openapi/strfmt v0.20.2/go.mod h1:43urheQI9dNtE5lTZQfuFJvjYJKPrxicA
 github.com/go-openapi/strfmt v0.21.2/go.mod h1:I/XVKeLc5+MM5oPNN7P6urMOpuLXEcNrCX/rPGuWb0k=
 github.com/go-openapi/strfmt v0.22.1 h1:5Ky8cybT4576C6Ffc+8gYji/wRXCo6Ozm8RaWjPI6jc=
 github.com/go-openapi/strfmt v0.22.1/go.mod h1:OfVoytIXJasDkkGvkb1Cceb3BPyMOwk1FgmyyEw7NYg=
+github.com/go-openapi/strfmt v0.23.0 h1:nlUS6BCqcnAk0pyhi9Y+kdDVZdZMHfEKQiS4HaMgO/c=
+github.com/go-openapi/strfmt v0.23.0/go.mod h1:NrtIpfKtWIygRkKVsxh7XQMDQW5HKQl6S5ik2elW+K4=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.14 h1:gm3vOOXfiuw5i9p5N9xJvfjvuofpyvLA9Wr6QfK5Fng=
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=

--- a/go.sum
+++ b/go.sum
@@ -758,8 +758,6 @@ github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-openapi/errors v0.19.2/go.mod h1:qX0BLWsyaKfvhluLejVpVNwNRdXZhEbTA4kxxpKBC94=
 github.com/go-openapi/errors v0.19.8/go.mod h1:cM//ZKUKyO06HSwqAelJ5NsEMMcpa6VpXe8DOa1Mi1M=
-github.com/go-openapi/errors v0.21.0 h1:FhChC/duCnfoLj1gZ0BgaBmzhJC2SL/sJr8a2vAobSY=
-github.com/go-openapi/errors v0.21.0/go.mod h1:jxNTMUxRCKj65yb/okJGEtahVd7uvWnuWfj53bse4ho=
 github.com/go-openapi/errors v0.22.0 h1:c4xY/OLxUBSTiepAg3j/MHuAv5mJhnf53LLMWFB+u/w=
 github.com/go-openapi/errors v0.22.0/go.mod h1:J3DmZScxCDufmIMsdOuDHxJbdOGC0xtUynjIx092vXE=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
@@ -773,8 +771,6 @@ github.com/go-openapi/strfmt v0.19.10/go.mod h1:qBBipho+3EoIqn6YDI+4RnQEtj6jT/Id
 github.com/go-openapi/strfmt v0.20.1/go.mod h1:43urheQI9dNtE5lTZQfuFJvjYJKPrxicATpEfZwHUNk=
 github.com/go-openapi/strfmt v0.20.2/go.mod h1:43urheQI9dNtE5lTZQfuFJvjYJKPrxicATpEfZwHUNk=
 github.com/go-openapi/strfmt v0.21.2/go.mod h1:I/XVKeLc5+MM5oPNN7P6urMOpuLXEcNrCX/rPGuWb0k=
-github.com/go-openapi/strfmt v0.22.1 h1:5Ky8cybT4576C6Ffc+8gYji/wRXCo6Ozm8RaWjPI6jc=
-github.com/go-openapi/strfmt v0.22.1/go.mod h1:OfVoytIXJasDkkGvkb1Cceb3BPyMOwk1FgmyyEw7NYg=
 github.com/go-openapi/strfmt v0.23.0 h1:nlUS6BCqcnAk0pyhi9Y+kdDVZdZMHfEKQiS4HaMgO/c=
 github.com/go-openapi/strfmt v0.23.0/go.mod h1:NrtIpfKtWIygRkKVsxh7XQMDQW5HKQl6S5ik2elW+K4=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=

--- a/providers/ibm/ibm_cd_toolchain.go
+++ b/providers/ibm/ibm_cd_toolchain.go
@@ -24,8 +24,6 @@ type ToolchainGenerator struct {
 	IBMService
 }
 
-var resourceMutex sync.RWMutex // Used for g.Resources
-
 var workerIDMutex sync.RWMutex // Used in PostConvertHook
 var repoMutex sync.RWMutex     // Used in PostConvertHook
 var toolMutex sync.RWMutex     // Used in PostConvertHook

--- a/providers/ibm/ibm_cd_toolchain.go
+++ b/providers/ibm/ibm_cd_toolchain.go
@@ -1,0 +1,711 @@
+package ibm
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	"github.com/IBM-Cloud/bluemix-go"
+	"github.com/IBM-Cloud/bluemix-go/api/resource/resourcev1/catalog"
+	"github.com/IBM-Cloud/bluemix-go/api/resource/resourcev2/controllerv2"
+	"github.com/IBM-Cloud/bluemix-go/session"
+	"github.com/IBM/continuous-delivery-go-sdk/v2/cdtektonpipelinev2"
+	"github.com/IBM/continuous-delivery-go-sdk/v2/cdtoolchainv2"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/platform-services-go-sdk/iampolicymanagementv1"
+)
+
+type ToolchainGenerator struct {
+	IBMService
+}
+
+var resourceMutex sync.RWMutex // Used for g.Resources
+
+var workerIdMutex sync.RWMutex // Used in PostConvertHook
+var repoMutex sync.RWMutex     // Used in PostConvertHook
+var toolMutex sync.RWMutex     // Used in PostConvertHook
+
+func (g ToolchainGenerator) loadToolchain(tcID string, tcName string) terraformutils.Resource {
+	resource := terraformutils.NewSimpleResource(
+		tcID,
+		tcName,
+		"ibm_cd_toolchain",
+		"ibm",
+		[]string{},
+	)
+	return resource
+}
+
+func (g ToolchainGenerator) loadTool(resourceType string, tID string, tName string, tcIDref string) terraformutils.Resource {
+	resource := terraformutils.NewResource(
+		tID,
+		tName,
+		resourceType,
+		"ibm",
+		map[string]string{},
+		[]string{},
+		map[string]interface{}{
+			"toolchain_id": tcIDref,
+		})
+	return resource
+}
+
+// Adds S2S authorization required by some integrations
+func (g ToolchainGenerator) loadAuthPolicies(policyID string, tcIDref string) terraformutils.Resource {
+	resource := terraformutils.NewResource(
+		policyID,
+		normalizeResourceName("iam_authorization_policy", true),
+		"ibm_iam_authorization_policy",
+		"ibm",
+		map[string]string{},
+		[]string{},
+		map[string]interface{}{
+			"source_resource_instance_id": tcIDref,
+		})
+
+	// Conflict parameters
+	resource.IgnoreKeys = append(resource.IgnoreKeys,
+		"^subject_attributes$",
+		"^resource_attributes$",
+		"^source_service_account$",
+		"^transaction_id$",
+	)
+	return resource
+}
+
+func (g ToolchainGenerator) loadPL(plID string, plName string, plIDref string) terraformutils.Resource {
+	resource := terraformutils.NewResource(
+		plID,
+		plName,
+		"ibm_cd_tekton_pipeline",
+		"ibm",
+		map[string]string{},
+		[]string{},
+		map[string]interface{}{
+			"pipeline_id": plIDref,
+		})
+	return resource
+}
+
+func (g ToolchainGenerator) loadPLProp(resourceType string, pID string, pName string, plIDref string, plID string) terraformutils.Resource {
+	resource := terraformutils.NewResource(
+		pID,
+		pName,
+		resourceType,
+		"ibm",
+		map[string]string{},
+		[]string{},
+		map[string]interface{}{
+			"pipeline_id": plIDref,
+		})
+	return resource
+}
+
+func (g ToolchainGenerator) loadPLDef(resourceType string, pID string, pName string, plIDref string, plID string, tcID string) terraformutils.Resource {
+	resource := terraformutils.NewResource(
+		pID,
+		pName,
+		resourceType,
+		"ibm",
+		map[string]string{},
+		[]string{},
+		map[string]interface{}{
+			"pipeline_id":         plIDref,
+			"toolchain_id_actual": tcID, // removed on PostConvertHook
+		})
+	return resource
+}
+
+func (g ToolchainGenerator) loadPLTrigProp(resourceType string, pID string, pName string, plIDref string, trigIDref string, plID string, trigID string) terraformutils.Resource {
+	resource := terraformutils.NewResource(
+		pID,
+		pName,
+		resourceType,
+		"ibm",
+		map[string]string{},
+		[]string{},
+		map[string]interface{}{
+			"pipeline_id": plIDref,
+			"trigger_id":  trigIDref,
+		})
+	return resource
+}
+
+// Goroutine helper to handle different tool types
+func (g *ToolchainGenerator) HandleTool(t cdtoolchainv2.ToolModel, toolType string, tID string, tName string, tcID string, tcIDref string, waitGroup *sync.WaitGroup) error {
+	defer waitGroup.Done()
+	apiKey := os.Getenv("IC_API_KEY")
+	if apiKey == "" {
+		log.Fatal("No API key set")
+	}
+
+	// typical case. handle exceptional cases seperately
+	// maps tool_type_id to the terraform resource type
+	supportedTools := map[string]string{
+		"appconfig":           "ibm_cd_toolchain_tool_appconfig",
+		"artifactory":         "ibm_cd_toolchain_tool_artifactory",
+		"bitbucketgit":        "ibm_cd_toolchain_tool_bitbucketgit",
+		"private_worker":      "ibm_cd_toolchain_tool_privateworker",
+		"draservicebroker":    "ibm_cd_toolchain_tool_devopsinsights",
+		"eventnotifications":  "ibm_cd_toolchain_tool_eventnotifications",
+		"hostedgit":           "ibm_cd_toolchain_tool_hostedgit",
+		"githubconsolidated":  "ibm_cd_toolchain_tool_githubconsolidated",
+		"gitlab":              "ibm_cd_toolchain_tool_gitlab",
+		"hashicorpvault":      "ibm_cd_toolchain_tool_hashicorpvault",
+		"jenkins":             "ibm_cd_toolchain_tool_jenkins",
+		"jira":                "ibm_cd_toolchain_tool_jira",
+		"keyprotect":          "ibm_cd_toolchain_tool_keyprotect",
+		"nexus":               "ibm_cd_toolchain_tool_nexus",
+		"customtool":          "ibm_cd_toolchain_tool_custom",
+		"saucelabs":           "ibm_cd_toolchain_tool_saucelabs",
+		"secretsmanager":      "ibm_cd_toolchain_tool_secretsmanager",
+		"security_compliance": "ibm_cd_toolchain_tool_securitycompliance",
+		"slack":               "ibm_cd_toolchain_tool_slack",
+		"sonarqube":           "ibm_cd_toolchain_tool_sonarqube",
+	}
+
+	if resourceType, ok := supportedTools[toolType]; ok {
+		resourceMutex.Lock()
+		g.Resources = append(g.Resources, g.loadTool(resourceType, tID, tName, tcIDref))
+		resourceMutex.Unlock()
+	} else if toolType == "pipeline" {
+		// Classic pipelines cannot be created using Terraform
+		if t.Parameters["type"] == "tekton" {
+			resourceMutex.Lock()
+			g.Resources = append(g.Resources, g.loadTool("ibm_cd_toolchain_tool_pipeline", tID, tName+"--tekton", tcIDref))
+			resourceMutex.Unlock()
+
+			plID := *(t.ID)
+			plName := tName
+
+			plIDref := fmt.Sprintf("${ibm_cd_toolchain_tool_pipeline.tfer--%s--tekton.tool_id}", tName)
+
+			resourceMutex.Lock()
+			g.Resources = append(g.Resources, g.loadPL(plID, plName, plIDref))
+			resourceMutex.Unlock()
+
+			// Get pipeline
+			cdTektonPipelineServiceOptions := &cdtektonpipelinev2.CdTektonPipelineV2Options{
+				Authenticator: &core.IamAuthenticator{
+					ApiKey: apiKey,
+				},
+			}
+
+			cdTektonPipelineService, err := cdtektonpipelinev2.NewCdTektonPipelineV2UsingExternalConfig(cdTektonPipelineServiceOptions)
+			if err != nil {
+				return err
+			}
+
+			getTektonPipelineOptions := cdTektonPipelineService.NewGetTektonPipelineOptions(plID)
+
+			tektonPipeline, _, err := cdTektonPipelineService.GetTektonPipeline(getTektonPipelineOptions)
+			if err != nil {
+				return err
+			}
+
+			// Definitions
+			for _, def := range tektonPipeline.Definitions {
+				defID := fmt.Sprintf("%s/%s", plID, *(def.ID))
+				defName := normalizeResourceName("definition", true)
+
+				resourceMutex.Lock()
+				g.Resources = append(g.Resources, g.loadPLDef("ibm_cd_tekton_pipeline_definition", defID, defName, plIDref, plID, tcID))
+				resourceMutex.Unlock()
+			}
+
+			// Properties
+			for _, prop := range tektonPipeline.Properties {
+				pID := fmt.Sprintf("%s/%s", plID, *(prop.Name))
+				pName := normalizeResourceName(*(prop.Name), true)
+
+				resourceMutex.Lock()
+				g.Resources = append(g.Resources, g.loadPLProp("ibm_cd_tekton_pipeline_property", pID, pName, plIDref, plID))
+				resourceMutex.Unlock()
+			}
+
+			// Triggers
+			for _, trig := range tektonPipeline.Triggers {
+				trigger := trig.(*cdtektonpipelinev2.Trigger)
+
+				trigID := fmt.Sprintf("%s/%s", plID, *(trigger.ID))
+				trigName := normalizeResourceName(*(trigger.Name), true)
+
+				resourceMutex.Lock()
+				g.Resources = append(g.Resources, g.loadPLProp("ibm_cd_tekton_pipeline_trigger", trigID, trigName, plIDref, plID))
+				resourceMutex.Unlock()
+
+				// Trigger Properties
+				for _, trigp := range trigger.Properties {
+					trigpID := fmt.Sprintf("%s/%s", trigID, *(trigp.Name))
+					trigpName := normalizeResourceName(*(trigp.Name), true)
+
+					trigIDref := fmt.Sprintf("${ibm_cd_tekton_pipeline_trigger.tfer--%s.trigger_id}", trigName)
+
+					resourceMutex.Lock()
+					g.Resources = append(g.Resources, g.loadPLTrigProp("ibm_cd_tekton_pipeline_trigger_property", trigpID, trigpName, plIDref, trigIDref, plID, *(trigger.ID)))
+					resourceMutex.Unlock()
+				}
+			}
+		} else {
+			resourceMutex.Lock()
+			g.Resources = append(g.Resources, g.loadTool("ibm_cd_toolchain_tool_pipeline", tID, tName+"--classic", tcIDref))
+			resourceMutex.Unlock()
+			fmt.Println("......! Only Tekton pipelines are supported in Terraform", toolType)
+		}
+	} else if toolType == "pagerduty" {
+		// If this integration is misconfigured, it lacks the necessary fields to work in Terraform
+		if *(t.State) == "configured" {
+			resourceMutex.Lock()
+			g.Resources = append(g.Resources, g.loadTool("ibm_cd_toolchain_tool_pagerduty", tID, tName, tcIDref))
+			resourceMutex.Unlock()
+		}
+	} else {
+		fmt.Println("......! Unknown tool type", toolType)
+	}
+	return nil
+}
+
+// Called within InitResources when IBM_CD_TOOLCHAIN_INCLUDE_S2S is set
+func getS2SPolicies(sess *session.Session, targetTcID string) (map[string][]iampolicymanagementv1.Policy, error) {
+	apiKey := os.Getenv("IC_API_KEY")
+	if apiKey == "" {
+		log.Fatal("No API key set")
+	}
+
+	emptyPolicies := map[string][]iampolicymanagementv1.Policy{}
+
+	iamPolicyOptions := &iampolicymanagementv1.IamPolicyManagementV1Options{
+		URL: "https://iam.cloud.ibm.com",
+		Authenticator: &core.IamAuthenticator{
+			ApiKey: apiKey,
+		},
+	}
+
+	iamPolicyClient, err := iampolicymanagementv1.NewIamPolicyManagementV1(iamPolicyOptions)
+	if err != nil {
+		return emptyPolicies, err
+	}
+
+	userInfo, err := fetchUserDetails(sess, 2)
+	if err != nil {
+		return emptyPolicies, err
+	}
+	accountID := userInfo.userAccount
+
+	listAuthPolicyOptions := iampolicymanagementv1.ListPoliciesOptions{
+		AccountID: core.StringPtr(accountID),
+		Type:      core.StringPtr("authorization"),
+	}
+
+	authPolicyList, _, err := iamPolicyClient.ListPolicies(&listAuthPolicyOptions)
+	if err != nil {
+		return emptyPolicies, fmt.Errorf("error retrieving authorization policy: %s", err)
+	}
+	authPolicies := authPolicyList.Policies
+
+	s2sPolicies := map[string][]iampolicymanagementv1.Policy{} // map of toolchain id to s2s policies under it
+
+	for _, ap := range authPolicies {
+		for _, a := range ap.Subjects[0].Attributes {
+			if *(a.Name) != "serviceInstance" {
+				continue
+			}
+			if (targetTcID != "" && *(a.Value) == targetTcID) || targetTcID == "" {
+				// get s2s policies for target toolchain
+				if _, ok := s2sPolicies[*(a.Value)]; !ok {
+					s2sPolicies[*(a.Value)] = []iampolicymanagementv1.Policy{}
+				}
+				s2sPolicies[*(a.Value)] = append(s2sPolicies[*(a.Value)], ap)
+			}
+		}
+	}
+	return s2sPolicies, nil
+}
+
+func (g *ToolchainGenerator) InitResources() error {
+	region := g.Args["region"].(string)
+
+	guidRegex := regexp.MustCompile("[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$")
+
+	targetTcID := os.Getenv("IBM_CD_TOOLCHAIN_TARGET")
+	if targetTcID != "" && !guidRegex.MatchString(targetTcID) {
+		log.Fatal("Env variable IBM_CD_TOOLCHAIN_TARGET is not a GUID")
+	}
+
+	apiKey := os.Getenv("IC_API_KEY")
+	if apiKey == "" {
+		log.Fatal("No API key set")
+	}
+
+	bmxConfig := &bluemix.Config{
+		BluemixAPIKey: apiKey,
+		Region:        region,
+	}
+
+	sess, err := session.New(bmxConfig)
+	if err != nil {
+		return err
+	}
+
+	err = authenticateAPIKey(sess)
+	if err != nil {
+		return err
+	}
+
+	catalogClient, err := catalog.New(sess)
+	if err != nil {
+		return err
+	}
+
+	controllerClient, err := controllerv2.New(sess)
+	if err != nil {
+		return err
+	}
+
+	serviceID, err := catalogClient.ResourceCatalog().FindByName("toolchain", true)
+	if err != nil {
+		return err
+	}
+
+	query := controllerv2.ServiceInstanceQuery{
+		ServiceID: serviceID[0].ID,
+	}
+
+	tcInstances, err := controllerClient.ResourceServiceInstanceV2().ListInstances(query)
+	if err != nil {
+		return err
+	}
+
+	// Get s2s policies
+	s2sPolicies := map[string][]iampolicymanagementv1.Policy{}
+
+	includeS2S := os.Getenv("IBM_CD_TOOLCHAIN_INCLUDE_S2S")
+	if includeS2S != "" {
+		s2sPolicies, err = getS2SPolicies(sess, targetTcID)
+		if err != nil {
+			return err
+		}
+	}
+
+	var toolWG sync.WaitGroup
+
+	// Iterate over toolchains to get tools
+	for _, tc := range tcInstances {
+		// Get toolchain ids, double-checking if they are valid
+		crnSplit := strings.Split(tc.ID, ":")
+		if len(crnSplit) < 8 {
+			fmt.Println("received invalid CRN format from Resource Controller, skipping...")
+			continue
+		}
+
+		tcID := crnSplit[7]
+
+		if !guidRegex.MatchString(tcID) {
+			fmt.Println("received invalid CRN format from Resource Controller, skipping...")
+			continue
+		}
+
+		if targetTcID != "" && tcID != targetTcID {
+			continue
+		}
+
+		if tc.RegionID == region {
+			tcName := normalizeResourceName(tc.Name, true)
+			tcIDref := fmt.Sprintf("${ibm_cd_toolchain.tfer--%s.id}", tcName)
+
+			resourceMutex.Lock()
+			g.Resources = append(g.Resources, g.loadToolchain(tcID, tcName))
+			resourceMutex.Unlock()
+
+			fmt.Println("=== FOUND TOOLCHAIN", tcID, "WITH NAME", tcName)
+
+			// Get tools
+			toolchainClientOptions := &cdtoolchainv2.CdToolchainV2Options{
+				Authenticator: &core.IamAuthenticator{
+					ApiKey: apiKey,
+				},
+			}
+
+			toolchainClient, err := cdtoolchainv2.NewCdToolchainV2UsingExternalConfig(toolchainClientOptions)
+			if err != nil {
+				return err
+			}
+
+			listToolsOptions := toolchainClient.NewListToolsOptions(tcID)
+
+			listToolsOptions.SetLimit(150) // 150 is max num tools per toolchain
+
+			tools, _, err := toolchainClient.ListTools(listToolsOptions)
+			if err != nil {
+				return err
+			}
+
+			if includeS2S != "" {
+				// Add toolchain's s2s policies (some tools require it)
+				for _, pol := range s2sPolicies[tcID] {
+					resourceMutex.Lock()
+					g.Resources = append(g.Resources, g.loadAuthPolicies(*(pol.ID), tcIDref))
+					resourceMutex.Unlock()
+				}
+			}
+
+			for _, t := range tools.Tools {
+				toolType := *(t.ToolTypeID)
+				tID := fmt.Sprintf("%s/%s", tcID, *(t.ID))
+
+				// Name won't always exist in Parameters
+				var tName string
+
+				if t.Parameters["name"] != nil {
+					tName = normalizeResourceName(t.Parameters["name"].(string), true)
+				} else {
+					tName = normalizeResourceName(toolType, true)
+				}
+
+				toolWG.Add(1)
+				go g.HandleTool(t, toolType, tID, tName, tcID, tcIDref, &toolWG)
+			}
+		}
+	}
+	toolWG.Wait()
+	return nil
+}
+
+// Goroutine helper to collect worker Ids for TektonPipelinePostProcess
+func (g *ToolchainGenerator) updateWorkerIds(i int, res terraformutils.Resource, workerIds map[string]string) {
+	resId := g.Resources[i].InstanceState.ID
+	wkrIdSplit := strings.Split(resId, "/")
+	if resId == "" || len(wkrIdSplit) != 2 {
+		return
+	}
+	workerId := wkrIdSplit[1]
+	workerIdMutex.Lock()
+	workerIds[workerId] = res.InstanceInfo.ResourceAddress().String()
+	workerIdMutex.Unlock()
+}
+
+// Goroutine helper to collect repos for TektonDefinitionPostProcess
+func (g *ToolchainGenerator) updateRepos(i int, res terraformutils.Resource, repos map[string](map[string]string)) {
+	params, ok := g.Resources[i].Item["parameters"].([]interface{})
+	if !ok || len(params) == 0 {
+		return
+	}
+	paramsMap, ok := params[0].(map[string]interface{})
+	if !ok {
+		return
+	}
+	if tcID, ok := g.Resources[i].InstanceState.Attributes["toolchain_id"]; ok {
+		if repos[tcID] == nil {
+			repos[tcID] = make(map[string]string)
+		}
+		repoMutex.Lock()
+		repos[tcID][paramsMap["repo_url"].(string)] = res.InstanceInfo.ResourceAddress().String()
+		repoMutex.Unlock()
+	}
+}
+
+func (g *ToolchainGenerator) PostConvertHook() error {
+	workerIds := map[string]string{}
+	repos := map[string](map[string]string){}
+	tools := map[string]string{}
+
+	var resWG sync.WaitGroup
+	for i, res := range g.Resources {
+		resWG.Add(1)
+		go func() {
+			defer resWG.Done()
+
+			switch res.InstanceInfo.Type {
+			case "ibm_cd_toolchain_tool_privateworker":
+				g.updateWorkerIds(i, res, workerIds)
+			case "ibm_cd_toolchain_tool_bitbucketgit":
+				g.updateRepos(i, res, repos)
+			case "ibm_cd_toolchain_tool_hostedgit":
+				g.updateRepos(i, res, repos)
+			case "ibm_cd_toolchain_tool_gitlab":
+				g.updateRepos(i, res, repos)
+			case "ibm_cd_toolchain_tool_githubconsolidated":
+				g.updateRepos(i, res, repos)
+			}
+
+			// Collect tools for TektonPropertyPostProcess
+			if strings.HasPrefix(res.InstanceInfo.Type, "ibm_cd_toolchain_tool_") {
+				if tId, ok := g.Resources[i].InstanceState.Attributes["tool_id"]; ok {
+					toolMutex.Lock()
+					tools[tId] = res.InstanceInfo.ResourceAddress().String()
+					toolMutex.Unlock()
+				}
+			}
+		}()
+	}
+	resWG.Wait()
+
+	for i, res := range g.Resources {
+		switch res.InstanceInfo.Type {
+		case "ibm_cd_tekton_pipeline":
+			g.TektonPipelinePostProcess(i, res, workerIds)
+
+		case "ibm_cd_tekton_pipeline_definition":
+			g.TektonDefinitionPostProcess(i, res, repos)
+
+		case "ibm_cd_tekton_pipeline_property":
+			g.TektonPropertyPostProcess(i, res, tools)
+
+		case "ibm_cd_tekton_pipeline_trigger_property":
+			g.TektonPropertyPostProcess(i, res, tools)
+
+		case "ibm_cd_toolchain_tool_jenkins":
+			g.JenkinsPostProcess(i, res)
+
+		case "ibm_cd_toolchain_tool_bitbucketgit":
+			g.GitRepositoryPostProcess(i, res)
+
+		case "ibm_cd_toolchain_tool_hostedgit":
+			g.GitRepositoryPostProcess(i, res)
+
+		case "ibm_cd_toolchain_tool_gitlab":
+			g.GitRepositoryPostProcess(i, res)
+
+		case "ibm_cd_toolchain_tool_githubconsolidated":
+			g.GitRepositoryPostProcess(i, res)
+		}
+	}
+
+	return nil
+}
+
+// PostConvertHook helper to add private workers refs to tekton pipelines
+func (g *ToolchainGenerator) TektonPipelinePostProcess(i int, res terraformutils.Resource, workerIds map[string]string) {
+	worker, ok := g.Resources[i].Item["worker"].([]interface{})
+	if !ok {
+		return
+	}
+	workerMap, ok := worker[0].(map[string]interface{})
+	if !ok {
+		return
+	}
+	plWorkerId := workerMap["id"]
+	if plWorkerId == nil || plWorkerId == "public" {
+		return
+	}
+	if wkr, ok := workerIds[plWorkerId.(string)]; ok {
+		workerMap["id"] = fmt.Sprintf("${%s.tool_id}", wkr)
+		return
+	}
+}
+
+// PostConvertHook helper to add repo depends_on to tekton pipeline definitions
+func (g *ToolchainGenerator) TektonDefinitionPostProcess(i int, res terraformutils.Resource, repos map[string](map[string]string)) {
+	defSource, ok := g.Resources[i].Item["source"].([]interface{})
+	if !ok || len(defSource) == 0 {
+		return
+	}
+	defSourceMap, ok := defSource[0].(map[string]interface{})
+	if !ok {
+		return
+	}
+	defProps, ok := defSourceMap["properties"].([]interface{})
+	if !ok || len(defProps) == 0 {
+		return
+	}
+	defPropsMap, ok := defProps[0].(map[string]interface{})
+	if !ok {
+		return
+	}
+	tcId, ok := g.Resources[i].Item["toolchain_id_actual"]
+	if !ok {
+		return
+	}
+	if repo, ok := repos[tcId.(string)][defPropsMap["url"].(string)]; ok {
+		g.Resources[i].Item["depends_on"] = []string{repo}
+	}
+	delete(g.Resources[i].Item, "toolchain_id_actual")
+}
+
+// PostConvertHook helper to add tool refs to tekton pipeline properties and additional escape appconfig substitution
+func (g *ToolchainGenerator) TektonPropertyPostProcess(i int, res terraformutils.Resource, tools map[string]string) {
+	target, ok := g.Resources[i].Item["value"].(string)
+	if !ok {
+		return
+	}
+
+	// escape appconfig values -- ${...} is interpreted as a template in terraform
+	g.Resources[i].Item["value"] = strings.Replace(g.Resources[i].Item["value"].(string), "${", "$${", -1)
+
+	// add tool integration ref to tekton definitions
+	if g.Resources[i].Item["type"] != "integration" {
+		return
+	}
+
+	if tool, ok := tools[target]; ok {
+		g.Resources[i].Item["value"] = fmt.Sprintf("${%s.tool_id}", tool)
+		return
+	}
+	fmt.Println("......! Could not link pipeline property of type integration:", res.InstanceInfo.ResourceAddress().String())
+}
+
+// PostConvertHook helper to remove Jenkins webhook_url from tf files, which is supposed to be sensitive and computed
+func (g *ToolchainGenerator) JenkinsPostProcess(i int, res terraformutils.Resource) {
+	params, ok := g.Resources[i].Item["parameters"].([]interface{})
+	if !ok || len(params) == 0 {
+		return
+	}
+	paramsMap, ok := params[0].(map[string]interface{})
+	if !ok {
+		return
+	}
+	if _, ok := paramsMap["webhook_url"].(string); ok {
+		delete(paramsMap, "webhook_url")
+	}
+}
+
+// PostConvertHook helper to generate initialization block and remove computed values for git repo resources
+func (g *ToolchainGenerator) GitRepositoryPostProcess(i int, res terraformutils.Resource) {
+	// Handle Initialization args
+	params, ok := g.Resources[i].Item["parameters"].([]interface{})
+	if !ok || len(params) == 0 {
+		return
+	}
+	paramsMap, ok := params[0].(map[string]interface{})
+	if !ok {
+		return
+	}
+	initMap := map[string]interface{}{}
+
+	initMap["git_id"] = paramsMap["git_id"]
+	initMap["type"] = paramsMap["type"] // this will always be "link"
+	initMap["repo_url"] = paramsMap["repo_url"]
+	initMap["private_repo"] = paramsMap["private_repo"]
+
+	// additional parameters
+	if res.InstanceInfo.Type == "ibm_cd_toolchain_tool_githubconsolidated" {
+		initMap["blind_connection"] = paramsMap["blind_connection"]
+		initMap["auto_init"] = paramsMap["auto_init"]
+	} else if res.InstanceInfo.Type == "ibm_cd_toolchain_tool_gitlab" {
+		initMap["blind_connection"] = paramsMap["blind_connection"]
+	}
+
+	// add to initialization accordingly
+	g.Resources[i].Item["initialization"] = initMap
+
+	// add missing initialization to terraform state attributes
+	g.Resources[i].InstanceState.Attributes["initialization.#"] = "1"
+	for key, val := range initMap {
+		g.Resources[i].InstanceState.Attributes["initialization.0."+key] = val.(string)
+	}
+
+	// only include non-computed parameters
+	includeParams := []string{"api_token", "auth_type", "enable_traceability", "integration_owner", "toolchain_issues_enabled"}
+
+	for key := range paramsMap {
+		if !slices.Contains(includeParams, key) {
+			delete(g.Resources[i].Item["parameters"].([]interface{})[0].(map[string]interface{}), key)
+			delete(g.Resources[i].InstanceState.Attributes, key)
+		}
+	}
+}

--- a/providers/ibm/ibm_cd_toolchain.go
+++ b/providers/ibm/ibm_cd_toolchain.go
@@ -499,10 +499,10 @@ func (g *ToolchainGenerator) updateRepos(i int, res terraformutils.Resource, rep
 		return
 	}
 	if tcID, ok := g.Resources[i].InstanceState.Attributes["toolchain_id"]; ok {
+		repoMutex.Lock()
 		if repos[tcID] == nil {
 			repos[tcID] = make(map[string]string)
 		}
-		repoMutex.Lock()
 		repos[tcID][paramsMap["repo_url"].(string)] = res.InstanceInfo.ResourceAddress().String()
 		repoMutex.Unlock()
 	}

--- a/providers/ibm/ibm_provider.go
+++ b/providers/ibm/ibm_provider.go
@@ -17,12 +17,15 @@ package ibm
 import (
 	"errors"
 	"os"
+	"sync"
 
 	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
 )
 
 const DefaultRegion = "us-south"
 const NoRegion = ""
+
+var resourceMutex sync.RWMutex // Used for g.Resources
 
 type IBMProvider struct { //nolint
 	terraformutils.Provider

--- a/providers/ibm/ibm_provider.go
+++ b/providers/ibm/ibm_provider.go
@@ -160,6 +160,7 @@ func (p *IBMProvider) GetSupportedService() map[string]terraformutils.ServiceGen
 		"ibm_satellite_data_plane":          &SatelliteDataPlaneGenerator{},
 		"ibm_secrets_manager":               &SecretsManagerGenerator{},
 		"ibm_continuous_delivery":           &ContinuousDeliveryGenerator{},
+		"ibm_cd_toolchain":                  &ToolchainGenerator{},
 		"ibm_cloud_sysdig_monitor":          &MonitoringGenerator{},
 		"ibm_cloud_logdna":                  &LogAnalysisGenerator{},
 		"ibm_cloud_atracker":                &ActivityTrackerGenerator{},

--- a/providers/ibm/instance_groups.go
+++ b/providers/ibm/instance_groups.go
@@ -88,11 +88,13 @@ func (g *InstanceGroupGenerator) handlePolicies(sess *vpcv1.VpcV1, instanceGroup
 			g.fatalErrors <- fmt.Errorf("Error Getting InstanceGroup Manager Policy: %s\n%s", err, response)
 		}
 		instanceGroupManagerPolicy := data.(*vpcv1.InstanceGroupManagerPolicy)
+		resourceMutex.Lock()
 		g.Resources = append(g.Resources, g.loadInstanceGroupMangerPolicy(instanceGroupID,
 			instanceGroupManagerID,
 			instanceGroupManagerPolicyID,
 			*instanceGroupManagerPolicy.Name,
 			dependsOn))
+		resourceMutex.Unlock()
 	}
 }
 
@@ -109,7 +111,9 @@ func (g *InstanceGroupGenerator) handleManagers(sess *vpcv1.VpcV1, instanceGroup
 			g.fatalErrors <- fmt.Errorf("Error Getting InstanceGroup Manager: %s\n%s", err, response)
 		}
 		instanceGroupManager := instanceGroupManagerIntf.(*vpcv1.InstanceGroupManager)
+		resourceMutex.Lock()
 		g.Resources = append(g.Resources, g.loadInstanceGroupManger(instanceGroupID, instanceGroupManagerID, *instanceGroupManager.Name, dependsOn))
+		resourceMutex.Unlock()
 
 		policies := make([]string, 0)
 
@@ -152,7 +156,9 @@ func (g *InstanceGroupGenerator) handleInstanceGroups(sess *vpcv1.VpcV1, waitGro
 		dependsOn = append(dependsOn,
 			"ibm_is_instance_group."+terraformutils.TfSanitize(*instanceGroup.Name))
 		instanceGoupID := *instanceGroup.ID
+		resourceMutex.Lock()
 		g.Resources = append(g.Resources, g.loadInstanceGroup(instanceGoupID, *instanceGroup.Name))
+		resourceMutex.Unlock()
 		managers := make([]string, 0)
 		for i := 0; i < len(instanceGroup.Managers); i++ {
 			managers = append(managers, *(instanceGroup.Managers[i].ID))


### PR DESCRIPTION
Includes changes from: https://github.com/GoogleCloudPlatform/terraformer/pull/2015 "Add support for ibm cd toolchain", which is using goroutines and mutexes.

Noticed that instance_groups.go is also using goroutines, but was not using a mutex, leading to the possibility of resources being overwritten. Changes in this PR include:
* Moving resourceMutex (which is used for g.Resources) from ibm_cd_toolchain.go to ibm_provider.go
* Adding resourceMutex to instance_groups.go