### PR TITLE
Fix CloudWatch Events import error caused by wrong NextToken

### DIFF
--- a/providers/aws/cloudwatch.go
+++ b/providers/aws/cloudwatch.go
@@ -143,7 +143,7 @@ func (g *CloudWatchGenerator) createRules(cloudwatcheventsSvc *cloudwatchevents.
 						cloudwatchAllowEmptyValues,
 						map[string]interface{}{}))
 				}
-				listTargetsNextToken = output.NextToken
+				listTargetsNextToken = targetResponse.NextToken
 				if listTargetsNextToken == nil {
 					break
 				}


### PR DESCRIPTION
This PR fixes a bug in retrieving AWS CloudWatch event targets.
Previously, the code was incorrectly using the token from the ListRules call instead of the one from ListTargetsByRule.

As a result, the following error occurred when attempting to import CloudWatch events:

> `aws error initializing resources in service cloudwatch, err: operation error CloudWatch Events: ListTargetsByRule, https response error StatusCode: 400, RequestID: 3509aae3-fe4e-49e3-8a93-9f8cd4ea66ca, api error ValidationException: Parameter NextToken is not valid.`