### PR TITLE
Fix aws_subnet - ignore default enable_lni_at_device_index

### DIFF
--- a/providers/aws/subnet.go
+++ b/providers/aws/subnet.go
@@ -38,6 +38,11 @@ func (SubnetGenerator) createResources(subnets *ec2.DescribeSubnetsOutput) []ter
 			SubnetAllowEmptyValues,
 		)
 		resource.IgnoreKeys = append(resource.IgnoreKeys, "availability_zone")
+
+		if subnet.EnableLniAtDeviceIndex == nil || *subnet.EnableLniAtDeviceIndex == 0 {
+			resource.IgnoreKeys = append(resource.IgnoreKeys, "enable_lni_at_device_index")
+		}
+
 		resources = append(resources, resource)
 	}
 	return resources


### PR DESCRIPTION
Omit the default LNI index (0) for aws_subnet to prevent Terraform errors.

When enable_lni_at_device_index = "0" is generated, Terraform fails with:

Error: enable_lni_at_device_index must not be zero, got 0

By ignoring the default 0 value, we avoid this invalid configuration and eliminate unwanted diffs.