### PR TITLE
fix(rds): use CustSubscriptionId instead of CustomerAwsId for event subscriptions

### DIFF
--- a/providers/aws/rds.go
+++ b/providers/aws/rds.go
@@ -213,7 +213,7 @@ func (g *RDSGenerator) loadEventSubscription(svc *rds.Client) error {
 			return err
 		}
 		for _, eventSubscription := range page.EventSubscriptionsList {
-			resourceName := StringValue(eventSubscription.CustomerAwsId)
+			resourceName := StringValue(eventSubscription.CustSubscriptionId)
 			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
 				resourceName,
 				resourceName,


### PR DESCRIPTION

The loadEventSubscription function was incorrectly using CustomerAwsId (AWS account ID) instead of CustSubscriptionId (subscription name) as the resource identifier. This caused import failures when the account ID was used as the subscription name in Terraform operations.

Fixes event subscription import errors where AWS would reject the account ID as an invalid subscription identifier.