### PR TITLE
Update feed test URI reference

### DIFF
--- a/tests/octopusdeploy/feed.tf
+++ b/tests/octopusdeploy/feed.tf
@@ -1,7 +1,7 @@
 resource "octopusdeploy_feed" "feed" {
   name          = "feedme"
   feed_type     = "Helm"
-  feed_uri      = "https://kubernetes-charts.storage.googleapis.com"
+  feed_uri      = "https://charts.helm.sh/stable"
   username      = "foo"
   password      = "bar"
   enhanced_mode = false


### PR DESCRIPTION
Update feed_uri to match the example at https://registry.terraform.io/providers/OctopusDeployLabs/octopusdeploy/latest/docs/resources/helm_feed