### PR TITLE
docs: add identitystore resources to AWS docs

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -183,6 +183,10 @@ terraformer import aws --resources=sg --regions=us-east-1
     * `aws_iam_user_group_membership`
     * `aws_iam_user_policy`
     * `aws_iam_user_policy_attachment`
+*   `identitystore`
+    * `aws_identitystore_group`
+    * `aws_identitystore_group_membership`
+    * `aws_identitystore_user`
 *   `igw`
     * `aws_internet_gateway`
 *   `iot`


### PR DESCRIPTION
Although it was actually supported, it wasn't mentioned in the documentation, so I added it.

```shell
$ terraformer import aws list | grep id
identitystore
```

ref: https://github.com/GoogleCloudPlatform/terraformer/pull/1685