### PR TITLE
Keycloak: Support username/password authentication

### DIFF
--- a/cmd/provider_cmd_keycloak.go
+++ b/cmd/provider_cmd_keycloak.go
@@ -56,6 +56,8 @@ func newCmdKeycloakImporter(options ImportOptions) *cobra.Command {
 			}
 			clientID := os.Getenv("KEYCLOAK_CLIENT_ID")
 			clientSecret := os.Getenv("KEYCLOAK_CLIENT_SECRET")
+			username := os.Getenv("KEYCLOAK_USERNAME")
+			password := os.Getenv("KEYCLOAK_PASSWORD")
 			realm := os.Getenv("KEYCLOAK_REALM")
 			if len(realm) == 0 {
 				realm = defaultKeycloakRealm
@@ -79,7 +81,7 @@ func newCmdKeycloakImporter(options ImportOptions) *cobra.Command {
 					log.Println(provider.GetName() + " importing realm " + target)
 					options.PathPattern = originalPathPattern
 					options.PathPattern = strings.ReplaceAll(options.PathPattern, "{provider}", "{provider}/"+target)
-					err := Import(provider, options, []string{url, basePath, clientID, clientSecret, realm, strconv.FormatInt(clientTimeout, 10), caCert, strconv.FormatBool(tlsInsecureSkipVerify), strconv.FormatBool(redHatSSO), target})
+					err := Import(provider, options, []string{url, basePath, clientID, clientSecret, realm, username, password, strconv.FormatInt(clientTimeout, 10), caCert, strconv.FormatBool(tlsInsecureSkipVerify), strconv.FormatBool(redHatSSO), target})
 					if err != nil {
 						return err
 					}
@@ -87,7 +89,7 @@ func newCmdKeycloakImporter(options ImportOptions) *cobra.Command {
 			} else {
 				provider := newKeycloakProvider()
 				log.Println(provider.GetName() + " importing all realms")
-				err := Import(provider, options, []string{url, basePath, clientID, clientSecret, realm, strconv.FormatInt(clientTimeout, 10), caCert, strconv.FormatBool(tlsInsecureSkipVerify), strconv.FormatBool(redHatSSO), "-"})
+				err := Import(provider, options, []string{url, basePath, clientID, clientSecret, username, password, realm, strconv.FormatInt(clientTimeout, 10), caCert, strconv.FormatBool(tlsInsecureSkipVerify), strconv.FormatBool(redHatSSO), "-"})
 				if err != nil {
 					return err
 				}

--- a/docs/keycloak.md
+++ b/docs/keycloak.md
@@ -7,6 +7,8 @@ Example:
  export KEYCLOAK_BASE_PATH=/auth # Only users of the legacy Wildfly distribution will need to set this.
  export KEYCLOAK_CLIENT_ID=[KEYCLOAK_CLIENT_ID]
  export KEYCLOAK_CLIENT_SECRET=[KEYCLOAK_CLIENT_SECRET]
+ export KEYCLOAK_USERNAME=[ADMIN_USERNAME]
+ export KEYCLOAK_PASSWORD=[ADMIN_PASSWORD]
  export RED_HAT_SSO=1 # Only users of the RH-SSO distribution will need to set this.
 
  terraformer import keycloak --resources=realms

--- a/providers/keycloak/generator.go
+++ b/providers/keycloak/generator.go
@@ -36,7 +36,7 @@ func (g *RealmGenerator) InitResources() error {
 
 	// Connect to keycloak instance
 	userAgent := "GoogleCloudPlatform Terraformer/0.8.22 (+https://github.com/GoogleCloudPlatform/terraformer) Terraform Plugin SDK/2.10.1"
-	kck, err := keycloak.NewKeycloakClient(ctx, g.GetArgs()["url"].(string), g.GetArgs()["base_path"].(string), g.GetArgs()["client_id"].(string), g.GetArgs()["client_secret"].(string), g.GetArgs()["realm"].(string), "", "", true, g.GetArgs()["client_timeout"].(int), g.GetArgs()["root_ca_certificate"].(string), g.GetArgs()["tls_insecure_skip_verify"].(bool), userAgent, g.GetArgs()["red_hat_sso"].(bool), make(map[string]string))
+	kck, err := keycloak.NewKeycloakClient(ctx, g.GetArgs()["url"].(string), g.GetArgs()["base_path"].(string), g.GetArgs()["client_id"].(string), g.GetArgs()["client_secret"].(string), g.GetArgs()["realm"].(string), g.GetArgs()["username"].(string), g.GetArgs()["password"].(string), true, g.GetArgs()["client_timeout"].(int), g.GetArgs()["root_ca_certificate"].(string), g.GetArgs()["tls_insecure_skip_verify"].(bool), userAgent, g.GetArgs()["red_hat_sso"].(bool), make(map[string]string))
 	if err != nil {
 		return errors.New("keycloak: could not connect to Keycloak")
 	}

--- a/providers/keycloak/keycloak_provider.go
+++ b/providers/keycloak/keycloak_provider.go
@@ -28,6 +28,8 @@ type KeycloakProvider struct { //nolint
 	basePath              string
 	clientID              string
 	clientSecret          string
+	username              string
+	password              string
 	realm                 string
 	clientTimeout         int
 	caCert                string
@@ -48,12 +50,14 @@ func (p *KeycloakProvider) Init(args []string) error {
 	p.basePath = args[1]
 	p.clientID = args[2]
 	p.clientSecret = args[3]
-	p.realm = args[4]
-	p.clientTimeout, _ = strconv.Atoi(args[5])
-	p.caCert = getArg(args[6])
-	p.tlsInsecureSkipVerify, _ = strconv.ParseBool(args[7])
-	p.redHatSSO, _ = strconv.ParseBool(args[8])
-	p.target = getArg(args[9])
+	p.username = args[4]
+	p.password = args[5]
+	p.realm = args[6]
+	p.clientTimeout, _ = strconv.Atoi(args[7])
+	p.caCert = getArg(args[8])
+	p.tlsInsecureSkipVerify, _ = strconv.ParseBool(args[9])
+	p.redHatSSO, _ = strconv.ParseBool(args[10])
+	p.target = getArg(args[11])
 	return nil
 }
 
@@ -71,6 +75,8 @@ func (p *KeycloakProvider) GetConfig() cty.Value {
 		"base_path":                cty.StringVal(p.basePath),
 		"client_id":                cty.StringVal(p.clientID),
 		"client_secret":            cty.StringVal(p.clientSecret),
+		"username":                 cty.StringVal(p.username),
+		"password":                 cty.StringVal(p.password),
 		"realm":                    cty.StringVal(p.realm),
 		"client_timeout":           cty.NumberIntVal(int64(p.clientTimeout)),
 		"root_ca_certificate":      cty.StringVal(p.caCert),
@@ -97,6 +103,8 @@ func (p *KeycloakProvider) InitService(serviceName string, verbose bool) error {
 		"base_path":                p.basePath,
 		"client_id":                p.clientID,
 		"client_secret":            p.clientSecret,
+		"username":                 p.username,
+		"password":                 p.password,
 		"realm":                    p.realm,
 		"client_timeout":           p.clientTimeout,
 		"root_ca_certificate":      p.caCert,


### PR DESCRIPTION
The [Keycloak Terraform provider](https://registry.terraform.io/providers/keycloak/keycloak/latest/docs) not only supports client-credentials grant, but also password grant type: https://registry.terraform.io/providers/keycloak/keycloak/latest/docs#example-usage-password-grant

```hcl
provider "keycloak" {
    client_id     = "admin-cli"
    username      = "keycloak"
    password      = "password"
    url           = "http://localhost:8080"
}
```

It would be very helpful if this is provided by Terraformer aswell :pray: 