### PR TITLE
fix: address bug with okta inline hook import

### DIFF
--- a/providers/okta/okta_provider.go
+++ b/providers/okta/okta_provider.go
@@ -113,7 +113,7 @@ func (p *OktaProvider) GetSupportedService() map[string]terraformutils.ServiceGe
 		"okta_group":                     &GroupGenerator{},
 		"okta_group_rule":                &GroupRuleGenerator{},
 		"okta_event_hook":                &EventHookGenerator{},
-		"okta_inline_hook":               &EventHookGenerator{},
+		"okta_inline_hook":               &InlineHookGenerator{},
 		"okta_policy_password":           &PasswordPolicyGenerator{},
 		"okta_policy_rule_password":      &PasswordPolicyRuleGenerator{},
 		"okta_policy_signon":             &SignOnPolicyGenerator{},


### PR DESCRIPTION
Found a copy/pasta error it appears.  

Verified okta_inline_hook now imports as a inline hook as opposed to a event hook.