### PR TITLE
fix: aws batch load job definition revision

### DIFF
--- a/providers/aws/batch.go
+++ b/providers/aws/batch.go
@@ -73,7 +73,7 @@ func (g *BatchGenerator) loadJobDefinitions(batchClient *batch.Client) error {
 			return err
 		}
 		for _, jobDefinition := range page.JobDefinitions {
-			jobDefinitionName := StringValue(jobDefinition.JobDefinitionName) + ":" + fmt.Sprint(jobDefinition.Revision)
+			jobDefinitionName := StringValue(jobDefinition.JobDefinitionName) + ":" + fmt.Sprint(*jobDefinition.Revision)
 			g.Resources = append(g.Resources, terraformutils.NewResource(
 				jobDefinitionName,
 				jobDefinitionName,


### PR DESCRIPTION
Related to: [#2124](https://github.com/GoogleCloudPlatform/terraformer/issues/2124)

# Root Cause
https://github.com/GoogleCloudPlatform/terraformer/blob/069060cf5cc98bc3d296f680e7a97c1498f3daed/providers/aws/batch.go#L76

- jobDefinition.Revision is not a simple string or integer. In the AWS SDK for Go, the Revision field within the JobDefinition struct is likely a pointer to an integer (*int64) or another complex type. It's not just a simple value.

- fmt.Sprint()'s default behavior for pointers. When you use fmt.Sprint() on a pointer or a struct that doesn't have a specific String() method defined, Go's default behavior is to print the memory address where that object is stored. Memory addresses are conventionally represented in hexadecimal format.

# Fix
```go
// Incorrect (what's currently there)
jobDefinitionName := StringValue(jobDefinition.JobDefinitionName) + ":" + fmt.Sprint(jobDefinition.Revision)

// Corrected version
jobDefinitionName := StringValue(jobDefinition.JobDefinitionName) + ":" + fmt.Sprint(*jobDefinition.Revision) // Note the *
```
